### PR TITLE
Implements --string and --read-timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ spanner:
       --emulator-image=                  container image for --embedded-emulator (default: gcr.io/cloud-spanner-emulator/emulator:1.5.25)
       --log-grpc                         Show gRPC logs
       --query-mode=[NORMAL|PLAN|PROFILE] Mode in which the query must be processed.
+      --strong                           Perform a strong query.
+      --read-timestamp=                  Perform a query at the given timestamp.
 ```
 
 ### Authentication


### PR DESCRIPTION
This PR implements `--strong` and `--read-timestamp` as shortcut of `READ_ONLY_STALENESS` system variable.

- part of #5 