### PR TITLE
Implements TRANSACTION_TAG and STATEMENT_TAG system variables

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -80,7 +80,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(ctx, test.transactionPriority, ""); err != nil {
+			if err := session.BeginReadWriteTransaction(ctx, test.transactionPriority); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
 			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
@@ -97,7 +97,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Only Transaction.
-			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority, ""); err != nil {
+			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority); err != nil {
 				t.Fatalf("failed to begin read only transaction: %v", err)
 			}
 			iter, _ = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"))

--- a/statement_test.go
+++ b/statement_test.go
@@ -286,57 +286,6 @@ func TestBuildStatement(t *testing.T) {
 			},
 		},
 		{
-			desc:  "BEGIN statement with TAG",
-			input: "BEGIN TAG app=spanner-cli,env=test",
-			want: &BeginRwStatement{
-				Tag: "app=spanner-cli,env=test",
-			},
-		},
-		{
-			desc:  "BEGIN RW statement with TAG",
-			input: "BEGIN RW TAG app=spanner-cli,env=test",
-			want: &BeginRwStatement{
-				Tag: "app=spanner-cli,env=test",
-			},
-		},
-		{
-			desc:  "BEGIN PRIORITY statement with TAG",
-			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli,env=test",
-			want: &BeginRwStatement{
-				Priority: sppb.RequestOptions_PRIORITY_MEDIUM,
-				Tag:      "app=spanner-cli,env=test",
-			},
-		},
-		{
-			desc:  "BEGIN statement with TAG whitespace",
-			input: "BEGIN TAG app=spanner-cli env=test",
-			want: &BeginRwStatement{
-				Tag: "app=spanner-cli env=test",
-			},
-		},
-		{
-			desc:  "BEGIN RW statement with TAG whitespace",
-			input: "BEGIN RW TAG app=spanner-cli env=test",
-			want: &BeginRwStatement{
-				Tag: "app=spanner-cli env=test",
-			},
-		},
-		{
-			desc:  "BEGIN PRIORITY statement with TAG whitespace",
-			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli env=test",
-			want: &BeginRwStatement{
-				Priority: sppb.RequestOptions_PRIORITY_MEDIUM,
-				Tag:      "app=spanner-cli env=test",
-			},
-		},
-		{
-			desc:  "BEGIN statement with TAG quoted",
-			input: "BEGIN TAG app=\"spanner-cli\" env='dev'",
-			want: &BeginRwStatement{
-				Tag: "app=\"spanner-cli\" env='dev'",
-			},
-		},
-		{
 			desc:  "BEGIN RO statement",
 			input: "BEGIN RO",
 			want:  &BeginRoStatement{TimestampBoundType: strong},
@@ -364,52 +313,6 @@ func TestBuildStatement(t *testing.T) {
 				Staleness:          time.Duration(10 * time.Second),
 				TimestampBoundType: exactStaleness,
 				Priority:           sppb.RequestOptions_PRIORITY_HIGH,
-			},
-		},
-		{
-			desc:  "BEGIN RO statement with TAG",
-			input: "BEGIN RO TAG app=spanner-cli,env=test",
-			want: &BeginRoStatement{
-				TimestampBoundType: strong,
-				Tag:                "app=spanner-cli,env=test",
-			},
-		},
-		{
-			desc:  "BEGIN RO staleness statement with TAG",
-			input: "BEGIN RO 10 TAG app=spanner-cli,env=test",
-			want: &BeginRoStatement{
-				Staleness:          time.Duration(10 * time.Second),
-				TimestampBoundType: exactStaleness,
-				Tag:                "app=spanner-cli,env=test",
-			},
-		},
-		{
-			desc:  "BEGIN RO read timestamp statement with TAG",
-			input: "BEGIN RO 2020-03-30T22:54:44.834017+09:00 TAG app=spanner-cli,env=test",
-			want: &BeginRoStatement{
-				Timestamp:          timestamp,
-				TimestampBoundType: readTimestamp,
-				Tag:                "app=spanner-cli,env=test",
-			},
-			skipLowerCase: true,
-		},
-		{
-			desc:  "BEGIN RO PRIORITY statement with TAG",
-			input: "BEGIN RO PRIORITY LOW TAG app=spanner-cli,env=test",
-			want: &BeginRoStatement{
-				TimestampBoundType: strong,
-				Priority:           sppb.RequestOptions_PRIORITY_LOW,
-				Tag:                "app=spanner-cli,env=test",
-			},
-		},
-		{
-			desc:  "BEGIN RO staleness with PRIORITY statement with TAG",
-			input: "BEGIN RO 10 PRIORITY HIGH TAG app=spanner-cli,env=test",
-			want: &BeginRoStatement{
-				Staleness:          time.Duration(10 * time.Second),
-				TimestampBoundType: exactStaleness,
-				Priority:           sppb.RequestOptions_PRIORITY_HIGH,
-				Tag:                "app=spanner-cli,env=test",
 			},
 		},
 		{


### PR DESCRIPTION
This PR implements `TRANSACTION_TAG` and `STATEMENT_TAG`.

- These are mostly compatible with the [Spanner JDBC driver](https://cloud.google.com/spanner/docs/jdbc-session-mgmt-commands?hl=en#tags).
  - `STATEMENT_TAG` should be `REQUEST_TAG`, but I have prioritized to be Spanner JDBC driver compatibility.
- They replaces `BEGIN RW TAG <tag>` and `BEGIN RO TAG <tag>`.

## Breaking changes

- `BEGIN RW TAG <tag>` and `BEGIN RO TAG <tag>` are no longer supported.

## References

- https://github.com/cloudspannerecosystem/spanner-cli/issues/132