### PR TITLE
Introduce system variables

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,6 +42,9 @@ jobs:
           PROJECT: fake-project
           INSTANCE: fake-instance
           DATABASE: fake-database
+      - uses: iFaxity/wait-on-action
+        with:
+          resource: http://localhost:9020
       - name: make test with Cloud Spanner Emulator
         run: make test
         env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.4.9
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.24
         ports:
           - 9010:9010
           - 9020:9020

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,3 +42,11 @@ jobs:
           PROJECT: fake-project
           INSTANCE: fake-instance
           DATABASE: fake-database
+      - name: make test with Cloud Spanner Emulator
+        run: make test
+        env:
+          SPANNER_EMULATOR_HOST: localhost:9010
+          SPANNER_EMULATOR_HOST_REST: localhost:9020
+          PROJECT: fake-project
+          INSTANCE: fake-instance
+          DATABASE: fake-database

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Wait on
         uses: iFaxity/wait-on-action@v1.2.1
         with:
-          resource: http://localhost:9020/v1/projects/fake-project/instances
+          resource: http-get://localhost:9020/v1/projects/fake-project/instances
       - run: make setup-emulator
         env:
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -35,6 +35,10 @@ jobs:
         with:
           go-version: '1.23'
       - run: go version
+      - name: Wait on
+        uses: iFaxity/wait-on-action@v1.2.1
+        with:
+          resource: http://localhost:9020
       - run: make setup-emulator
         env:
           SPANNER_EMULATOR_HOST: localhost:9010
@@ -42,10 +46,6 @@ jobs:
           PROJECT: fake-project
           INSTANCE: fake-instance
           DATABASE: fake-database
-      - name: Wait on
-        uses: iFaxity/wait-on-action@v1.2.1
-        with:
-          resource: http://localhost:9020
       - name: make test with Cloud Spanner Emulator
         run: make test
         env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: '1.23'
       - run: go version
       - run: make setup-emulator
         env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,7 +42,8 @@ jobs:
           PROJECT: fake-project
           INSTANCE: fake-instance
           DATABASE: fake-database
-      - uses: iFaxity/wait-on-action
+      - name: Wait on
+        uses: iFaxity/wait-on-action@v1.2.1
         with:
           resource: http://localhost:9020
       - name: make test with Cloud Spanner Emulator

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Wait on
         uses: iFaxity/wait-on-action@v1.2.1
         with:
-          resource: http://localhost:9020
+          resource: http://localhost:9020/v1/projects/fake-project/instances
       - run: make setup-emulator
         env:
           SPANNER_EMULATOR_HOST: localhost:9010

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ and `{}` for a mutually exclusive keyword.
 | End Read-Only Transaction | `CLOSE;` | |
 | Exit CLI | `EXIT;` | |
 | Show variable | `SHOW VARIABLE <name>;` | |
