### PR TITLE
Use mattn/go-runewidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,47 +231,47 @@ and `{}` for a mutually exclusive keyword.
 * The syntax is case-insensitive.
 * `\G` delimiter is also supported for displaying results vertically.
 
-| Usage | Syntax | Note |
-| --- | --- | --- |
-| List databases | `SHOW DATABASES;` | |
-| Switch database | `USE <database> [ROLE <role>];` | The role you set is used for accessing with [fine-grained access control](https://cloud.google.com/spanner/docs/fgac-about). |
-| Create database | `CREATE DATABSE <database>;` | |
-| Drop database | `DROP DATABASE <database>;` | |
-| List tables | `SHOW TABLES [<schema>];` | If schema is not provided, default schema is used |
-| Show table schema | `SHOW CREATE TABLE <table>;` | The table can be a FQN.|
-| Show columns | `SHOW COLUMNS FROM <table>;` | The table can be a FQN.|
-| Show indexes | `SHOW INDEX FROM <table>;` | The table can be a FQN.|
-| Create table | `CREATE TABLE ...;` | |
-| Change table schema | `ALTER TABLE ...;` | |
-| Delete table | `DROP TABLE ...;` | |
-| Truncate table | `TRUNCATE TABLE <table>;` | Only rows are deleted. Note: Non-atomically because executed as a [partitioned DML statement](https://cloud.google.com/spanner/docs/dml-partitioned?hl=en). |
-| Create index | `CREATE INDEX ...;` | |
-| Delete index | `DROP INDEX ...;` | |
-| Create role | `CREATE ROLE ...;` | |
-| Drop role | `DROP ROLE ...;` | |
-| Grant | `GRANT ...;` | |
-| Revoke | `REVOKE ...;` | |
-| Query | `SELECT ...;` | |
-| DML | `{INSERT\|UPDATE\|DELETE} ...;` | |
-| Partitioned DML | `PARTITIONED {UPDATE\|DELETE} ...;` | |
-| Show local proto descriptors | `SHOW LOCAL PROTO;` | |
-| Show remote proto bundle | `SHOW PROTO;` | |
-| Show Query Execution Plan | `EXPLAIN SELECT ...;` | |
-| Show DML Execution Plan | `EXPLAIN {INSERT\|UPDATE\|DELETE} ...;` | |
-| Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | |
-| Show DML Execution Plan with Stats | `EXPLAIN ANALYZE {INSERT\|UPDATE\|DELETE} ...;` | |
-| Show Query Result Shape | `DESCRIBE SELECT ...;` | |
-| Show DML Result Shape | `DESCRIBE {INSERT\|UPDATE\|DELETE} ... THEN RETURN ...;` | |
-| Start a new query optimizer statistics package construction | `ANALYZE;` | |
-| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | See [Request Priority](#request-priority) for details on the priority. The tag you set is used as both transaction tag and request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
-| Commit Read-Write Transaction | `COMMIT;` | |
-| Rollback Read-Write Transaction | `ROLLBACK;` | |
+| Usage | Syntax                                                                                         | Note |
+| --- |------------------------------------------------------------------------------------------------| --- |
+| List databases | `SHOW DATABASES;`                                                                              | |
+| Switch database | `USE <database> [ROLE <role>];`                                                                | The role you set is used for accessing with [fine-grained access control](https://cloud.google.com/spanner/docs/fgac-about). |
+| Create database | `CREATE DATABSE <database>;`                                                                   | |
+| Drop database | `DROP DATABASE <database>;`                                                                    | |
+| List tables | `SHOW TABLES [<schema>];`                                                                      | If schema is not provided, default schema is used |
+| Show table schema | `SHOW CREATE TABLE <table>;`                                                                   | The table can be a FQN.|
+| Show columns | `SHOW COLUMNS FROM <table>;`                                                                   | The table can be a FQN.|
+| Show indexes | `SHOW INDEX FROM <table>;`                                                                     | The table can be a FQN.|
+| Create table | `CREATE TABLE ...;`                                                                            | |
+| Change table schema | `ALTER TABLE ...;`                                                                             | |
+| Delete table | `DROP TABLE ...;`                                                                              | |
+| Truncate table | `TRUNCATE TABLE <table>;`                                                                      | Only rows are deleted. Note: Non-atomically because executed as a [partitioned DML statement](https://cloud.google.com/spanner/docs/dml-partitioned?hl=en). |
+| Create index | `CREATE INDEX ...;`                                                                            | |
+| Delete index | `DROP INDEX ...;`                                                                              | |
+| Create role | `CREATE ROLE ...;`                                                                             | |
+| Drop role | `DROP ROLE ...;`                                                                               | |
+| Grant | `GRANT ...;`                                                                                   | |
+| Revoke | `REVOKE ...;`                                                                                  | |
+| Query | `SELECT ...;`                                                                                  | |
+| DML | `{INSERT\|UPDATE\|DELETE} ...;`                                                                | |
+| Partitioned DML | `PARTITIONED {UPDATE\|DELETE} ...;`                                                            | |
+| Show local proto descriptors | `SHOW LOCAL PROTO;`                                                                            | |
+| Show remote proto bundle | `SHOW REMOTE PROTO;`                                                                           | |
+| Show Query Execution Plan | `EXPLAIN SELECT ...;`                                                                          | |
+| Show DML Execution Plan | `EXPLAIN {INSERT\|UPDATE\|DELETE} ...;`                                                        | |
+| Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;`                                                                  | |
+| Show DML Execution Plan with Stats | `EXPLAIN ANALYZE {INSERT\|UPDATE\|DELETE} ...;`                                                | |
+| Show Query Result Shape | `DESCRIBE SELECT ...;`                                                                         | |
+| Show DML Result Shape | `DESCRIBE {INSERT\|UPDATE\|DELETE} ... THEN RETURN ...;`                                       | |
+| Start a new query optimizer statistics package construction | `ANALYZE;`                                                                                     | |
+| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];`                                       | See [Request Priority](#request-priority) for details on the priority. The tag you set is used as both transaction tag and request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
+| Commit Read-Write Transaction | `COMMIT;`                                                                                      | |
+| Rollback Read-Write Transaction | `ROLLBACK;`                                                                                    | |
 | Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. The tag you set is used as request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
-| End Read-Only Transaction | `CLOSE;` | |
-| Exit CLI | `EXIT;` | |
-| Show variable | `SHOW VARIABLE <name>;` | |
-| Set variable | `SET <name> = <value>;` | |
-| Show variables | `SHOW VARIABLES;` | |
+| End Read-Only Transaction | `CLOSE;`                                                                                       | |
+| Exit CLI | `EXIT;`                                                                                        | |
+| Show variable | `SHOW VARIABLE <name>;`                                                                        | |
+| Set variable | `SET <name> = <value>;`                                                                        | |
+| Show variables | `SHOW VARIABLES;`                                                                              | |
 
 ## System Variables
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -127,29 +127,100 @@ func TestBuildCommands(t *testing.T) {
 
 func TestPrintResult(t *testing.T) {
 	t.Run("DisplayModeTable", func(t *testing.T) {
-		out := &bytes.Buffer{}
-		result := &Result{
-			ColumnNames: []string{"foo", "bar"},
-			Rows: []Row{
-				Row{[]string{"1", "2"}},
-				Row{[]string{"3", "4"}},
-			},
-			IsMutation: false,
-		}
-		printResult(false, math.MaxInt, out, result, DisplayModeTable, false, false)
-
-		expected := strings.TrimPrefix(`
+		tests := []struct {
+			desc        string
+			displayMode DisplayMode
+			result      *Result
+			screenWidth int
+			verbose     bool
+			want        string
+		}{
+			{
+				desc:        "DisplayModeTable: simple table",
+				displayMode: DisplayModeTable,
+				result: &Result{
+					ColumnNames: []string{"foo", "bar"},
+					Rows: []Row{
+						{[]string{"1", "2"}},
+						{[]string{"3", "4"}},
+					},
+					IsMutation: false,
+				},
+				want: strings.TrimPrefix(`
 +-----+-----+
 | foo | bar |
 +-----+-----+
 | 1   | 2   |
 | 3   | 4   |
 +-----+-----+
-`, "\n")
+`, "\n"),
+			},
+			{
+				desc:        "DisplayModeTable: most preceding column name",
+				displayMode: DisplayModeTable,
+				screenWidth: 20,
+				verbose:     true,
+				result: &Result{
+					ColumnTypes: []*sppb.StructType_Field{
+						{Name: "NAME", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+						{Name: "LONG_NAME", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+					},
+					Rows: []Row{
+						{[]string{"1", "2"}},
+						{[]string{"3", "4"}},
+					},
+					IsMutation: false,
+				},
+				want: strings.TrimPrefix(`
++------+-----------+
+| NAME | LONG_NAME |
+| STRI | STRING    |
+| NG   |           |
++------+-----------+
+| 1    | 2         |
+| 3    | 4         |
++------+-----------+
+Empty set ()
+`, "\n"),
+			},
+			{
+				desc:        "DisplayModeTable: also respect column type",
+				displayMode: DisplayModeTable,
+				screenWidth: 19,
+				verbose:     true,
+				result: &Result{
+					ColumnTypes: []*sppb.StructType_Field{
+						{Name: "NAME", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+						{Name: "LONG_NAME", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+					},
+					Rows: []Row{
+						{[]string{"1", "2"}},
+						{[]string{"3", "4"}},
+					},
+					IsMutation: false,
+				},
+				want: strings.TrimPrefix(`
++--------+--------+
+| NAME   | LONG_N |
+| STRING | AME    |
+|        | STRING |
++--------+--------+
+| 1      | 2      |
+| 3      | 4      |
++--------+--------+
+Empty set ()
+`, "\n"),
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.desc, func(t *testing.T) {
+				out := &bytes.Buffer{}
+				printResult(false, test.screenWidth, out, test.result, test.displayMode, false, test.verbose)
 
-		got := out.String()
-		if got != expected {
-			t.Errorf("invalid print: expected = %s, but got = %s", expected, got)
+				if diff := cmp.Diff(test.want, out.String()); diff != "" {
+					t.Errorf("result differ: %v", diff)
+				}
+			})
 		}
 	})
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -211,6 +211,34 @@ Empty set ()
 Empty set ()
 `, "\n"),
 			},
+			{
+				desc:        "DisplayModeTable: also respect column value",
+				displayMode: DisplayModeTable,
+				screenWidth: 25,
+				verbose:     true,
+				result: &Result{
+					ColumnTypes: []*sppb.StructType_Field{
+						{Name: "English", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+						{Name: "Japanese", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
+					},
+					Rows: []Row{
+						{[]string{"Hello World", "こんにちは"}},
+						{[]string{"Bye", "さようなら"}},
+					},
+					IsMutation: false,
+				},
+				want: strings.TrimPrefix(`
++---------+------------+
+| English | Japanese   |
+| STRING  | STRING     |
++---------+------------+
+| Hello W | こんにちは |
+| orld    |            |
+| Bye     | さようなら |
++---------+------------+
+Empty set ()
+`, "\n"),
+			},
 		}
 		for _, test := range tests {
 			t.Run(test.desc, func(t *testing.T) {

--- a/cli_test.go
+++ b/cli_test.go
@@ -228,14 +228,14 @@ Empty set ()
 					IsMutation: false,
 				},
 				want: strings.TrimPrefix(`
-+---------+------------+
-| English | Japanese   |
-| STRING  | STRING     |
-+---------+------------+
-| Hello W | こんにちは |
-| orld    |            |
-| Bye     | さようなら |
-+---------+------------+
++----------+------------+
+| English  | Japanese   |
+| STRING   | STRING     |
++----------+------------+
+| Hello Wo | こんにちは |
+| rld      |            |
+| Bye      | さようなら |
++----------+------------+
 Empty set ()
 `, "\n"),
 			},
@@ -245,7 +245,8 @@ Empty set ()
 				out := &bytes.Buffer{}
 				printResult(false, test.screenWidth, out, test.result, test.displayMode, false, test.verbose)
 
-				if diff := cmp.Diff(test.want, out.String()); diff != "" {
+				got := out.String()
+				if diff := cmp.Diff(test.want, got); diff != "" {
 					t.Errorf("result differ: %v", diff)
 				}
 			})

--- a/emulator.go
+++ b/emulator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
+
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
@@ -17,8 +19,16 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/gcloud"
 )
 
+type noopLogger struct{}
+
+// Printf implements testcontainers.Logging.
+func (n noopLogger) Printf(string, ...interface{}) {
+}
+
 func newEmulator(ctx context.Context, opts spannerOptions) (container *gcloud.GCloudContainer, teardown func(), err error) {
-	container, err = gcloud.RunSpanner(ctx, lo.CoalesceOrEmpty(opts.EmulatorImage, defaultEmulatorImage))
+	// Workaround to suppress log output with `-v`.
+	testcontainers.Logger = &noopLogger{}
+	container, err = gcloud.RunSpanner(ctx, lo.CoalesceOrEmpty(opts.EmulatorImage, defaultEmulatorImage), testcontainers.WithLogger(&noopLogger{}))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/apstndb/lox v0.0.0-20241102092239-40172f618f5c
 	github.com/apstndb/spantype v0.2.0
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cloudspannerecosystem/memefish v0.0.0-20241031032728-970586f04071
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.6.1
+	github.com/mattn/go-runewidth v0.0.10
 	github.com/ngicks/go-iterator-helper v0.0.15
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/reeflective/readline v1.0.15
@@ -72,7 +72,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -674,7 +674,6 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
#30 uses https://github.com/chzyer/readline/runes, but it is not good https://github.com/chzyer/readline/issues/43.
I have noticed the most logic can be replaced with https://github.com/mattn/go-runewidth. It should be.