### PR TITLE
Add CLI_LINT_PLAN system variable

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -808,6 +808,13 @@ func printResult(debug bool, screenWidth int, out io.Writer, result *Result, mod
 		fmt.Fprintln(out)
 	}
 
+	if len(result.LintResults) > 0 {
+		fmt.Fprintln(out, "Experimental Lint Result:")
+		for _, s := range result.LintResults {
+			fmt.Fprintf(out, " %s\n", s)
+		}
+		fmt.Fprintln(out)
+	}
 	if verbose || result.ForceVerbose {
 		fmt.Fprint(out, resultLine(result, true))
 	} else if interactive {

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -143,6 +143,7 @@ func executeExplain(ctx context.Context, session *Session, sql string, isDML boo
 		Rows:         rows,
 		Timestamp:    timestamp,
 		Predicates:   predicates,
+		LintResults:  lox.IfOrEmptyF(session.systemVariables.LintPlan, func() []string { return lintPlan(queryPlan) }),
 	}
 
 	return result, nil
@@ -187,6 +188,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string) (*
 		Timestamp:    lox.IfOrEmptyF(roTxn != nil, func() time.Time { return ignoreError(roTxn.Timestamp()) }),
 		Rows:         rows,
 		Predicates:   predicates,
+		LintResults:  lox.IfOrEmptyF(session.systemVariables.LintPlan, func() []string { return lintPlan(plan) }),
 	}
 	return result, nil
 }
@@ -249,6 +251,7 @@ func executeExplainAnalyzeDML(ctx context.Context, session *Session, sql string)
 		Rows:             rows,
 		Predicates:       predicates,
 		Timestamp:        commitResp.CommitTs,
+		LintResults:      lox.IfOrEmptyF(session.systemVariables.LintPlan, func() []string { return lintPlan(queryPlan) }),
 	}
 
 	return result, nil

--- a/lint_plan.go
+++ b/lint_plan.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplanviz/queryplan"
+)
+
+func lintPlan(plan *spannerpb.QueryPlan) []string {
+	var result []string
+	qp := queryplan.New(plan.GetPlanNodes())
+	for _, row := range qp.PlanNodes() {
+		var msgs []string
+		switch {
+		case row.GetDisplayName() == "Filter":
+			msgs = append(msgs, "Potentially expensive operator Filter can't utilize index: Maybe better to modify to use Filter Scan with Seek Condition?")
+		case strings.Contains(row.GetDisplayName(), "Minor Sort"):
+			msgs = append(msgs, "Potentially expensive operator Minor Sort is cheaper than Sort but it may be not optimal: Maybe better to modify to use the same order with the index?")
+		case strings.Contains(row.GetDisplayName(), "Sort"):
+			msgs = append(msgs, "Potentially expensive operator Sort: Maybe better to modify to use the same order with the index?")
+		}
+		for _, childLink := range row.GetChildLinks() {
+			var msg string
+			switch {
+			case childLink.GetType() == "Residual Condition":
+				msg = "Potentially expensive Residual Condition: Maybe better to modify it to Scan Condition"
+			}
+			if msg != "" {
+				msgs = append(msgs, fmt.Sprintf("%v: %v", childLink.GetType(), msg))
+			}
+		}
+		for k, v := range row.GetMetadata().AsMap() {
+			var msg string
+			switch {
+			case k == "Full scan" && v == "true":
+				msg = "Potentially expensive execution full scan: Do you really want full scan?"
+			case k == "iterator_type" && v == "Hash":
+				msg = fmt.Sprintf("Potentially expensive execution Hash %s: Maybe better to modify to use Stream %s?", row.GetDisplayName(), row.GetDisplayName())
+			case k == "join_type" && v == "Hash":
+				msg = fmt.Sprintf("Potentially expensive execution Hash %s: Maybe better to modify to use Cross Apply or Merge Join?", row.GetDisplayName())
+			}
+			if msg != "" {
+				msgs = append(msgs, fmt.Sprintf("%v=%v: %v", k, v, msg))
+			}
+		}
+		if len(msgs) > 0 {
+			result = append(result, fmt.Sprintf("%v: %v", row.GetIndex(), queryplan.NodeTitle(row)))
+			for _, msg := range msgs {
+				result = append(result, fmt.Sprintf("    %v", msg))
+			}
+		}
+	}
+	return result
+}

--- a/statement.go
+++ b/statement.go
@@ -80,6 +80,7 @@ type Result struct {
 	// ColumnTypes will be printed in `--verbose` mode if it is not empty
 	ColumnTypes []*sppb.StructType_Field
 	ForceWrap   bool
+	LintResults []string
 }
 
 type Row struct {

--- a/system_variables.go
+++ b/system_variables.go
@@ -44,6 +44,7 @@ type systemVariables struct {
 	BuildStatementMode          parseMode
 	LogGrpc                     bool
 	QueryMode                   *sppb.ExecuteSqlRequest_QueryMode
+	LintPlan                    bool
 
 	// it is internal variable and hidden from system variable statements
 	ProtoDescriptor *descriptorpb.FileDescriptorSet
@@ -390,6 +391,12 @@ var accessorMap = map[string]accessor{
 		Getter: boolGetter(func(sysVars *systemVariables) *bool {
 			return lo.Ternary(sysVars.LogGrpc, &sysVars.LogGrpc, nil)
 		}),
+	},
+	"CLI_LINT_PLAN": {
+		Getter: boolGetter(func(sysVars *systemVariables) *bool {
+			return lo.Ternary(sysVars.LintPlan, lo.ToPtr(sysVars.LintPlan), nil)
+		}),
+		Setter: boolSetter(func(sysVars *systemVariables) *bool { return &sysVars.LintPlan }),
 	},
 	"CLI_QUERY_MODE": {
 		Getter: func(this *systemVariables, name string) (map[string]string, error) {


### PR DESCRIPTION
This PR adds experimental support of query plan linter, which is enabled by `CLI_LINT_PLAN`.

```
spanner> SET CLI_LINT_PLAN = TRUE;
Empty set (0.00 sec)

spanner> EXPLAIN SELECT * FROM Singers WHERE FirstName LIKE "%Hoge%";
+----+----------------------------------------------------------------------------------+
| ID | Query_Execution_Plan                                                             |
+----+----------------------------------------------------------------------------------+
|  0 | Distributed Union (distribution_table: Singers, split_ranges_aligned: false)     |
|  1 | +- Local Distributed Union                                                       |
|  2 |    +- Serialize Result                                                           |
| *3 |       +- Filter Scan (seekable_key_size: 0)                                      |
|  4 |          +- Table Scan (Full scan: true, Table: Singers, scan_method: Automatic) |
+----+----------------------------------------------------------------------------------+
Predicates(identified by ID):
 3: Residual Condition: ($FirstName LIKE '%Hoge%')

Experimental Lint Result:
 3: Filter Scan (seekable_key_size: 0)
     Residual Condition: Potentially expensive Residual Condition: Maybe better to modify it to Scan Condition
 4: Table Scan (Full scan: true, Table: Singers, scan_method: Automatic)
     Full scan=true: Potentially expensive execution full scan: Do you really want full scan?
```