### PR TITLE
Bump go-multiline-ny@v0.16.4, and remove workaround

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -173,14 +173,10 @@ func (c *Cli) RunInteractive(ctx context.Context) int {
 	var ed multiline.Editor
 
 	type ac = readline.AnonymousCommand
+	type _ = ac
 
 	// TODO: There is no multiline version of CmdISearchBackward.
 	err := ed.BindKey(keys.CtrlR, readline.CmdISearchBackward)
-	if err != nil {
-		return c.ExitOnError(err)
-	}
-
-	err = ed.BindKey(keys.Backspace, ac(ed.CmdBackwardDeleteChar))
 	if err != nil {
 		return c.ExitOnError(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e
 	github.com/cloudspannerecosystem/memefish v0.0.0-20241106111047-2b2b4b23a1e7
 	github.com/google/go-cmp v0.6.0
-	github.com/hymkor/go-multiline-ny v0.16.3
+	github.com/hymkor/go-multiline-ny v0.16.4
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/ngicks/go-iterator-helper v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -896,6 +896,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hymkor/go-multiline-ny v0.16.3 h1:BeoQo34J8zzNb+TWH9wxXlIxoSjamqHlJGIwBEBeqRY=
 github.com/hymkor/go-multiline-ny v0.16.3/go.mod h1:8f3QNpDDbhrl/1hdsXPh3vivRb6i/WaC6pzDhpVW/7o=
+github.com/hymkor/go-multiline-ny v0.16.4 h1:yanx/Wox8sGxk7ha0EGVlA+Sc4zPlZ1bt7kGFoyEEyg=
+github.com/hymkor/go-multiline-ny v0.16.4/go.mod h1:8f3QNpDDbhrl/1hdsXPh3vivRb6i/WaC6pzDhpVW/7o=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
This PR bumps go-multiline-ny to [v0.16.4](https://github.com/hymkor/go-multiline-ny/releases/tag/v0.16.4).
It fixes default binding of Backspace/Delete(macOS).