-| Set variable | `SET VARIABLE <name> = <value>;` | |
+| Set variable | `SET <name> = <value>;` | |
 | Show variables | `SHOW VARIABLES;` | |
 
 ## Customize prompt

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ My personal fork of spanner-cli, interactive command line tool for Cloud Spanner
 `spanner-mycli` is an interactive command line tool for [Google Cloud Spanner](https://cloud.google.com/spanner/).  
 You can control your Spanner databases with idiomatic SQL commands.
 
+## Differences from original spanner-cli
+
+* Concept
+  * Respects minor use cases.
+  * Respects batch use cases as well as interactive use cases.
+  * More `gcloud spanner` compatibilities
+    * Support `--sql` flag
+  * Minimize to use own syntax.
+    * System variables concept inspired by Spanner JDBC
+      * `SET <name> = <value>` statement
+      * `SHOW VARIABLES` statement
+      * `SHOW VARIABLE <name> statement`
+      * `--set <name>=<value>` flag
+  * Use [`reeflective/readline`](https://github.com/reeflective/readline) instead of [`chzyer/readline"`](https://github.com/chzyer/readline)
+
 ## Install
 
 [Install Go](https://go.dev/doc/install) and run the following command.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ and `{}` for a mutually exclusive keyword.
 | Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. The tag you set is used as request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
 | End Read-Only Transaction | `CLOSE;` | |
 | Exit CLI | `EXIT;` | |
+| Show variable | `SHOW VARIABLE <name>;` | |
+| Set variable | `SET VARIABLE <name> = <value>;` | |
+| Show variables | `SHOW VARIABLES;` | |
 
 ## Customize prompt
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ You can control your Spanner databases with idiomatic SQL commands.
 
 ## Differences from original spanner-cli
 
-* Concept
-  * Respects minor use cases.
-  * Respects batch use cases as well as interactive use cases.
-  * More `gcloud spanner` compatibilities
-    * Support `--sql` flag
-  * Minimize to use own syntax.
-    * System variables concept inspired by Spanner JDBC
-      * `SET <name> = <value>` statement
-      * `SHOW VARIABLES` statement
-      * `SHOW VARIABLE <name> statement`
-      * `--set <name>=<value>` flag
+* Respects minor use cases
+* Respects batch use cases as well as interactive use cases
+* More `gcloud spanner` compatibilities
+  * Support `--sql` flag
+* Minimize to use own syntax
+  * Generalized system variables concept inspired by Spanner JDBC
+    * `SET <name> = <value>` statement
+    * `SHOW VARIABLES` statement
+    * `SHOW VARIABLE <name> statement`
+    * `--set <name>=<value>` flag
+* Improved interactive experience
   * Use [`reeflective/readline`](https://github.com/reeflective/readline) instead of [`chzyer/readline"`](https://github.com/chzyer/readline)
+    * Native multi-line editing and histories
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ You can control your Spanner databases with idiomatic SQL commands.
 
 ## Differences from original spanner-cli
 
-* Respects minor use cases
+* Respects my minor use cases
 * Respects batch use cases as well as interactive use cases
-* More `gcloud spanner` compatibilities
+* More `gcloud spanner databases execute-sql` compatibilities
   * Support `--sql` flag
 * Minimize to use own syntax
   * Generalized system variables concept inspired by Spanner JDBC
@@ -23,6 +23,8 @@ You can control your Spanner databases with idiomatic SQL commands.
 * Improved interactive experience
   * Use [`reeflective/readline`](https://github.com/reeflective/readline) instead of [`chzyer/readline"`](https://github.com/chzyer/readline)
     * Native multi-line editing and histories
+* Utilize other libraries
+  * Dogfooding [`cloudspannerecosystem/memefish`](https://github.com/cloudspannerecosystem/memefish)
 
 ## Install
 

--- a/cli.go
+++ b/cli.go
@@ -229,6 +229,10 @@ func (c *Cli) RunInteractive() int {
 			result.Stats.ElapsedTime = fmt.Sprintf("%0.2f sec", elapsed)
 		}
 
+		if !result.Timestamp.IsZero() {
+			c.SystemVariables.ReadTimestamp = result.Timestamp
+		}
+
 		if input.delim == delimiterHorizontal {
 			c.PrintResult(result, DisplayModeTable, true)
 		} else {
@@ -256,6 +260,8 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 			c.PrintBatchError(err)
 			return exitCodeError
 		}
+
+		c.SystemVariables.ReadTimestamp = result.Timestamp
 
 		if displayTable {
 			c.PrintResult(result, DisplayModeTable, false)

--- a/cli.go
+++ b/cli.go
@@ -230,7 +230,7 @@ func (c *Cli) RunInteractive() int {
 			result.Stats.ElapsedTime = fmt.Sprintf("%0.2f sec", elapsed)
 		}
 
-		if result.UpdateVariables {
+		if !result.KeepVariables {
 			if result.IsMutation {
 				c.SystemVariables.ReadTimestamp = time.Time{}
 				c.SystemVariables.CommitTimestamp = result.Timestamp

--- a/cli.go
+++ b/cli.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
 	"os"
 	"os/signal"
@@ -229,8 +230,20 @@ func (c *Cli) RunInteractive() int {
 			result.Stats.ElapsedTime = fmt.Sprintf("%0.2f sec", elapsed)
 		}
 
-		if !result.Timestamp.IsZero() {
-			c.SystemVariables.ReadTimestamp = result.Timestamp
+		if result.UpdateVariables {
+			if result.IsMutation {
+				c.SystemVariables.ReadTimestamp = time.Time{}
+				c.SystemVariables.CommitTimestamp = result.Timestamp
+			} else {
+				c.SystemVariables.ReadTimestamp = result.Timestamp
+				c.SystemVariables.CommitTimestamp = time.Time{}
+			}
+
+			if result.CommitStats != nil {
+				c.SystemVariables.CommitResponse = &pb.CommitResponse{CommitStats: result.CommitStats, CommitTimestamp: timestamppb.New(result.Timestamp)}
+			} else {
+				c.SystemVariables.CommitResponse = nil
+			}
 		}
 
 		if input.delim == delimiterHorizontal {

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,13 @@
 module github.com/apstndb/spanner-mycli
 
-go 1.21
+go 1.23
 
-toolchain go1.21.5
+toolchain go1.23.1
 
 require (
 	cloud.google.com/go v0.113.0
 	cloud.google.com/go/spanner v1.62.0
 	github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cloudspannerecosystem/memefish v0.0.0-20241020063446-60438f4a9ffb
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -641,15 +641,10 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241019141852-f27abfc63edf h1:wke4O0w5mfmBtBtkEVTveX47PLz4iyybIaHuALGlugM=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241019141852-f27abfc63edf/go.mod h1:A3kg33HoLP0687AgabrwhnXBN8nx96ki2qJ3MisirOM=
 github.com/cloudspannerecosystem/memefish v0.0.0-20241020063446-60438f4a9ffb h1:JQglTd9iQaOefmLTZ/02ru8Cl7CWNEoSHYygLAh2DJQ=
 github.com/cloudspannerecosystem/memefish v0.0.0-20241020063446-60438f4a9ffb/go.mod h1:A3kg33HoLP0687AgabrwhnXBN8nx96ki2qJ3MisirOM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/integration_test.go
+++ b/integration_test.go
@@ -86,7 +86,7 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 	if testCredential != "" {
 		options = append(options, option.WithCredentialsJSON([]byte(testCredential)))
 	}
-	session, err := NewSession(testProjectId, testInstanceId, testDatabaseId, pb.RequestOptions_PRIORITY_UNSPECIFIED, "", nil, options...)
+	session, err := NewSession(testProjectId, testInstanceId, testDatabaseId, "", nil, &systemVariables{RPCPriority: pb.RequestOptions_PRIORITY_UNSPECIFIED}, options...)
 	if err != nil {
 		t.Fatalf("failed to create test session: err=%s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 	}
 
 	opts := gopts.Spanner
+	var sysVars systemVariables
 
 	logMemefish = opts.LogMemefish
 
@@ -92,13 +93,12 @@ func main() {
 		}
 	}
 
-	var priority pb.RequestOptions_Priority
 	if opts.Priority != "" {
-		var err error
-		priority, err = parsePriority(opts.Priority)
+		priority, err := parsePriority(opts.Priority)
 		if err != nil {
 			exitf("priority must be either HIGH, MEDIUM, or LOW\n")
 		}
+		sysVars.RPCPriority = priority
 	}
 
 	var directedRead *pb.DirectedReadOptions
@@ -110,7 +110,7 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead)
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, opts.Role, opts.Endpoint, directedRead, &sysVars)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	pb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	flags "github.com/jessevdk/go-flags"
@@ -33,22 +34,23 @@ type globalOptions struct {
 }
 
 type spannerOptions struct {
-	ProjectId    string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
-	InstanceId   string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
-	DatabaseId   string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
-	Execute      string `short:"e" long:"execute" description:"Execute SQL statement and quit. --sql is an alias."`
-	File         string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
-	Table        bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
-	Verbose      bool   `short:"v" long:"verbose" description:"Display verbose output."`
-	Credential   string `long:"credential" description:"Use the specific credential file"`
-	Prompt       string `long:"prompt" description:"Set the prompt to the specified format"`
-	LogMemefish  bool   `long:"log-memefish" description:"Emit SQL parse log using memefish"`
-	HistoryFile  string `long:"history" description:"Set the history file to the specified path"`
-	Priority     string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
-	Role         string `long:"role" description:"Use the specific database role"`
-	Endpoint     string `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
-	DirectedRead string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
-	SQL          string `long:"sql" description:"alias of --execute" hidden:"true"`
+	ProjectId    string   `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId   string   `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
+	DatabaseId   string   `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
+	Execute      string   `short:"e" long:"execute" description:"Execute SQL statement and quit. --sql is an alias."`
+	File         string   `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
+	Table        bool     `short:"t" long:"table" description:"Display output in table format for batch mode."`
+	Verbose      bool     `short:"v" long:"verbose" description:"Display verbose output."`
+	Credential   string   `long:"credential" description:"Use the specific credential file"`
+	Prompt       string   `long:"prompt" description:"Set the prompt to the specified format"`
+	LogMemefish  bool     `long:"log-memefish" description:"Emit SQL parse log using memefish"`
+	HistoryFile  string   `long:"history" description:"Set the history file to the specified path"`
+	Priority     string   `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
+	Role         string   `long:"role" description:"Use the specific database role"`
+	Endpoint     string   `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
+	DirectedRead string   `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
+	SQL          string   `long:"sql" description:"alias of --execute" hidden:"true"`
+	Set          []string `long:"set" description:"Set system variables e.g. --set=name1=value1 --set=name2=value2"`
 }
 
 var logMemefish bool
@@ -70,6 +72,15 @@ func main() {
 
 	var sysVars systemVariables
 
+	sets := make(map[string]string)
+	for _, s := range opts.Set {
+		k, v, ok := strings.Cut(s, "=")
+		if !ok {
+			exitf("invalid system variable %v\n", s)
+		}
+		sets[k] = v
+	}
+
 	logMemefish = opts.LogMemefish
 
 	if opts.ProjectId == "" || opts.InstanceId == "" || opts.DatabaseId == "" {
@@ -82,6 +93,7 @@ func main() {
 			cnt += 1
 		}
 	}
+
 	if cnt > 1 {
 		exitf("Invalid combination: -e, -f, --sql are exclusive\n")
 	}
@@ -113,6 +125,12 @@ func main() {
 		}
 	}
 
+	for k, v := range sets {
+		if err := sysVars.Set(k, v); err != nil {
+			exitf("failed to set system variable. name: %v, value: %v, err: %v\n", k, v, err)
+		}
+
+	}
 	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, opts.Role, opts.Endpoint, directedRead, &sysVars)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 	}
 
 	opts := gopts.Spanner
+
 	var sysVars systemVariables
 
 	logMemefish = opts.LogMemefish
@@ -99,6 +100,8 @@ func main() {
 			exitf("priority must be either HIGH, MEDIUM, or LOW\n")
 		}
 		sysVars.RPCPriority = priority
+	} else {
+		sysVars.RPCPriority = defaultPriority
 	}
 
 	var directedRead *pb.DirectedReadOptions

--- a/session.go
+++ b/session.go
@@ -296,6 +296,7 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 // useUpdate flag enforce to use Update function internally and disable `THEN RETURN` result printing.
 func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, useUpdate bool) ([]Row, []string, int64, *sppb.ResultSetMetadata, error) {
 	logParseStatement(stmt.SQL)
+
 	if !s.InReadWriteTransaction() {
 		return nil, nil, 0, nil, errors.New("read-write transaction is not running")
 	}

--- a/session.go
+++ b/session.go
@@ -85,10 +85,6 @@ func NewSession(projectId string, instanceId string, databaseId string, role str
 		return nil, err
 	}
 
-	if sysVars.RPCPriority == sppb.RequestOptions_PRIORITY_UNSPECIFIED {
-		sysVars.RPCPriority = defaultPriority
-	}
-
 	session := &Session{
 		projectId:       projectId,
 		instanceId:      instanceId,

--- a/session.go
+++ b/session.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
-	pb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
 
 var defaultClientConfig = spanner.ClientConfig{
@@ -44,7 +44,7 @@ var defaultClientOpts = []option.ClientOption{
 }
 
 // Use MEDIUM priority not to disturb regular workloads on the database.
-const defaultPriority = pb.RequestOptions_PRIORITY_MEDIUM
+const defaultPriority = sppb.RequestOptions_PRIORITY_MEDIUM
 
 type Session struct {
 	projectId       string
@@ -54,7 +54,7 @@ type Session struct {
 	adminClient     *adminapi.DatabaseAdminClient
 	clientConfig    spanner.ClientConfig
 	clientOpts      []option.ClientOption
-	directedRead    *pb.DirectedReadOptions
+	directedRead    *sppb.DirectedReadOptions
 	tc              *transactionContext
 	tcMutex         sync.Mutex // Guard a critical section for transaction.
 	systemVariables *systemVariables
@@ -62,13 +62,13 @@ type Session struct {
 
 type transactionContext struct {
 	tag           string
-	priority      pb.RequestOptions_Priority
+	priority      sppb.RequestOptions_Priority
 	sendHeartbeat bool // Becomes true only after a user-driven query is executed on the transaction.
 	rwTxn         *spanner.ReadWriteStmtBasedTransaction
 	roTxn         *spanner.ReadOnlyTransaction
 }
 
-func NewSession(projectId string, instanceId string, databaseId string, role string, directedRead *pb.DirectedReadOptions, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
+func NewSession(projectId string, instanceId string, databaseId string, role string, directedRead *sppb.DirectedReadOptions, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
 	ctx := context.Background()
 	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId)
 	clientConfig := defaultClientConfig
@@ -85,7 +85,7 @@ func NewSession(projectId string, instanceId string, databaseId string, role str
 		return nil, err
 	}
 
-	if sysVars.RPCPriority == pb.RequestOptions_PRIORITY_UNSPECIFIED {
+	if sysVars.RPCPriority == sppb.RequestOptions_PRIORITY_UNSPECIFIED {
 		sysVars.RPCPriority = defaultPriority
 	}
 
@@ -116,13 +116,13 @@ func (s *Session) InReadOnlyTransaction() bool {
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
-func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority pb.RequestOptions_Priority, tag string) error {
+func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority sppb.RequestOptions_Priority, tag string) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
 
 	// Use session's priority if transaction priority is not set.
-	if priority == pb.RequestOptions_PRIORITY_UNSPECIFIED {
+	if priority == sppb.RequestOptions_PRIORITY_UNSPECIFIED {
 		priority = s.systemVariables.RPCPriority
 	}
 
@@ -172,7 +172,7 @@ func (s *Session) RollbackReadWriteTransaction(ctx context.Context) error {
 }
 
 // BeginReadOnlyTransaction starts read-only transaction and returns the snapshot timestamp for the transaction if successful.
-func (s *Session) BeginReadOnlyTransaction(ctx context.Context, typ timestampBoundType, staleness time.Duration, timestamp time.Time, priority pb.RequestOptions_Priority, tag string) (time.Time, error) {
+func (s *Session) BeginReadOnlyTransaction(ctx context.Context, typ timestampBoundType, staleness time.Duration, timestamp time.Time, priority sppb.RequestOptions_Priority, tag string) (time.Time, error) {
 	if s.InReadOnlyTransaction() {
 		return time.Time{}, errors.New("read-only transaction is already running")
 	}
@@ -188,7 +188,7 @@ func (s *Session) BeginReadOnlyTransaction(ctx context.Context, typ timestampBou
 	}
 
 	// Use session's priority if transaction priority is not set.
-	if priority == pb.RequestOptions_PRIORITY_UNSPECIFIED {
+	if priority == sppb.RequestOptions_PRIORITY_UNSPECIFIED {
 		priority = s.systemVariables.RPCPriority
 	}
 
@@ -224,7 +224,7 @@ func (s *Session) CloseReadOnlyTransaction() error {
 // RunQueryWithStats executes a statement with stats either on the running transaction or on the temporal read-only transaction.
 // It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
 func (s *Session) RunQueryWithStats(ctx context.Context, stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
-	mode := pb.ExecuteSqlRequest_PROFILE
+	mode := sppb.ExecuteSqlRequest_PROFILE
 	opts := spanner.QueryOptions{
 		Mode:     &mode,
 		Priority: s.currentPriority(),
@@ -242,8 +242,8 @@ func (s *Session) RunQuery(ctx context.Context, stmt spanner.Statement) (*spanne
 }
 
 // RunAnalyzeQuery analyzes a statement either on the running transaction or on the temporal read-only transaction.
-func (s *Session) RunAnalyzeQuery(ctx context.Context, stmt spanner.Statement) (*pb.QueryPlan, *pb.ResultSetMetadata, error) {
-	mode := pb.ExecuteSqlRequest_PLAN
+func (s *Session) RunAnalyzeQuery(ctx context.Context, stmt spanner.Statement) (*sppb.QueryPlan, *sppb.ResultSetMetadata, error) {
+	mode := sppb.ExecuteSqlRequest_PLAN
 	opts := spanner.QueryOptions{
 		Mode:     &mode,
 		Priority: s.currentPriority(),
@@ -261,6 +261,16 @@ func (s *Session) RunAnalyzeQuery(ctx context.Context, stmt spanner.Statement) (
 }
 
 func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statement, opts spanner.QueryOptions) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+	if opts.Options == nil {
+		opts.Options = &sppb.ExecuteSqlRequest_QueryOptions{}
+	}
+
+	opts.Options.OptimizerVersion = s.systemVariables.OptimizerVersion
+	// opts.Options.OptimizerStatisticsPackage = s.systemVariables.OptimizerStatisticsPackage
+
+	fmt.Println("runQueryWithOptions:", opts.Options)
+	fmt.Println("systemVariables.OptimizerVersion:", s.systemVariables.OptimizerVersion)
+
 	logParseStatement(stmt.SQL)
 	if s.InReadWriteTransaction() {
 		// The current Go Spanner client library does not apply client-level directed read options to read-write transactions.
@@ -286,7 +296,7 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 // RunUpdate executes a DML statement on the running read-write transaction.
 // It returns error if there is no running read-write transaction.
 // useUpdate flag enforce to use Update function internally and disable `THEN RETURN` result printing.
-func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, useUpdate bool) ([]Row, []string, int64, *pb.ResultSetMetadata, error) {
+func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, useUpdate bool) ([]Row, []string, int64, *sppb.ResultSetMetadata, error) {
 	logParseStatement(stmt.SQL)
 	if !s.InReadWriteTransaction() {
 		return nil, nil, 0, nil, errors.New("read-write transaction is not running")
@@ -362,7 +372,7 @@ func (s *Session) RecreateClient() error {
 	return nil
 }
 
-func (s *Session) currentPriority() pb.RequestOptions_Priority {
+func (s *Session) currentPriority() sppb.RequestOptions_Priority {
 	if s.tc != nil {
 		return s.tc.priority
 	}
@@ -394,7 +404,7 @@ func (s *Session) startHeartbeat() {
 	}
 }
 
-func heartbeat(txn *spanner.ReadWriteStmtBasedTransaction, priority pb.RequestOptions_Priority) error {
+func heartbeat(txn *spanner.ReadWriteStmtBasedTransaction, priority sppb.RequestOptions_Priority) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	iter := txn.QueryWithOptions(ctx, spanner.NewStatement("SELECT 1"), spanner.QueryOptions{Priority: priority})
@@ -403,31 +413,31 @@ func heartbeat(txn *spanner.ReadWriteStmtBasedTransaction, priority pb.RequestOp
 	return err
 }
 
-func parseDirectedReadOption(directedReadOptionText string) (*pb.DirectedReadOptions, error) {
+func parseDirectedReadOption(directedReadOptionText string) (*sppb.DirectedReadOptions, error) {
 	directedReadOption := strings.Split(directedReadOptionText, ":")
 	if len(directedReadOption) > 2 {
 		return nil, fmt.Errorf("directed read option must be in the form of <replica_location>:<replica_type>, but got %q", directedReadOptionText)
 	}
 
-	replicaSelection := pb.DirectedReadOptions_ReplicaSelection{
+	replicaSelection := sppb.DirectedReadOptions_ReplicaSelection{
 		Location: directedReadOption[0],
 	}
 
 	if len(directedReadOption) == 2 {
 		switch strings.ToUpper(directedReadOption[1]) {
 		case "READ_ONLY":
-			replicaSelection.Type = pb.DirectedReadOptions_ReplicaSelection_READ_ONLY
+			replicaSelection.Type = sppb.DirectedReadOptions_ReplicaSelection_READ_ONLY
 		case "READ_WRITE":
-			replicaSelection.Type = pb.DirectedReadOptions_ReplicaSelection_READ_WRITE
+			replicaSelection.Type = sppb.DirectedReadOptions_ReplicaSelection_READ_WRITE
 		default:
 			return nil, fmt.Errorf("<replica_type> must be either READ_WRITE or READ_ONLY, but got %q", directedReadOption[1])
 		}
 	}
 
-	return &pb.DirectedReadOptions{
-		Replicas: &pb.DirectedReadOptions_IncludeReplicas_{
-			IncludeReplicas: &pb.DirectedReadOptions_IncludeReplicas{
-				ReplicaSelections:    []*pb.DirectedReadOptions_ReplicaSelection{&replicaSelection},
+	return &sppb.DirectedReadOptions{
+		Replicas: &sppb.DirectedReadOptions_IncludeReplicas_{
+			IncludeReplicas: &sppb.DirectedReadOptions_IncludeReplicas{
+				ReplicaSelections:    []*sppb.DirectedReadOptions_ReplicaSelection{&replicaSelection},
 				AutoFailoverDisabled: true,
 			},
 		},

--- a/session.go
+++ b/session.go
@@ -261,17 +261,15 @@ func (s *Session) RunAnalyzeQuery(ctx context.Context, stmt spanner.Statement) (
 }
 
 func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statement, opts spanner.QueryOptions) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+	logParseStatement(stmt.SQL)
+
 	if opts.Options == nil {
 		opts.Options = &sppb.ExecuteSqlRequest_QueryOptions{}
 	}
 
 	opts.Options.OptimizerVersion = s.systemVariables.OptimizerVersion
-	// opts.Options.OptimizerStatisticsPackage = s.systemVariables.OptimizerStatisticsPackage
+	opts.Options.OptimizerStatisticsPackage = s.systemVariables.OptimizerStatisticsPackage
 
-	fmt.Println("runQueryWithOptions:", opts.Options)
-	fmt.Println("systemVariables.OptimizerVersion:", s.systemVariables.OptimizerVersion)
-
-	logParseStatement(stmt.SQL)
 	if s.InReadWriteTransaction() {
 		// The current Go Spanner client library does not apply client-level directed read options to read-write transactions.
 		// Therefore, we explicitly set query-level options here to fail the query during a read-write transaction.

--- a/session.go
+++ b/session.go
@@ -277,6 +277,9 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 	}
 
 	txn := s.client.Single()
+	if s.systemVariables.ReadOnlyStaleness != nil {
+		txn = txn.WithTimestampBound(*s.systemVariables.ReadOnlyStaleness)
+	}
 	return txn.QueryWithOptions(ctx, stmt, opts), txn
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -66,7 +66,7 @@ func TestRequestPriority(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			defer recorder.flush()
 
-			session, err := NewSession("project", "instance", "database", test.sessionPriority, "role", nil, option.WithGRPCConn(conn))
+			session, err := NewSession("project", "instance", "database", "role", nil, &systemVariables{RPCPriority: test.sessionPriority}, option.WithGRPCConn(conn))
 			if err != nil {
 				t.Fatalf("failed to create spanner-cli session: %v", err)
 			}

--- a/session_test.go
+++ b/session_test.go
@@ -39,7 +39,7 @@ func TestRequestPriority(t *testing.T) {
 		want                pb.RequestOptions_Priority
 	}{
 		{
-			desc:                "use default MEDIUM priority",
+			desc:                "use default priority",
 			sessionPriority:     pb.RequestOptions_PRIORITY_UNSPECIFIED,
 			transactionPriority: pb.RequestOptions_PRIORITY_UNSPECIFIED,
 			want:                pb.RequestOptions_PRIORITY_UNSPECIFIED,

--- a/session_test.go
+++ b/session_test.go
@@ -42,7 +42,7 @@ func TestRequestPriority(t *testing.T) {
 			desc:                "use default MEDIUM priority",
 			sessionPriority:     pb.RequestOptions_PRIORITY_UNSPECIFIED,
 			transactionPriority: pb.RequestOptions_PRIORITY_UNSPECIFIED,
-			want:                pb.RequestOptions_PRIORITY_MEDIUM,
+			want:                pb.RequestOptions_PRIORITY_UNSPECIFIED,
 		},
 		{
 			desc:                "use session priority",

--- a/statement.go
+++ b/statement.go
@@ -441,18 +441,8 @@ type ShowVariableStatement struct {
 }
 
 func (s *ShowVariableStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	name := s.VarName
-	upperName := strings.ToUpper(name)
-	a, ok := accessorMap[upperName]
-	if !ok {
-		return nil, fmt.Errorf("unknown variable name: %v", name)
-	}
-	if a.Getter == nil {
-		return nil, fmt.Errorf("getter unimplemented: %v", name)
-	}
-
-	value, err := a.Getter(session.systemVariables, name)
-	if err != nil && !errors.Is(err, errIgnored) {
+	value, err := session.systemVariables.Get(s.VarName)
+	if err != nil {
 		return nil, err
 	}
 
@@ -517,18 +507,7 @@ type SetStatement struct {
 }
 
 func (s *SetStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	name := s.VarName
-	upper := strings.ToUpper(name)
-	a, ok := accessorMap[name]
-	if !ok {
-		return nil, fmt.Errorf("unknown variable name: %v", name)
-	}
-	if a.Setter == nil {
-		return nil, fmt.Errorf("setter unimplemented: %v", name)
-	}
-
-	err := a.Setter(session.systemVariables, upper, s.Value)
-	if err != nil {
+	if err := session.systemVariables.Set(s.VarName, s.Value); err != nil {
 		return nil, err
 	}
 	return &Result{KeepVariables: true}, nil

--- a/statement.go
+++ b/statement.go
@@ -437,6 +437,10 @@ func (s *ShowVariableStatement) Execute(ctx context.Context, session *Session) (
 	if !ok {
 		return nil, fmt.Errorf("unknown variable name: %v", s.VarName)
 	}
+	if a.Getter == nil {
+		return nil, fmt.Errorf("getter unimplemented: %v", s.VarName)
+	}
+
 	value, err := a.Getter(session.systemVariables)
 	if err != nil {
 		return nil, err
@@ -455,6 +459,10 @@ func (s *SetVariableStatement) Execute(ctx context.Context, session *Session) (*
 	if !ok {
 		return nil, fmt.Errorf("unknown variable name: %v", s.VarName)
 	}
+	if a.Setter == nil {
+		return nil, fmt.Errorf("setter unimplemented: %v", s.VarName)
+	}
+
 	err := a.Setter(session.systemVariables, s.Value)
 	if err != nil {
 		return nil, err

--- a/statement_test.go
+++ b/statement_test.go
@@ -596,7 +596,6 @@ func TestBuildStatement(t *testing.T) {
 	}{
 		{"FOO BAR"},
 		{"SELEC T FROM t1"},
-		{"SET @a = 1"},
 		{"BEGIN PRIORITY CRITICAL"},
 	} {
 		got, err := BuildStatement(test.input)

--- a/system_variables.go
+++ b/system_variables.go
@@ -108,7 +108,7 @@ var accessorMap = map[string]accessor{
 				return singletonMap(name, "STRONG"), nil
 
 			case "exactStaleness":
-				return singletonMap(name, fmt.Sprintf("EXACT_STALENESS %v")), nil
+				return singletonMap(name, fmt.Sprintf("EXACT_STALENESS %v", matches[2])), nil
 			case "maxStaleness":
 				return singletonMap(name, fmt.Sprintf("MAX_STALENESS %v", matches[2])), nil
 			// TODO: re-format timestamp as RFC3339

--- a/system_variables.go
+++ b/system_variables.go
@@ -11,9 +11,10 @@ import (
 )
 
 type systemVariables struct {
-	RPCPriority       sppb.RequestOptions_Priority
-	ReadOnlyStaleness *spanner.TimestampBound
-	ReadTimestamp     time.Time
+	RPCPriority                sppb.RequestOptions_Priority
+	ReadOnlyStaleness          *spanner.TimestampBound
+	ReadTimestamp              time.Time
+	OptimizerVersion           string
 }
 
 var errIgnored = errors.New("ignored")
@@ -106,7 +107,15 @@ var accessorMap = map[string]accessor{
 			}
 		},
 	},
-	"OPTIMIZER_VERSION":            {},
+	"OPTIMIZER_VERSION": {
+		func(this *systemVariables, value string) error {
+			this.OptimizerVersion = unquoteString(value)
+			return nil
+		},
+		func(this *systemVariables) (string, error) {
+			return this.OptimizerVersion, nil
+		},
+	},
 	"OPTIMIZER_STATISTICS_PACKAGE": {},
 	"RETURN_COMMIT_STATS":          {},
 	"RPC_PRIORITY": {

--- a/system_variables.go
+++ b/system_variables.go
@@ -85,30 +85,28 @@ var accessorMap = map[string]accessor{
 
 			upper := strings.ToUpper(first)
 			var staleness spanner.TimestampBound
-			switch {
-			case upper == "STRONG":
+			switch upper {
+			case "STRONG":
 				staleness = spanner.StrongRead()
-			case upper == "MIN_READ_TIMESTAMP" || upper == "READ_TIMESTAMP":
-				var minReadTimestamp bool
-				if strings.HasPrefix(upper, "MIN_") {
-					minReadTimestamp = true
-				}
+			case "MIN_READ_TIMESTAMP":
 				ts, err := time.Parse(time.RFC3339Nano, second)
 				if err != nil {
 					return err
 				}
-				if minReadTimestamp {
-					staleness = spanner.MinReadTimestamp(ts)
-				} else {
-					staleness = spanner.ReadTimestamp(ts)
+				staleness = spanner.MinReadTimestamp(ts)
+			case "READ_TIMESTAMP":
+				ts, err := time.Parse(time.RFC3339Nano, second)
+				if err != nil {
+					return err
 				}
-			case upper == "MAX_STALENESS":
+				staleness = spanner.ReadTimestamp(ts)
+			case "MAX_STALENESS":
 				ts, err := time.ParseDuration(second)
 				if err != nil {
 					return err
 				}
 				staleness = spanner.MaxStaleness(ts)
-			case upper == "EXACT_STALENESS":
+			case "EXACT_STALENESS":
 				ts, err := time.ParseDuration(second)
 				if err != nil {
 					return err

--- a/system_variables.go
+++ b/system_variables.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"strconv"
+	"strings"
+)
+
+type systemVariables struct {
+	RPCPriority sppb.RequestOptions_Priority
+}
+
+type setter func(this *systemVariables, value string) error
+
+type getter func(this *systemVariables) (string, error)
+
+type accessor struct {
+	Setter setter
+	Getter getter
+}
+
+var accessorMap = map[string]accessor{
+	"RPC_PRIORITY": {
+		func(this *systemVariables, value string) error {
+			s, err := strconv.Unquote(value)
+			if err != nil {
+				return err
+			}
+
+			p, err := parsePriority(s)
+			if err != nil {
+				return err
+			}
+
+			this.RPCPriority = p
+			return nil
+		},
+		func(this *systemVariables) (string, error) {
+			return strings.TrimPrefix(this.RPCPriority.String(), "PRIORITY_"), nil
+		},
+	},
+}

--- a/system_variables.go
+++ b/system_variables.go
@@ -15,6 +15,7 @@ type systemVariables struct {
 	ReadOnlyStaleness          *spanner.TimestampBound
 	ReadTimestamp              time.Time
 	OptimizerVersion           string
+	OptimizerStatisticsPackage string
 }
 
 var errIgnored = errors.New("ignored")
@@ -116,8 +117,16 @@ var accessorMap = map[string]accessor{
 			return this.OptimizerVersion, nil
 		},
 	},
-	"OPTIMIZER_STATISTICS_PACKAGE": {},
-	"RETURN_COMMIT_STATS":          {},
+	"OPTIMIZER_STATISTICS_PACKAGE": {
+		func(this *systemVariables, value string) error {
+			this.OptimizerStatisticsPackage = unquoteString(value)
+			return nil
+		},
+		func(this *systemVariables) (string, error) {
+			return this.OptimizerStatisticsPackage, nil
+		},
+	},
+	"RETURN_COMMIT_STATS": {},
 	"RPC_PRIORITY": {
 		func(this *systemVariables, value string) error {
 			s := unquoteString(value)

--- a/system_variables.go
+++ b/system_variables.go
@@ -74,6 +74,10 @@ func singletonMap[K comparable, V any](k K, v V) map[K]V {
 	return map[K]V{k: v}
 }
 
+func parseTimeString(s string) (time.Time, error) {
+	return time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", s)
+}
+
 var accessorMap = map[string]accessor{
 	"AUTOCOMMIT":              {},
 	"RETRY_ABORTS_INTERNALLY": {},
@@ -102,15 +106,24 @@ var accessorMap = map[string]accessor{
 			switch matches[1] {
 			case "strong":
 				return singletonMap(name, "STRONG"), nil
+
 			case "exactStaleness":
-				return singletonMap(name, fmt.Sprintf("EXACT_STALENESS %v", matches[2])), nil
+				return singletonMap(name, fmt.Sprintf("EXACT_STALENESS %v")), nil
 			case "maxStaleness":
 				return singletonMap(name, fmt.Sprintf("MAX_STALENESS %v", matches[2])), nil
 			// TODO: re-format timestamp as RFC3339
 			case "readTimestamp":
-				return singletonMap(name, fmt.Sprintf("READ_TIMESTAMP %v", matches[2])), nil
+				ts, err := parseTimeString(matches[2])
+				if err != nil {
+					return nil, err
+				}
+				return singletonMap(name, fmt.Sprintf("READ_TIMESTAMP %v", ts.Format(time.RFC3339Nano))), nil
 			case "minReadTimestamp":
-				return singletonMap(name, fmt.Sprintf("MIN_READ_TIMESTAMP %v", matches[2])), nil
+				ts, err := parseTimeString(matches[2])
+				if err != nil {
+					return nil, err
+				}
+				return singletonMap(name, fmt.Sprintf("MIN_READ_TIMESTAMP %v", ts.Format(time.RFC3339Nano))), nil
 			default:
 				return singletonMap(name, s), nil
 			}

--- a/system_variables.go
+++ b/system_variables.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -16,13 +17,15 @@ type systemVariables struct {
 	ReadTimestamp              time.Time
 	OptimizerVersion           string
 	OptimizerStatisticsPackage string
+	CommitResponse             *sppb.CommitResponse
+	CommitTimestamp            time.Time
 }
 
 var errIgnored = errors.New("ignored")
 
-type setter = func(this *systemVariables, value string) error
+type setter = func(this *systemVariables, name, value string) error
 
-type getter = func(this *systemVariables) (string, error)
+type getter = func(this *systemVariables, name string) (map[string]string, error)
 
 type accessor struct {
 	Setter setter
@@ -33,13 +36,21 @@ func unquoteString(s string) string {
 	return strings.Trim(s, `"'`)
 }
 
+func sliceOf[V any](vs ...V) []V {
+	return vs
+}
+
+func singletonMap[K comparable, V any](k K, v V) map[K]V {
+	return map[K]V{k: v}
+}
+
 var accessorMap = map[string]accessor{
 	"AUTOCOMMIT":              {},
 	"RETRY_ABORTS_INTERNALLY": {},
 	"AUTOCOMMIT_DML_MODE":     {},
 	"STATEMENT_TIMEOUT":       {},
 	"READ_ONLY_STALENESS": {
-		func(this *systemVariables, value string) error {
+		func(this *systemVariables, name, value string) error {
 			s := unquoteString(value)
 
 			var staleness spanner.TimestampBound
@@ -82,53 +93,53 @@ var accessorMap = map[string]accessor{
 			this.ReadOnlyStaleness = &staleness
 			return nil
 		},
-		func(this *systemVariables) (string, error) {
+		func(this *systemVariables, name string) (map[string]string, error) {
 			if this.ReadOnlyStaleness == nil {
-				return "NULL", nil
+				return singletonMap(name, "NULL"), nil
 			}
 			s := this.ReadOnlyStaleness.String()
 			stalenessRe := regexp.MustCompile(`^\(([^:]+)(?:: (.+))?\)$`)
 			matches := stalenessRe.FindStringSubmatch(s)
 			if matches == nil {
-				return s, nil
+				return singletonMap(name, s), nil
 			}
 			switch matches[1] {
 			case "strong":
-				return "STRONG", nil
+				return singletonMap(name, "STRONG"), nil
 			case "exactStaleness":
-				return fmt.Sprintf("EXACT_STALENESS %v", matches[2]), nil
+				return singletonMap(name, fmt.Sprintf("EXACT_STALENESS %v", matches[2])), nil
 			case "maxStaleness":
-				return fmt.Sprintf("MAX_STALENESS %v", matches[2]), nil
+				return singletonMap(name, fmt.Sprintf("MAX_STALENESS %v", matches[2])), nil
 			case "readTimestamp":
-				return fmt.Sprintf("READ_TIMESTAMP %v", matches[2]), nil
+				return singletonMap(name, fmt.Sprintf("READ_TIMESTAMP %v", matches[2])), nil
 			case "minReadTimestamp":
-				return fmt.Sprintf("MIN_READ_TIMESTAMP %v", matches[2]), nil
+				return singletonMap(name, fmt.Sprintf("MIN_READ_TIMESTAMP %v", matches[2])), nil
 			default:
-				return s, nil
+				return singletonMap(name, s), nil
 			}
 		},
 	},
 	"OPTIMIZER_VERSION": {
-		func(this *systemVariables, value string) error {
+		func(this *systemVariables, name, value string) error {
 			this.OptimizerVersion = unquoteString(value)
 			return nil
 		},
-		func(this *systemVariables) (string, error) {
-			return this.OptimizerVersion, nil
+		func(this *systemVariables, name string) (map[string]string, error) {
+			return singletonMap(name, this.OptimizerVersion), nil
 		},
 	},
 	"OPTIMIZER_STATISTICS_PACKAGE": {
-		func(this *systemVariables, value string) error {
+		func(this *systemVariables, name, value string) error {
 			this.OptimizerStatisticsPackage = unquoteString(value)
 			return nil
 		},
-		func(this *systemVariables) (string, error) {
-			return this.OptimizerStatisticsPackage, nil
+		func(this *systemVariables, name string) (map[string]string, error) {
+			return singletonMap(name, this.OptimizerStatisticsPackage), nil
 		},
 	},
 	"RETURN_COMMIT_STATS": {},
 	"RPC_PRIORITY": {
-		func(this *systemVariables, value string) error {
+		func(this *systemVariables, name, value string) error {
 			s := unquoteString(value)
 
 			p, err := parsePriority(s)
@@ -139,22 +150,43 @@ var accessorMap = map[string]accessor{
 			this.RPCPriority = p
 			return nil
 		},
-		func(this *systemVariables) (string, error) {
-			return strings.TrimPrefix(this.RPCPriority.String(), "PRIORITY_"), nil
+		func(this *systemVariables, name string) (map[string]string, error) {
+			return singletonMap(name, strings.TrimPrefix(this.RPCPriority.String(), "PRIORITY_")), nil
 		},
 	},
 	"STATEMENT_TAG":   {},
 	"TRANSACTION_TAG": {},
 	"READ_TIMESTAMP": {
 		nil,
-		func(this *systemVariables) (string, error) {
+		func(this *systemVariables, name string) (map[string]string, error) {
 			ts := this.ReadTimestamp
 			if ts.IsZero() {
-				return "", errIgnored
+				return nil, errIgnored
 			}
-			return ts.Format(time.RFC3339Nano), nil
+			return singletonMap(name, ts.Format(time.RFC3339Nano)), nil
 		},
 	},
-	"COMMIT_TIMESTAMP": {},
-	"COMMIT_RESPONSE":  {},
+	"COMMIT_TIMESTAMP": {
+		nil,
+		func(this *systemVariables, name string) (map[string]string, error) {
+			if this.CommitTimestamp.IsZero() {
+				return nil, errIgnored
+			}
+			s := this.CommitTimestamp.Format(time.RFC3339Nano)
+			return singletonMap(name, s), nil
+		},
+	},
+	"COMMIT_RESPONSE": {
+		nil,
+		func(this *systemVariables, name string) (map[string]string, error) {
+			if this.CommitResponse == nil {
+				return nil, errIgnored
+			}
+			mutationCount := this.CommitResponse.GetCommitStats().GetMutationCount()
+			return map[string]string{
+				"COMMIT_TIMESTAMP": this.CommitTimestamp.Format(time.RFC3339Nano),
+				"MUTATION_COUNT":   strconv.FormatInt(mutationCount, 10),
+			}, nil
+		},
+	},
 }

--- a/system_variables.go
+++ b/system_variables.go
@@ -10,9 +10,9 @@ type systemVariables struct {
 	RPCPriority sppb.RequestOptions_Priority
 }
 
-type setter func(this *systemVariables, value string) error
+type setter = func(this *systemVariables, value string) error
 
-type getter func(this *systemVariables) (string, error)
+type getter = func(this *systemVariables) (string, error)
 
 type accessor struct {
 	Setter setter
@@ -20,6 +20,14 @@ type accessor struct {
 }
 
 var accessorMap = map[string]accessor{
+	"AUTOCOMMIT":                   {},
+	"RETRY_ABORTS_INTERNALLY":      {},
+	"AUTOCOMMIT_DML_MODE":          {},
+	"STATEMENT_TIMEOUT":            {},
+	"READ_ONLY_STALENESS":          {},
+	"OPTIMIZER_VERSION":            {},
+	"OPTIMIZER_STATISTICS_PACKAGE": {},
+	"RETURN_COMMIT_STATS":          {},
 	"RPC_PRIORITY": {
 		func(this *systemVariables, value string) error {
 			s, err := strconv.Unquote(value)
@@ -39,4 +47,9 @@ var accessorMap = map[string]accessor{
 			return strings.TrimPrefix(this.RPCPriority.String(), "PRIORITY_"), nil
 		},
 	},
+	"STATEMENT_TAG":    {},
+	"TRANSACTION_TAG":  {},
+	"READ_TIMESTAMP":   {},
+	"COMMIT_TIMESTAMP": {},
+	"COMMIT_RESPONSE":  {},
 }


### PR DESCRIPTION
Introduce [Spanner JDBC driver style system variables](https://cloud.google.com/spanner/docs/jdbc-session-mgmt-commands?hl=en).

Statements

* `SHOW VARIABLE <name>;`
* `SET <name> = <value>;`
* `SHOW VARIABLES;`

Flags
* `--set name=value`

Implemented variables
* `READ_ONLY_STALENESS`
* `OPTIMIZER_VERSION` (not work because backend bug?)
* `OPTIMIZER_STATISTICS_PACKAGE`
* `RPC_PRIORITY`
* `READ_TIMESTAMP`
* `COMMIT_TIMESTAMP`
* `COMMIT_RESPONSE`

Refs:
* Original proposal in spanner-cli repo: https://github.com/cloudspannerecosystem/spanner-cli/issues/188

Example
```
$ spanner-mycli -t --set 'read_only_staleness=max_staleness 10m' -v
Connected.
spanner> SHOW VARIABLES;
+------------------------------+---------------------+
| name                         | value               |
+------------------------------+---------------------+
| OPTIMIZER_STATISTICS_PACKAGE |                     |
| OPTIMIZER_VERSION            |                     |
| READ_ONLY_STALENESS          | MAX_STALENESS 10m0s |
| RPC_PRIORITY                 | MEDIUM              |
+------------------------------+---------------------+
Empty set (0.00 sec)

spanner> SELECT 1;
+-------+
|       |
| INT64 |
+-------+
| 1     |
+-------+
1 rows in set (0.14 msecs)
timestamp:            2024-10-26T22:57:45.759191+09:00
cpu time:             0.12 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    7
optimizer statistics: auto_20241023_13_33_54UTC

spanner> SET READ_ONLY_STALENESS = "READ_TIMESTAMP 2024-10-26T22:45:00+09:00";
Empty set (0.00 sec)

spanner> SELECT 1;
+-------+
|       |
| INT64 |
+-------+
| 1     |
+-------+
1 rows in set (0.2 msecs)
timestamp:            2024-10-26T22:45:00+09:00
cpu time:             0.16 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    7
optimizer statistics: auto_20241023_13_33_54UTC

spanner> SHOW VARIABLES;
+------------------------------+------------------------------------------+
| name                         | value                                    |
+------------------------------+------------------------------------------+
| OPTIMIZER_STATISTICS_PACKAGE |                                          |
| OPTIMIZER_VERSION            |                                          |
| READ_ONLY_STALENESS          | READ_TIMESTAMP 2024-10-26T22:45:00+09:00 |
| READ_TIMESTAMP               | 2024-10-26T22:45:00+09:00                |
| RPC_PRIORITY                 | MEDIUM                                   |
+------------------------------+------------------------------------------+
Empty set (0.00 sec)

```