### PR TITLE
Use memefish as the statement detector

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -161,7 +161,7 @@ func (c *Cli) RunInteractive() int {
 			continue
 		}
 
-		stmt, err := BuildStatementWithComments(input.statementWithoutComments, input.statement)
+		stmt, err := BuildStatementWithCommentsWithMode(input.statementWithoutComments, input.statement, c.SystemVariables.BuildStatementMode)
 		if err != nil {
 			c.PrintInteractiveError(err)
 			continue
@@ -274,7 +274,7 @@ func (c *Cli) updateSystemVariables(result *Result) {
 }
 
 func (c *Cli) RunBatch(input string) int {
-	cmds, err := buildCommands(input)
+	cmds, err := buildCommands(input, c.SystemVariables.BuildStatementMode)
 	if err != nil {
 		c.PrintBatchError(err)
 		return exitCodeError
@@ -546,7 +546,7 @@ func resultLine(result *Result, verbose bool) string {
 	return fmt.Sprintf("%s (%s)\n", set, result.Stats.ElapsedTime)
 }
 
-func buildCommands(input string) ([]*command, error) {
+func buildCommands(input string, mode parseMode) ([]*command, error) {
 	var cmds []*command
 	var pendingDdls []string
 
@@ -560,7 +560,7 @@ func buildCommands(input string) ([]*command, error) {
 			continue
 		}
 
-		stmt, err := BuildStatementWithComments(strings.TrimSpace(separated.statementWithoutComments), separated.statement)
+		stmt, err := BuildStatementWithCommentsWithMode(strings.TrimSpace(separated.statementWithoutComments), separated.statement, mode)
 		if err != nil {
 			return nil, fmt.Errorf("failed with statement, error: %w, statement: %q, without comments: %q", err, separated.statement, separated.statementWithoutComments)
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -107,7 +107,7 @@ func TestBuildCommands(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			got, err := buildCommands(test.Input)
+			got, err := buildCommands(test.Input, parseModeFallback)
 			if test.ExpectError && err == nil {
 				t.Errorf("expect error but not error, input: %v", test.Input)
 			}

--- a/cli_test.go
+++ b/cli_test.go
@@ -29,23 +29,27 @@ import (
 
 func TestBuildCommands(t *testing.T) {
 	tests := []struct {
+		Desc        string
 		Input       string
 		Expected    []*command
 		ExpectError bool
 	}{
-		{Input: `SELECT * FROM t1;`, Expected: []*command{{&SelectStatement{"SELECT * FROM t1"}}}},
-		{Input: `CREATE TABLE t1;`, Expected: []*command{{&BulkDdlStatement{[]string{"CREATE TABLE t1"}}}}},
-		{Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64; CREATE INDEX i1 ON t1(col); DROP INDEX i1; DROP TABLE t1;`,
+		{Desc: "SELECT", Input: `SELECT * FROM t1;`, Expected: []*command{{&SelectStatement{"SELECT * FROM t1"}}}},
+		{Desc: "CREATE TABLE(Invalid)", Input: `CREATE TABLE t1;`, Expected: []*command{{&BulkDdlStatement{[]string{"CREATE TABLE t1"}}}}},
+		{Desc: "DDLs",
+			Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64; CREATE INDEX i1 ON t1(col); DROP INDEX i1; DROP TABLE t1;`,
 			Expected: []*command{{&BulkDdlStatement{[]string{
-				"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)",
+				"CREATE TABLE t1 (pk INT64) PRIMARY KEY (pk)",
 				"ALTER TABLE t1 ADD COLUMN col INT64",
-				"CREATE INDEX i1 ON t1(col)",
+				// TODO: memefish issue, "CREATE INDEX i1 ON t1 (col)" is more standard
+				"CREATE INDEX i1 ON t1 (col)",
 				"DROP INDEX i1",
 				"DROP TABLE t1",
 			}}}},
 		},
-		{Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
-                CREATE TABLE t2(pk INT64) PRIMARY KEY(pk);
+		{Desc: "mixed statements",
+			Input: `CREATE TABLE t1 (pk INT64) PRIMARY KEY(pk);
+                CREATE TABLE t2 (pk INT64) PRIMARY KEY(pk);
                 SELECT * FROM t1;
                 DROP TABLE t1;
                 DROP TABLE t2;
@@ -54,8 +58,8 @@ func TestBuildCommands(t *testing.T) {
 				{
 					&BulkDdlStatement{
 						[]string{
-							"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)",
-							"CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)",
+							"CREATE TABLE t1 (pk INT64) PRIMARY KEY (pk)",
+							"CREATE TABLE t2 (pk INT64) PRIMARY KEY (pk)",
 						},
 					},
 				},
@@ -63,7 +67,7 @@ func TestBuildCommands(t *testing.T) {
 				{&BulkDdlStatement{[]string{"DROP TABLE t1", "DROP TABLE t2"}}},
 				{&SelectStatement{"SELECT 1"}},
 			}},
-		{
+		{Desc: "mixed statements with comments",
 			Input: `
 			CREATE TABLE t1(pk INT64 /* NOT NULL*/, col INT64) PRIMARY KEY(pk);
 			INSERT t1(pk/*, col*/) VALUES(1/*, 2*/);
@@ -73,7 +77,7 @@ func TestBuildCommands(t *testing.T) {
 			Expected: []*command{
 				{
 					&BulkDdlStatement{
-						[]string{"CREATE TABLE t1(pk INT64  , col INT64) PRIMARY KEY(pk)"},
+						[]string{"CREATE TABLE t1 (pk INT64, col INT64) PRIMARY KEY (pk)"},
 					},
 				},
 				{&DmlStatement{"INSERT t1(pk/*, col*/) VALUES(1/*, 2*/)"}},
@@ -82,15 +86,18 @@ func TestBuildCommands(t *testing.T) {
 				{&SelectStatement{"SELECT 0x1/**/A"}},
 			}},
 		{
+			Desc: "empty statement",
 			// spanner-cli don't permit empty statements.
 			Input:       `SELECT 1; /* comment */; SELECT 2`,
 			ExpectError: true,
 		},
 		{
+			Desc:        "empty statements",
 			Input:       `SELECT 1; /* comment 1 */; /* comment 2 */`,
 			ExpectError: true,
 		},
 		{
+			Desc: "comment after semicolon",
 			// A comment after the last semicolon is permitted.
 			Input: `SELECT 1; /* comment */`,
 			Expected: []*command{
@@ -99,17 +106,19 @@ func TestBuildCommands(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got, err := buildCommands(test.Input)
-		if test.ExpectError && err == nil {
-			t.Errorf("expect error but not error, input: %v", test.Input)
-		}
-		if !test.ExpectError && err != nil {
-			t.Errorf("err: %v, input: %v", err, test.Input)
-		}
+		t.Run(test.Desc, func(t *testing.T) {
+			got, err := buildCommands(test.Input)
+			if test.ExpectError && err == nil {
+				t.Errorf("expect error but not error, input: %v", test.Input)
+			}
+			if !test.ExpectError && err != nil {
+				t.Errorf("err: %v, input: %v", err, test.Input)
+			}
 
-		if !cmp.Equal(got, test.Expected) {
-			t.Errorf("invalid result: %v", cmp.Diff(test.Expected, got))
-		}
+			if !cmp.Equal(got, test.Expected) {
+				t.Errorf("invalid result: %v", cmp.Diff(test.Expected, got))
+			}
+		})
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.1
 require (
 	cloud.google.com/go v0.113.0
 	cloud.google.com/go/spanner v1.62.0
-	github.com/cloudspannerecosystem/memefish v0.0.0-20241029131948-98b8bf288447
+	github.com/cloudspannerecosystem/memefish v0.0.0-20241031032728-970586f04071
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -665,8 +665,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241029131948-98b8bf288447 h1:t3OhQwTZ9zbnjjURAJ4OYL6z01rSJKmlYF+SrQ/+S4o=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241029131948-98b8bf288447/go.mod h1:iYAaNZfVIn4QYfUmXt+3EeHAok/kqpN/fp/8kgDHjx8=
+github.com/cloudspannerecosystem/memefish v0.0.0-20241031032728-970586f04071 h1:BHIA83AA8ct5TgPaLp+Ric2Q0s+2EwdasT3i/dMvXjw=
+github.com/cloudspannerecosystem/memefish v0.0.0-20241031032728-970586f04071/go.mod h1:iYAaNZfVIn4QYfUmXt+3EeHAok/kqpN/fp/8kgDHjx8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/integration_test.go
+++ b/integration_test.go
@@ -94,7 +94,9 @@ func initialize(tb testing.TB) (container *gcloud.GCloudContainer, teardown func
 	}
 
 	return spannerContainer, func() {
-		tb.Log(spannerContainer.Terminate(ctx))
+		if err := spannerContainer.Terminate(ctx); err != nil {
+			tb.Log(err)
+		}
 	}
 }
 

--- a/statement.go
+++ b/statement.go
@@ -278,15 +278,16 @@ func BuildNativeStatementMemefish(raw string) (Statement, error) {
 	}
 
 	switch stmt.(type) {
-	// Only CREATE DATABASE needs special treatment
-	case *ast.CreateDatabase:
-		return &CreateDatabaseStatement{CreateStatement: stmt.SQL()}, nil
-	case ast.DDL:
-		return &DdlStatement{Ddl: stmt.SQL()}, nil
 	case *ast.QueryStatement:
 		return &SelectStatement{Query: raw}, nil
 	case ast.DML:
 		return &DmlStatement{Dml: raw}, nil
+	// Currently, UpdateDdl doesn't permit comments, so we need to unparse DDLs.
+	// Only CREATE DATABASE needs special treatment in DDL.
+	case *ast.CreateDatabase:
+		return &CreateDatabaseStatement{CreateStatement: stmt.SQL()}, nil
+	case ast.DDL:
+		return &DdlStatement{Ddl: stmt.SQL()}, nil
 	default:
 		return nil, fmt.Errorf("unknown memefish statement, stmt %T, err: %w", stmt, errStatementNotMatched)
 	}

--- a/statement_test.go
+++ b/statement_test.go
@@ -84,7 +84,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "ALTER DATABASE statement",
 			input: "ALTER DATABASE d1 SET OPTIONS ( version_retention_period = '7d' )",
-			want:  &DdlStatement{Ddl: "ALTER DATABASE d1 SET OPTIONS ( version_retention_period = '7d' )"},
+			want:  &DdlStatement{Ddl: `ALTER DATABASE d1 SET OPTIONS (version_retention_period = "7d")`},
 		},
 		{
 			desc:  "CREATE TABLE statement",
@@ -154,7 +154,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "ALTER CHANGE STREAM SET OPTIONS statement",
 			input: "ALTER CHANGE STREAM NamesAndAlbums SET OPTIONS( retention_period = '36h' )",
-			want:  &DdlStatement{Ddl: "ALTER CHANGE STREAM NamesAndAlbums SET OPTIONS( retention_period = '36h' )"},
+			want:  &DdlStatement{Ddl: `ALTER CHANGE STREAM NamesAndAlbums SET OPTIONS (retention_period = "36h")`},
 		},
 		{
 			desc:  "ALTER CHANGE STREAM DROP FOR ALL statement",
@@ -583,8 +583,8 @@ func TestBuildStatement(t *testing.T) {
 			if err != nil {
 				t.Fatalf("BuildStatement(%q) got error: %v", test.input, err)
 			}
-			if !cmp.Equal(got, test.want) {
-				t.Errorf("BuildStatement(%q) = %v, but want = %v", test.input, got, test.want)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("BuildStatement(%q) differ: %v", test.input, diff)
 			}
 		})
 

--- a/system_variables.go
+++ b/system_variables.go
@@ -36,6 +36,7 @@ type systemVariables struct {
 	Endpoint                    string
 	DirectedRead                *sppb.DirectedReadOptions
 	ProtoDescriptorFile         string
+	BuildStatementMode          parseMode
 
 	// it is internal variable and hidden from system variable statements
 	ProtoDescriptor *descriptorpb.FileDescriptorProto
@@ -308,6 +309,28 @@ var accessorMap = map[string]accessor{
 			this.ProtoDescriptorFile = filename
 			this.ProtoDescriptor = fds
 			return nil
+		},
+	},
+	"CLI_PARSE_MODE": {
+		Getter: func(this *systemVariables, name string) (map[string]string, error) {
+			if this.BuildStatementMode == parseModeUnspecified {
+				return nil, errIgnored
+			}
+			return singletonMap(name, string(this.BuildStatementMode)), nil
+		},
+		Setter: func(this *systemVariables, name, value string) error {
+			s := strings.ToUpper(unquoteString(value))
+			switch s {
+			case string(parseModeFallback),
+				string(parseMemefishOnly),
+				string(parseModeNoMemefish),
+				string(parseModeUnspecified):
+
+				this.BuildStatementMode = parseMode(s)
+				return nil
+			default:
+				return fmt.Errorf("invalid value: %v", s)
+			}
 		},
 	},
 }


### PR DESCRIPTION
This PR modify `BuildStatement*` logic to use memefish for statement type detection and unparse.

* Add `CLI_PARSE_MODE` system variable to control behaviors.