### PR TITLE
Add ColumnAlign to fix alignment problem

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -734,6 +734,10 @@ func printResult(debug bool, screenWidth int, out io.Writer, result *Result, mod
 		table.SetAlignment(tablewriter.ALIGN_LEFT)
 		table.SetAutoWrapText(false)
 
+		if len(result.ColumnAlign) > 0 {
+			table.SetColumnAlignment(result.ColumnAlign)
+		}
+
 		var adjustedWidths []int
 		if len(result.ColumnTypes) > 0 {
 			names := slices.Collect(xiter.Map(

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -138,6 +138,7 @@ func executeExplain(ctx context.Context, session *Session, sql string, isDML boo
 
 	result := &Result{
 		ColumnNames:  explainColumnNames,
+		ColumnAlign:  explainColumnAlign,
 		AffectedRows: len(rows),
 		Rows:         rows,
 		Timestamp:    timestamp,
@@ -179,6 +180,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string) (*
 	// ReadOnlyTransaction.Timestamp() is invalid until read.
 	result := &Result{
 		ColumnNames:  explainAnalyzeColumnNames,
+		ColumnAlign:  explainAnalyzeColumnAlign,
 		ForceVerbose: true,
 		AffectedRows: len(rows),
 		Stats:        queryStats,

--- a/statement.go
+++ b/statement.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olekukonko/tablewriter"
+
 	"cloud.google.com/go/spanner"
 	adminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -63,6 +65,7 @@ const (
 
 type Result struct {
 	ColumnNames      []string
+	ColumnAlign      []int // optional
 	Rows             []Row
 	Predicates       []string
 	AffectedRows     int
@@ -145,9 +148,13 @@ var (
 )
 
 var (
-	explainColumnNames        = []string{"ID", "Query_Execution_Plan"}
+	explainColumnNames = []string{"ID", "Query_Execution_Plan"}
+	explainColumnAlign = []int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT}
+
 	explainAnalyzeColumnNames = []string{"ID", "Query_Execution_Plan", "Rows_Returned", "Executions", "Total_Latency"}
-	describeColumnNames       = []string{"Column_Name", "Column_Type"}
+	explainAnalyzeColumnAlign = []int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT}
+
+	describeColumnNames = []string{"Column_Name", "Column_Type"}
 )
 
 func BuildStatement(input string) (Statement, error) {


### PR DESCRIPTION
This PR fixes alignment bug by introducing ColumnAlign field. 
Before
```
+----+------------------------------------------------------------------------------+---------------+------------+---------------+
| ID | Query_Execution_Plan                                                         | Rows_Returned | Executions | Total_Latency |
+----+------------------------------------------------------------------------------+---------------+------------+---------------+
| *0 | Distributed Union (distribution_table: Singers, split_ranges_aligned: false) | 0             | 1          | 0.05 msecs    |
| 1  | +- Local Distributed Union                                                   | 0             | 1          | 0.03 msecs    |
| 2  |    +- Serialize Result                                                       | 0             | 1          | 0.03 msecs    |
| 3  |       +- Filter Scan (seekable_key_size: 0)                                  |               |            |               |
| *4 |          +- Table Scan (Table: Singers, scan_method: Scalar)                 | 0             | 1          | 0.03 msecs    |
+----+------------------------------------------------------------------------------+---------------+------------+---------------+
```
After
```
+----+------------------------------------------------------------------------------+---------------+------------+---------------+
| ID | Query_Execution_Plan                                                         | Rows_Returned | Executions | Total_Latency |
+----+------------------------------------------------------------------------------+---------------+------------+---------------+
| *0 | Distributed Union (distribution_table: Singers, split_ranges_aligned: false) | 0             | 1          | 0.06 msecs    |
|  1 | +- Local Distributed Union                                                   | 0             | 1          | 0.04 msecs    |
|  2 |    +- Serialize Result                                                       | 0             | 1          | 0.03 msecs    |
|  3 |       +- Filter Scan (seekable_key_size: 0)                                  |               |            |               |
| *4 |          +- Table Scan (Table: Singers, scan_method: Scalar)                 | 0             | 1          | 0.03 msecs    |
+----+------------------------------------------------------------------------------+---------------+------------+---------------+
```
