### PR TITLE
Use FormatTypeMoreVerbose in DESCRIBE

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -31,6 +31,7 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 	return spanvalue.FormatColumnSpannerCLICompatible(column)
 }
 
+// formatTypeSimple is format type for headers.
 func formatTypeSimple(typ *sppb.Type) string {
 	return spantype.FormatType(typ, spantype.FormatOption{
 		Struct: spantype.StructModeBase,
@@ -40,6 +41,7 @@ func formatTypeSimple(typ *sppb.Type) string {
 	})
 }
 
+// formatTypeVerbose is format type for DESCRIBE.
 func formatTypeVerbose(typ *sppb.Type) string {
-	return spantype.FormatTypeVerbose(typ)
+	return spantype.FormatTypeMoreVerbose(typ)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/typepb"
@@ -437,6 +439,33 @@ func TestDecodeRow(t *testing.T) {
 			}
 			if !equalStringSlice(got, test.want) {
 				t.Errorf("DecodeRow(%v) = %v, want = %v", test.values, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFormatTypeVerbose(t *testing.T) {
+	tests := []struct {
+		desc     string
+		sppbType *sppb.Type
+		want     string
+	}{
+		{
+			desc:     "PROTO",
+			sppbType: &sppb.Type{Code: sppb.TypeCode_PROTO, ProtoTypeFqn: "example.ProtoType"},
+			want:     "PROTO<example.ProtoType>",
+		},
+		{
+			desc:     "ENUM",
+			sppbType: &sppb.Type{Code: sppb.TypeCode_ENUM, ProtoTypeFqn: "example.EnumType"},
+			want:     "ENUM<example.EnumType>",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := formatTypeVerbose(test.sppbType)
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("formatTypeVerbose(%v) mismatch (-got +want):\n%s", test.sppbType, diff)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/apstndb/lox v0.0.0-20241102092239-40172f618f5c
 	github.com/apstndb/memebridge v0.0.0-20241123172322-a745771fe5be
 	github.com/apstndb/spannerplanviz v0.3.2
-	github.com/apstndb/spantype v0.2.0
+	github.com/apstndb/spantype v0.3.0
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e
 	github.com/cloudspannerecosystem/memefish v0.0.0-20241106111047-2b2b4b23a1e7
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -672,6 +672,8 @@ github.com/apstndb/spannerplanviz v0.3.2 h1:AeTNTdE05+7T4HWPV1yjLSYCbr51ZugtR3KC
 github.com/apstndb/spannerplanviz v0.3.2/go.mod h1:/tY1Y1tLTp3Czj9BI2/M02W3P/wJgmKwuDS5zARLhvc=
 github.com/apstndb/spantype v0.2.0 h1:yoV0riMXhLeT9z8D1zhvwIraOvIU0fDKwWrWgtmoNns=
 github.com/apstndb/spantype v0.2.0/go.mod h1:zn3qR4ebyy3HumRKRG0COMRSf4tmaR1HptQwe7/Xu7g=
+github.com/apstndb/spantype v0.3.0 h1:MX9ODH338O7KW7IHxiv09uaZZRQS6PZm3t9s/wdiPSQ=
+github.com/apstndb/spantype v0.3.0/go.mod h1:zn3qR4ebyy3HumRKRG0COMRSf4tmaR1HptQwe7/Xu7g=
 github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e h1:uWViNQM3/1RPtJcw6+4l3XHAm4uCWCWe0xVQvpXj8mM=
 github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e/go.mod h1:NV6r4opNnDtM+cU6IjbMyAtNbV/oIX8X9xknIGJ1B8k=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=


### PR DESCRIPTION
This PR changes format of `DESCRIBE`.

It maybe a breaking changes.

## Before

`PROTO` and `ENUM` are formatted as `protoTypeFqn`.
Named types can't be distinguished between `PROTO` and `ENUM`.
```
spanner> DESCRIBE SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+---------------------+--------------------------+
| Column_Name         | Column_Type              |
+---------------------+--------------------------+
| CATALOG_NAME        | STRING                   |
| SCHEMA_NAME         | STRING                   |
| EFFECTIVE_TIMESTAMP | INT64                    |
| PROTO_BUNDLE        | proto2.FileDescriptorSet |
| SCHEMA_OWNER        | STRING                   |
+---------------------+--------------------------+
```
##After

`PROTO` and `ENUM` are formatted as `kind<protoTypeFqn>`.

```
spanner> DESCRIBE SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+---------------------+---------------------------------+
| Column_Name         | Column_Type                     |
+---------------------+---------------------------------+
| CATALOG_NAME        | STRING                          |
| SCHEMA_NAME         | STRING                          |
| EFFECTIVE_TIMESTAMP | INT64                           |
| PROTO_BUNDLE        | PROTO<proto2.FileDescriptorSet> |
| SCHEMA_OWNER        | STRING                          |
+---------------------+---------------------------------+
```

This format is the same to `SPANNER_TYPE` of `INFORMATION_SCHEMA.COLUMNS`.
```
spanner> SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, SPANNER_TYPE
         FROM INFORMATION_SCHEMA.COLUMNS
         WHERE TABLE_NAME = "SCHEMATA";
+--------------------+------------+---------------------+---------------------------------+
| TABLE_SCHEMA       | TABLE_NAME | COLUMN_NAME         | SPANNER_TYPE                    |
| STRING             | STRING     | STRING              | STRING                          |
+--------------------+------------+---------------------+---------------------------------+
| INFORMATION_SCHEMA | SCHEMATA   | CATALOG_NAME        | STRING(MAX)                     |
| INFORMATION_SCHEMA | SCHEMATA   | SCHEMA_NAME         | STRING(MAX)                     |
| INFORMATION_SCHEMA | SCHEMATA   | EFFECTIVE_TIMESTAMP | INT64                           |
| INFORMATION_SCHEMA | SCHEMATA   | PROTO_BUNDLE        | PROTO<proto2.FileDescriptorSet> |
| INFORMATION_SCHEMA | SCHEMATA   | SCHEMA_OWNER        | STRING(MAX)                     |
+--------------------+------------+---------------------+---------------------------------
```