### PR TITLE
Fix not to terminate on lexer error

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -225,11 +225,11 @@ func (c *Cli) RunInteractive(ctx context.Context) int {
 		if err == io.EOF {
 			return c.Exit()
 		}
+		if errors.Is(err, readline.CtrlC) {
+			c.PrintInteractiveError(err)
+			continue
+		}
 		if err != nil {
-			if input == nil {
-				return c.ExitOnError(err)
-			}
-
 			c.PrintInteractiveError(err)
 			continue
 		}


### PR DESCRIPTION
```
spanner> SELECT "
ERROR: syntax error: :1:8: unclosed string literal: newline appears in non triple-quoted

  1:  SELECT "
             ^

exit status 1
$
```

It is not ideal behavior so I fixed.