### PR TITLE
More memefish integration

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -553,9 +553,9 @@ func buildCommands(input string) ([]*command, error) {
 			continue
 		}
 
-		stmt, err := BuildStatementWithComments(separated.statementWithoutComments, separated.statement)
+		stmt, err := BuildStatementWithComments(strings.TrimSpace(separated.statementWithoutComments), separated.statement)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed with statement, error: %w, statement: %q, without comments: %q", err, separated.statement, separated.statementWithoutComments)
 		}
 		if ddl, ok := stmt.(*DdlStatement); ok {
 			pendingDdls = append(pendingDdls, ddl.Ddl)

--- a/cli.go
+++ b/cli.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/reeflective/readline/inputrc"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
@@ -108,6 +109,20 @@ func NewCli(projectId, instanceId, databaseId, prompt, historyFile string, crede
 
 func (c *Cli) RunInteractive() int {
 	shell := readline.NewShell()
+
+	shell.Keymap.Register(map[string]func(){"force-end-of-file": func() {
+		switch shell.Line().Len() {
+		case 0:
+			shell.Display.AcceptLine()
+			shell.History.Accept(false, false, io.EOF)
+		default:
+			shell.Display.AcceptLine()
+			shell.History.Accept(false, false, nil)
+		}
+	}})
+
+	shell.Config.Bind("emacs", inputrc.Unescape(`\C-D`), "force-end-of-file", false)
+
 	shell.AcceptMultiline = func(line []rune) (accept bool) {
 		statements, err := separateInput(string(line))
 		if e, ok := lo.ErrorsAs[*ErrLexerStatus](err); ok {
@@ -244,11 +259,7 @@ func (c *Cli) RunInteractive() int {
 			c.updateSystemVariables(result)
 		}
 
-		if input.delim == delimiterHorizontal {
-			c.PrintResult(result, DisplayModeTable, true)
-		} else {
-			c.PrintResult(result, DisplayModeVertical, true)
-		}
+		c.PrintResult(result, DisplayModeTable, true)
 
 		fmt.Fprintf(c.OutStream, "\n")
 		cancel()
@@ -271,7 +282,7 @@ func (c *Cli) updateSystemVariables(result *Result) {
 	}
 }
 
-func (c *Cli) RunBatch(input string, displayTable bool) int {
+func (c *Cli) RunBatch(input string) int {
 	cmds, err := buildCommands(input)
 	if err != nil {
 		c.PrintBatchError(err)
@@ -292,13 +303,7 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 			c.updateSystemVariables(result)
 		}
 
-		if displayTable {
-			c.PrintResult(result, DisplayModeTable, false)
-		} else if cmd.Vertical {
-			c.PrintResult(result, DisplayModeVertical, false)
-		} else {
-			c.PrintResult(result, DisplayModeTab, false)
-		}
+		c.PrintResult(result, c.SystemVariables.CLIFormat, false)
 	}
 
 	return exitCodeSuccess
@@ -394,12 +399,9 @@ func readInteractiveInput(rl *readline.Shell, prompt string) (*inputStatement, e
 		case 0:
 			// read next input
 		case 1:
-			if statements[0].delim != delimiterUndefined {
-				return &statements[0], nil
-			}
-			// read next input
+			return &statements[0], nil
 		default:
-			return nil, errors.New("sql queries are limited to single statements")
+			return nil, errors.New("sql queries are limited to single statements in interactive mode")
 		}
 
 		// show prompt to urge next input

--- a/cli_test.go
+++ b/cli_test.go
@@ -54,13 +54,13 @@ func TestBuildCommands(t *testing.T) {
 			}}, false}}},
 		{Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
                 CREATE TABLE t2(pk INT64) PRIMARY KEY(pk);
-                SELECT * FROM t1\G
+                SELECT * FROM t1;
                 DROP TABLE t1;
                 DROP TABLE t2;
                 SELECT 1;`,
 			Expected: []*command{
 				{&BulkDdlStatement{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)", "CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)"}}, false},
-				{&SelectStatement{"SELECT * FROM t1"}, true},
+				{&SelectStatement{"SELECT * FROM t1"}, false},
 				{&BulkDdlStatement{[]string{"DROP TABLE t1", "DROP TABLE t2"}}, false},
 				{&SelectStatement{"SELECT 1"}, false},
 			}},

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.1
 require (
 	cloud.google.com/go v0.113.0
 	cloud.google.com/go/spanner v1.62.0
-	github.com/cloudspannerecosystem/memefish v0.0.0-20241025043324-0b37cb66062c
+	github.com/cloudspannerecosystem/memefish v0.0.0-20241029131948-98b8bf288447
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5
@@ -63,5 +63,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240708141625-4ad9e859172b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240708141625-4ad9e859172b // indirect
 )
-
-replace github.com/cloudspannerecosystem/memefish => github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
@@ -63,3 +63,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240708141625-4ad9e859172b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240708141625-4ad9e859172b // indirect
 )
+
+replace github.com/cloudspannerecosystem/memefish => github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.1
 require (
 	cloud.google.com/go v0.113.0
 	cloud.google.com/go/spanner v1.62.0
-	github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080
 	github.com/cloudspannerecosystem/memefish v0.0.0-20241025043324-0b37cb66062c
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/reeflective/readline v1.0.15
+	github.com/samber/lo v1.47.0
 	github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01
 	google.golang.org/api v0.180.0
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
+	spheric.cloud/xiter v0.0.0-20240904151420-c999f37a46b2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,6 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080 h1:L1KrVddvtrBT7T2/408TOPu9xNr2I/OCJUUOugMezNk=
-github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080/go.mod h1:NQogaK8AOkyzXEXMqGvc6hV0SKO8cUkcqqXJimyvTlw=
 github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de h1:s4in0OmKZrCE8L/SBAk19LIdMS9xzJfv88D+mhU3fbs=
 github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de/go.mod h1:iYAaNZfVIn4QYfUmXt+3EeHAok/kqpN/fp/8kgDHjx8=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -647,8 +645,6 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241025043324-0b37cb66062c h1:2mEHwpdhPRTYLPyg7EZAoeN57W+Jc722a8Dt6Dql8zA=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241025043324-0b37cb66062c/go.mod h1:A3kg33HoLP0687AgabrwhnXBN8nx96ki2qJ3MisirOM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -1200,8 +1196,6 @@ golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,6 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de h1:s4in0OmKZrCE8L/SBAk19LIdMS9xzJfv88D+mhU3fbs=
-github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de/go.mod h1:iYAaNZfVIn4QYfUmXt+3EeHAok/kqpN/fp/8kgDHjx8=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -645,6 +643,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudspannerecosystem/memefish v0.0.0-20241029131948-98b8bf288447 h1:t3OhQwTZ9zbnjjURAJ4OYL6z01rSJKmlYF+SrQ/+S4o=
+github.com/cloudspannerecosystem/memefish v0.0.0-20241029131948-98b8bf288447/go.mod h1:iYAaNZfVIn4QYfUmXt+3EeHAok/kqpN/fp/8kgDHjx8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -645,8 +645,6 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241020063446-60438f4a9ffb h1:JQglTd9iQaOefmLTZ/02ru8Cl7CWNEoSHYygLAh2DJQ=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241020063446-60438f4a9ffb/go.mod h1:A3kg33HoLP0687AgabrwhnXBN8nx96ki2qJ3MisirOM=
 github.com/cloudspannerecosystem/memefish v0.0.0-20241025043324-0b37cb66062c h1:2mEHwpdhPRTYLPyg7EZAoeN57W+Jc722a8Dt6Dql8zA=
 github.com/cloudspannerecosystem/memefish v0.0.0-20241025043324-0b37cb66062c/go.mod h1:A3kg33HoLP0687AgabrwhnXBN8nx96ki2qJ3MisirOM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -890,6 +888,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/go.sum
+++ b/go.sum
@@ -1635,3 +1635,5 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+spheric.cloud/xiter v0.0.0-20240904151420-c999f37a46b2 h1:/2/LZep2TpsdSwYhdMsGRh+OVun1UMYlMEip4EEsgg8=
+spheric.cloud/xiter v0.0.0-20240904151420-c999f37a46b2/go.mod h1:i4SlkNfFrn1974zbGZWg8FYXAWLnrS6cYAXtSfmIDhU=

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080 h1:L1KrVddvtrBT7T2/408TOPu9xNr2I/OCJUUOugMezNk=
 github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080/go.mod h1:NQogaK8AOkyzXEXMqGvc6hV0SKO8cUkcqqXJimyvTlw=
+github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de h1:s4in0OmKZrCE8L/SBAk19LIdMS9xzJfv88D+mhU3fbs=
+github.com/apstndb/memefish v0.0.0-20241027133659-ab1fad4c32de/go.mod h1:iYAaNZfVIn4QYfUmXt+3EeHAok/kqpN/fp/8kgDHjx8=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -1200,6 +1202,8 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/samber/lo"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -78,7 +79,7 @@ func main() {
 		if !ok {
 			exitf("invalid system variable %v\n", s)
 		}
-		sets[k] = v
+		sets[strings.ToUpper(k)] = v
 	}
 
 	logMemefish = opts.LogMemefish
@@ -164,9 +165,12 @@ func main() {
 		}
 	}
 
+	if _, ok := sets["CLI_FORMAT"]; !ok {
+		sysVars.CLIFormat = lo.Ternary(opts.Table, DisplayModeTable, DisplayModeTab)
+	}
 	var exitCode int
 	if input != "" {
-		exitCode = cli.RunBatch(input, opts.Table)
+		exitCode = cli.RunBatch(input)
 	} else {
 		exitCode = cli.RunInteractive()
 	}

--- a/memefish.go
+++ b/memefish.go
@@ -1,0 +1,168 @@
+package main
+
+// This file will eventually become another library.
+
+import (
+	"fmt"
+	"github.com/cloudspannerecosystem/memefish"
+	"github.com/cloudspannerecosystem/memefish/token"
+	"github.com/samber/lo"
+	"strings"
+)
+
+type RawStatement struct {
+	Pos, End   token.Pos
+	Statement  string
+	Terminator string
+}
+
+func (stmt *RawStatement) StripComments() (RawStatement, error) {
+	result, err := StripComments("", stmt.Statement)
+
+	// It can assume InputStatement.Statement doesn't have any terminating characters.
+	return RawStatement{
+		Statement:  result,
+		Terminator: stmt.Terminator,
+	}, err
+}
+
+type ErrLexerStatus struct {
+	WaitingString string
+}
+
+func (e *ErrLexerStatus) Error() string {
+	return fmt.Sprintf("lexer error with waiting: %v", e.WaitingString)
+}
+
+func SeparateInputPreserveCommentsWithStatus(filepath, s string) ([]RawStatement, error) {
+	lex := newLexer(filepath, s)
+
+	var results []RawStatement
+	// var b strings.Builder
+	var pos token.Pos
+outer:
+	for {
+		err := lex.NextToken()
+
+		if err != nil {
+			if e, ok := lo.ErrorsAs[*memefish.Error](err); ok {
+				results = append(results, RawStatement{
+					Pos:        pos,
+					End:        e.Position.End,
+					Statement:  lex.Buffer[pos:e.Position.End],
+					Terminator: "",
+				})
+
+				switch e.Message {
+				case `unclosed triple-quoted string literal`:
+					if strings.HasPrefix(lex.Buffer[lex.Token.Pos:], `"""`) {
+						return results, &ErrLexerStatus{
+							WaitingString: `"""`,
+						}
+					}
+					return results, &ErrLexerStatus{
+						WaitingString: `'''`,
+					}
+				case `unclosed comment`:
+					return results, &ErrLexerStatus{
+						WaitingString: `*/`,
+					}
+				default:
+					return results, err
+				}
+			}
+			return results, err
+		}
+
+		if pos.Invalid() {
+			if len(lex.Token.Comments) > 0 {
+				pos = lex.Token.Comments[0].Pos
+			} else {
+				pos = lex.Token.Pos
+			}
+		}
+
+		switch lex.Token.Kind {
+		case token.TokenEOF:
+			if pos != lex.Token.Pos {
+				results = append(results, RawStatement{Statement: s[pos:lex.Token.Pos], Pos: pos, End: lex.Token.Pos, Terminator: ""})
+			}
+
+			// no need to continue
+			break outer
+		case ";":
+			results = append(results, RawStatement{Statement: s[pos:lex.Token.Pos], Pos: pos, End: lex.Token.End, Terminator: ";"})
+
+			// b.Reset()
+			pos = token.InvalidPos
+
+			continue
+		default:
+		}
+	}
+	return results, nil
+}
+
+// StripComments strips comments in an input string without parsing.
+// This function won't panic but return error if lexer become error state.
+// filepath can be empty, it is only used in error message.
+//
+// [terminating semicolons]: https://cloud.google.com/spanner/docs/reference/standard-sql/lexical#terminating_semicolons
+func StripComments(filepath, s string) (string, error) {
+	lex := newLexer(filepath, s)
+
+	var b strings.Builder
+	var firstPos token.Pos
+	for {
+		_ = firstPos
+		if len(lex.Token.Comments) > 0 {
+			// flush
+			b.WriteString(s[firstPos:lex.Token.Comments[0].Pos])
+			if lex.Token.Kind == token.TokenEOF {
+				// no need to continue
+				break
+			}
+			var commentStrBuilder strings.Builder
+			var hasNewline bool
+			for _, comment := range lex.Token.Comments {
+				commentStrBuilder.WriteString(comment.Space)
+				if strings.ContainsAny(comment.Raw, "\n") {
+					hasNewline = true
+				}
+			}
+			commentStr := strings.TrimSpace(commentStrBuilder.String())
+			if commentStr != "" {
+				b.WriteString(commentStr)
+			} else {
+				if hasNewline {
+					b.WriteString("\n")
+				} else {
+					b.WriteString(" ")
+				}
+			}
+			b.WriteString(lex.Token.Raw)
+			firstPos = lex.Token.End
+		}
+
+		if lex.Token.Kind == token.TokenEOF {
+			b.WriteString(s[firstPos:lex.Token.Pos])
+			break
+		}
+
+		err := lex.NextToken()
+		if err != nil {
+			return "", err
+		}
+	}
+	return b.String(), nil
+}
+
+func newLexer(filepath string, s string) *memefish.Lexer {
+	lex := &memefish.Lexer{
+		File: &token.File{
+			FilePath: filepath,
+			Buffer:   s,
+		},
+	}
+	return lex
+}

--- a/memefish_test.go
+++ b/memefish_test.go
@@ -59,10 +59,8 @@ func TestSeparateInputPreserveCommentsWithStatus(t *testing.T) {
 			input: `SELECT "123`,
 			want: []RawStatement{
 				{
-					// Statement:  `SELECT "123`,
-					// TODO: Currently, position is not correct. it will be fixed.
-					Statement:  `SELECT `,
-					End:        7,
+					Statement:  `SELECT "123`,
+					End:        11,
 					Terminator: terminatorUndefined,
 				},
 			},
@@ -73,10 +71,8 @@ func TestSeparateInputPreserveCommentsWithStatus(t *testing.T) {
 			input: `SELECT '123`,
 			want: []RawStatement{
 				{
-					// TODO: Fix when Lexer is fixed
-					// Statement:  `SELECT '123`,
-					Statement:  `SELECT `,
-					End:        7,
+					Statement:  `SELECT '123`,
+					End:        11,
 					Terminator: terminatorUndefined,
 				},
 			},
@@ -98,10 +94,8 @@ func TestSeparateInputPreserveCommentsWithStatus(t *testing.T) {
 			input: "SELECT `123",
 			want: []RawStatement{
 				{
-					// TODO: Fix when Lexer is fixed
-					// Statement:  "SELECT `123",
-					Statement:  "SELECT ",
-					End:        7,
+					Statement:  "SELECT `123",
+					End:        11,
 					Terminator: terminatorUndefined,
 				},
 			},
@@ -146,10 +140,8 @@ func TestSeparateInputPreserveCommentsWithStatus(t *testing.T) {
 			input: `SELECT """123`,
 			want: []RawStatement{
 				{
-					// TODO: Fix when Lexer is fixed
-					// Statement:  `SELECT """123`,
-					Statement:  `SELECT `,
-					End:        7,
+					Statement:  `SELECT """123`,
+					End:        13,
 					Terminator: terminatorUndefined,
 				},
 			},
@@ -171,10 +163,8 @@ func TestSeparateInputPreserveCommentsWithStatus(t *testing.T) {
 			input: `SELECT '''123`,
 			want: []RawStatement{
 				{
-					// TODO: Fix after memefish.Lexer is fixed.
-					// Statement:  `SELECT '''123`,
-					Statement:  `SELECT `,
-					End:        7,
+					Statement:  `SELECT '''123`,
+					End:        13,
 					Terminator: terminatorUndefined,
 				},
 			},

--- a/memefish_test.go
+++ b/memefish_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestStripComments(t *testing.T) {
+	for _, test := range []struct {
+		desc  string
+		input string
+		want  string
+	}{
+		{desc: "no comment", input: "SELECT 1", want: "SELECT 1"},
+		{desc: "line comment before EOF", input: "SELECT 1 // comment", want: "SELECT 1 "},
+		{desc: "line comment", input: "SELECT 1// comment \n+ 2", want: "SELECT 1\n+ 2"},
+		{desc: "inline multiline comment", input: `SELECT 1/**/+ 2`, want: "SELECT 1 + 2"},
+		{desc: "multiline comment", input: "SELECT 1/*\n*/+ 2", want: "SELECT 1\n+ 2"},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := StripComments("", test.input)
+			if err != nil {
+				t.Errorf("StripComments() error = %v", err)
+				return
+			}
+			if got != test.want {
+				t.Errorf("StripComments() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSeparateInputPreserveCommentsWithStatus(t *testing.T) {
+	const (
+		terminatorHorizontal = `;`
+		terminatorVertical   = `\G`
+		terminatorUndefined  = ``
+	)
+	for _, tt := range []struct {
+		desc       string
+		input      string
+		want       []RawStatement
+		wantErr    error
+		wantAnyErr bool
+	}{
+		{
+			desc:  "closed double quoted",
+			input: `SELECT "123"`,
+			want: []RawStatement{
+				{
+					Statement:  `SELECT "123"`,
+					End:        12,
+					Terminator: terminatorUndefined,
+				},
+			},
+		},
+		{
+			desc:  "non-closed double quoted",
+			input: `SELECT "123`,
+			want: []RawStatement{
+				{
+					// Statement:  `SELECT "123`,
+					// TODO: Currently, position is not correct. it will be fixed.
+					Statement:  `SELECT `,
+					End:        7,
+					Terminator: terminatorUndefined,
+				},
+			},
+			wantAnyErr: true,
+		},
+		{
+			desc:  "non-closed single quoted",
+			input: `SELECT '123`,
+			want: []RawStatement{
+				{
+					// TODO: Fix when Lexer is fixed
+					// Statement:  `SELECT '123`,
+					Statement:  `SELECT `,
+					End:        7,
+					Terminator: terminatorUndefined,
+				},
+			},
+			wantAnyErr: true,
+		},
+		{
+			desc:  "closed single quoted",
+			input: `SELECT '123'`,
+			want: []RawStatement{
+				{
+					Statement:  `SELECT '123'`,
+					End:        12,
+					Terminator: terminatorUndefined,
+				},
+			},
+		},
+		{
+			desc:  "non-closed back quoted",
+			input: "SELECT `123",
+			want: []RawStatement{
+				{
+					// TODO: Fix when Lexer is fixed
+					// Statement:  "SELECT `123",
+					Statement:  "SELECT ",
+					End:        7,
+					Terminator: terminatorUndefined,
+				},
+			},
+			wantAnyErr: true,
+		},
+		{
+			desc:  "closed back quoted",
+			input: "SELECT `123`",
+			want: []RawStatement{
+				{
+					Statement:  "SELECT `123`",
+					End:        12,
+					Terminator: terminatorUndefined,
+				},
+			},
+		},
+		{
+			desc:  "closed comment",
+			input: "SELECT /*123*/",
+			want: []RawStatement{
+				{
+					Statement:  "SELECT /*123*/",
+					End:        14,
+					Terminator: terminatorUndefined,
+				},
+			},
+		},
+		{
+			desc:  "closed comment",
+			input: "SELECT /*123",
+			want: []RawStatement{
+				{
+					Statement:  "SELECT /*123",
+					End:        12,
+					Terminator: terminatorUndefined,
+				},
+			},
+			wantErr: &ErrLexerStatus{"*/"},
+		},
+		{
+			desc:  "non-closed triple double quoted",
+			input: `SELECT """123`,
+			want: []RawStatement{
+				{
+					// TODO: Fix when Lexer is fixed
+					// Statement:  `SELECT """123`,
+					Statement:  `SELECT `,
+					End:        7,
+					Terminator: terminatorUndefined,
+				},
+			},
+			wantErr: &ErrLexerStatus{`"""`},
+		},
+		{
+			desc:  "closed triple double quoted",
+			input: `SELECT """123"""`,
+			want: []RawStatement{
+				{
+					Statement:  `SELECT """123"""`,
+					End:        16,
+					Terminator: terminatorUndefined,
+				},
+			},
+		},
+		{
+			desc:  "non-closed triple single quoted",
+			input: `SELECT '''123`,
+			want: []RawStatement{
+				{
+					// TODO: Fix after memefish.Lexer is fixed.
+					// Statement:  `SELECT '''123`,
+					Statement:  `SELECT `,
+					End:        7,
+					Terminator: terminatorUndefined,
+				},
+			},
+			wantErr: &ErrLexerStatus{`'''`},
+		},
+		{
+			desc:  "closed triple single quoted",
+			input: `SELECT '''123'''`,
+			want: []RawStatement{
+				{
+					Statement:  `SELECT '''123'''`,
+					Pos:        0,
+					End:        16,
+					Terminator: terminatorUndefined,
+				},
+			},
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := SeparateInputPreserveCommentsWithStatus("", tt.input)
+			if (!tt.wantAnyErr && tt.wantErr == nil) && err != nil {
+				t.Errorf("should success, but failed: %v", err)
+			}
+			if tt.wantAnyErr && err == nil {
+				t.Error("should fail with any error, but success")
+			}
+			if diff := cmp.Diff(tt.wantErr, err); tt.wantErr != nil && diff != "" {
+				t.Errorf("difference in err: (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(RawStatement{})); diff != "" {
+				t.Errorf("difference in statements: (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/separator.go
+++ b/separator.go
@@ -16,6 +16,8 @@
 
 package main
 
+import "log"
+
 const (
 	delimiterUndefined  = ""
 	delimiterHorizontal = ";"
@@ -34,16 +36,16 @@ func separateInput(input string) ([]inputStatement, error) {
 	var result []inputStatement
 	for _, stmt := range stmts {
 		stripped, err := stmt.StripComments()
+		var stmtWithoutComments string
 		if err != nil {
-			result = append(result, inputStatement{
-				statement:                stmt.Statement,
-				statementWithoutComments: stmt.Statement,
-				delim:                    stmt.Terminator,
-			})
+			log.Printf("separateInput error ignored: %v", err)
+			stmtWithoutComments = stmt.Statement
+		} else {
+			stmtWithoutComments = stripped.Statement
 		}
 		result = append(result, inputStatement{
 			statement:                stmt.Statement,
-			statementWithoutComments: stripped.Statement,
+			statementWithoutComments: stmtWithoutComments,
 			delim:                    stmt.Terminator,
 		})
 	}

--- a/separator.go
+++ b/separator.go
@@ -16,8 +16,6 @@
 
 package main
 
-import "github.com/apstndb/gsqlsep"
-
 const (
 	delimiterUndefined  = ""
 	delimiterHorizontal = ";"
@@ -30,14 +28,24 @@ type inputStatement struct {
 	delim                    string
 }
 
-func separateInput(input string) []inputStatement {
+func separateInput(input string) ([]inputStatement, error) {
+	stmts, err := SeparateInputPreserveCommentsWithStatus("", input)
+
 	var result []inputStatement
-	for _, stmt := range gsqlsep.SeparateInputPreserveComments(input, delimiterVertical) {
+	for _, stmt := range stmts {
+		stripped, err := stmt.StripComments()
+		if err != nil {
+			result = append(result, inputStatement{
+				statement:                stmt.Statement,
+				statementWithoutComments: stmt.Statement,
+				delim:                    stmt.Terminator,
+			})
+		}
 		result = append(result, inputStatement{
 			statement:                stmt.Statement,
-			statementWithoutComments: stmt.StripComments().Statement,
+			statementWithoutComments: stripped.Statement,
 			delim:                    stmt.Terminator,
 		})
 	}
-	return result
+	return result, err
 }

--- a/separator_test.go
+++ b/separator_test.go
@@ -304,7 +304,10 @@ func TestSeparateInput(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := separateInput(tt.input)
+			got, err := separateInput(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
 			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(inputStatement{})); diff != "" {
 				t.Errorf("difference in statements: (-want +got):\n%s", diff)
 			}

--- a/separator_test.go
+++ b/separator_test.go
@@ -217,11 +217,8 @@ func TestSeparateInput(t *testing.T) {
 					delim:                    delimiterHorizontal,
 				},
 				{
-					// TODO: Fix when Lexer is fixed
-					// statement:                `SELECT "45`,
-					// statementWithoutComments: `SELECT "45`,
-					statement:                `SELECT `,
-					statementWithoutComments: `SELECT `,
+					statement:                `SELECT "45`,
+					statementWithoutComments: `SELECT "45`,
 					delim:                    delimiterUndefined,
 				},
 			},
@@ -232,8 +229,8 @@ func TestSeparateInput(t *testing.T) {
 			input: `a"""""""""'''''''''b`,
 			want: []inputStatement{
 				{
-					statement:                `a""""""`,
-					statementWithoutComments: `a""""""`,
+					statement:                `a"""""""""'''''''''b`,
+					statementWithoutComments: `a"""""""""'''''''''b`,
 					delim:                    delimiterUndefined,
 				},
 			},

--- a/statement.go
+++ b/statement.go
@@ -145,47 +145,48 @@ func BuildStatement(input string) (Statement, error) {
 }
 
 func BuildStatementWithComments(stripped, raw string) (Statement, error) {
+	trimmed := strings.TrimSpace(stripped)
 	switch {
-	case exitRe.MatchString(stripped):
+	case exitRe.MatchString(trimmed):
 		return &ExitStatement{}, nil
-	case useRe.MatchString(stripped):
-		matched := useRe.FindStringSubmatch(stripped)
+	case useRe.MatchString(trimmed):
+		matched := useRe.FindStringSubmatch(trimmed)
 		return &UseStatement{Database: unquoteIdentifier(matched[1]), Role: unquoteIdentifier(matched[2])}, nil
-	case selectRe.MatchString(stripped):
+	case selectRe.MatchString(trimmed):
 		return &SelectStatement{Query: raw}, nil
-	case createDatabaseRe.MatchString(stripped):
-		return &CreateDatabaseStatement{CreateStatement: stripped}, nil
-	case createRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case dropDatabaseRe.MatchString(stripped):
-		matched := dropDatabaseRe.FindStringSubmatch(stripped)
+	case createDatabaseRe.MatchString(trimmed):
+		return &CreateDatabaseStatement{CreateStatement: trimmed}, nil
+	case createRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case dropDatabaseRe.MatchString(trimmed):
+		matched := dropDatabaseRe.FindStringSubmatch(trimmed)
 		return &DropDatabaseStatement{DatabaseId: unquoteIdentifier(matched[1])}, nil
-	case dropRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case alterRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case renameRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case grantRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case revokeRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case truncateTableRe.MatchString(stripped):
-		matched := truncateTableRe.FindStringSubmatch(stripped)
+	case dropRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case alterRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case renameRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case grantRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case revokeRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case truncateTableRe.MatchString(trimmed):
+		matched := truncateTableRe.FindStringSubmatch(trimmed)
 		return &TruncateTableStatement{Table: unquoteIdentifier(matched[1])}, nil
-	case analyzeRe.MatchString(stripped):
-		return &DdlStatement{Ddl: stripped}, nil
-	case showDatabasesRe.MatchString(stripped):
+	case analyzeRe.MatchString(trimmed):
+		return &DdlStatement{Ddl: trimmed}, nil
+	case showDatabasesRe.MatchString(trimmed):
 		return &ShowDatabasesStatement{}, nil
-	case showCreateTableRe.MatchString(stripped):
-		matched := showCreateTableRe.FindStringSubmatch(stripped)
+	case showCreateTableRe.MatchString(trimmed):
+		matched := showCreateTableRe.FindStringSubmatch(trimmed)
 		schema, table := extractSchemaAndTable(unquoteIdentifier(matched[1]))
 		return &ShowCreateTableStatement{Schema: schema, Table: table}, nil
-	case showTablesRe.MatchString(stripped):
-		matched := showTablesRe.FindStringSubmatch(stripped)
+	case showTablesRe.MatchString(trimmed):
+		matched := showTablesRe.FindStringSubmatch(trimmed)
 		return &ShowTablesStatement{Schema: unquoteIdentifier(matched[1])}, nil
-	case describeRe.MatchString(stripped):
-		matched := describeRe.FindStringSubmatch(stripped)
+	case describeRe.MatchString(trimmed):
+		matched := describeRe.FindStringSubmatch(trimmed)
 		isDML := dmlRe.MatchString(matched[1])
 		switch {
 		case isDML:
@@ -193,8 +194,8 @@ func BuildStatementWithComments(stripped, raw string) (Statement, error) {
 		default:
 			return &DescribeStatement{Statement: matched[1]}, nil
 		}
-	case explainRe.MatchString(stripped):
-		matched := explainRe.FindStringSubmatch(stripped)
+	case explainRe.MatchString(trimmed):
+		matched := explainRe.FindStringSubmatch(trimmed)
 		isAnalyze := matched[1] != ""
 		isDML := dmlRe.MatchString(matched[2])
 		switch {
@@ -205,36 +206,36 @@ func BuildStatementWithComments(stripped, raw string) (Statement, error) {
 		default:
 			return &ExplainStatement{Explain: matched[2], IsDML: isDML}, nil
 		}
-	case showColumnsRe.MatchString(stripped):
-		matched := showColumnsRe.FindStringSubmatch(stripped)
+	case showColumnsRe.MatchString(trimmed):
+		matched := showColumnsRe.FindStringSubmatch(trimmed)
 		schema, table := extractSchemaAndTable(unquoteIdentifier(matched[1]))
 		return &ShowColumnsStatement{Schema: schema, Table: table}, nil
-	case showIndexRe.MatchString(stripped):
-		matched := showIndexRe.FindStringSubmatch(stripped)
+	case showIndexRe.MatchString(trimmed):
+		matched := showIndexRe.FindStringSubmatch(trimmed)
 		schema, table := extractSchemaAndTable(unquoteIdentifier(matched[1]))
 		return &ShowIndexStatement{Schema: schema, Table: table}, nil
-	case dmlRe.MatchString(stripped):
+	case dmlRe.MatchString(trimmed):
 		return &DmlStatement{Dml: raw}, nil
-	case pdmlRe.MatchString(stripped):
-		matched := pdmlRe.FindStringSubmatch(stripped)
+	case pdmlRe.MatchString(trimmed):
+		matched := pdmlRe.FindStringSubmatch(trimmed)
 		return &PartitionedDmlStatement{Dml: matched[1]}, nil
-	case beginRwRe.MatchString(stripped):
-		return newBeginRwStatement(stripped)
-	case beginRoRe.MatchString(stripped):
-		return newBeginRoStatement(stripped)
-	case commitRe.MatchString(stripped):
+	case beginRwRe.MatchString(trimmed):
+		return newBeginRwStatement(trimmed)
+	case beginRoRe.MatchString(trimmed):
+		return newBeginRoStatement(trimmed)
+	case commitRe.MatchString(trimmed):
 		return &CommitStatement{}, nil
-	case rollbackRe.MatchString(stripped):
+	case rollbackRe.MatchString(trimmed):
 		return &RollbackStatement{}, nil
-	case closeRe.MatchString(stripped):
+	case closeRe.MatchString(trimmed):
 		return &CloseStatement{}, nil
-	case showVariableRe.MatchString(stripped):
-		matched := showVariableRe.FindStringSubmatch(stripped)
+	case showVariableRe.MatchString(trimmed):
+		matched := showVariableRe.FindStringSubmatch(trimmed)
 		return &ShowVariableStatement{VarName: matched[1]}, nil
-	case setRe.MatchString(stripped):
-		matched := setRe.FindStringSubmatch(stripped)
+	case setRe.MatchString(trimmed):
+		matched := setRe.FindStringSubmatch(trimmed)
 		return &SetStatement{VarName: matched[1], Value: matched[2]}, nil
-	case showVariablesRe.MatchString(stripped):
+	case showVariablesRe.MatchString(trimmed):
 		return &ShowVariablesStatement{}, nil
 	}
 

--- a/system_variables.go
+++ b/system_variables.go
@@ -19,7 +19,15 @@ type systemVariables struct {
 	OptimizerStatisticsPackage string
 	CommitResponse             *sppb.CommitResponse
 	CommitTimestamp            time.Time
+	CLIFormat                  DisplayMode
 }
+
+type CLIFormat int
+
+const (
+	CLIFormatTable CLIFormat = iota
+	CLIFormatVertical
+)
 
 var errIgnored = errors.New("ignored")
 
@@ -196,6 +204,31 @@ var accessorMap = map[string]accessor{
 				"COMMIT_TIMESTAMP": this.CommitTimestamp.Format(time.RFC3339Nano),
 				"MUTATION_COUNT":   strconv.FormatInt(mutationCount, 10),
 			}, nil
+		},
+	},
+	"CLI_FORMAT": {
+		func(this *systemVariables, name, value string) error {
+			switch strings.ToUpper(unquoteString(value)) {
+			case "TABLE":
+				this.CLIFormat = DisplayModeTable
+			case "VERTICAL":
+				this.CLIFormat = DisplayModeVertical
+			case "TAB":
+				this.CLIFormat = DisplayModeTab
+			}
+			return nil
+		},
+		func(this *systemVariables, name string) (map[string]string, error) {
+			var formatStr string
+			switch this.CLIFormat {
+			case DisplayModeTable:
+				formatStr = "TABLE"
+			case DisplayModeVertical:
+				formatStr = "VERTICAL"
+			case DisplayModeTab:
+				formatStr = "TAB"
+			}
+			return singletonMap(name, formatStr), nil
 		},
 	},
 }


### PR DESCRIPTION
* Replace gsqlsep with memefish-based implementation.
* Decomission `\G` as terminating token.
* Implement `CLI_OPTIONS` flag.
* Early return when occuring lexer error, except continuing multiline string literal or comments.
```
spanner> SELECT '123
ERROR: syntax error: :1:8: unclosed string literal: newline appears in non triple-quoted

  1:  SELECT '123
             ^
```

```
spanner> SET CLI_FORMAT = "VERTICAL";
Empty set (0.00 sec)

spanner> SELECT 1 AS n, "foo" AS s;
*************************** 1. row ***************************
n: 1
s: foo
1 rows in set (0.32 msecs)

spanner> SET CLI_FORMAT = "TAB";
Empty set (0.00 sec)

spanner> SELECT 1 AS n, "foo" AS s;
n       s
1       foo
1 rows in set (2.42 msecs)

spanner> SET CLI_FORMAT = "TABLE";
Empty set (0.00 sec)

spanner> SELECT 1 AS n, "foo" AS s;
+---+-----+
| n | s   |
+---+-----+
| 1 | foo |
+---+-----+
1 rows in set (2.2 msecs)
```