### PR TITLE
Fix STATEMENT_TAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Note that transaction-level priority takes precedence over command-level priorit
 ## Transaction Tags and Request Tags
 
 You can set transaction tag using `SET TRANSACTION_TAG = "<tag>"`, and request tag using `SET STATEMENT_TAG = "<tag>"`.
+Note: `STATEMENT_TAG` is effective only in the next query.
 
 ```
 +------------------------------+
@@ -442,6 +443,9 @@ You can set transaction tag using `SET TRANSACTION_TAG = "<tag>"`, and request t
 | SELECT val                   |
 | FROM tab1      +--------------transaction_tag = tx1, request_tag = req1
 | WHERE id = 1;                |
+|                              |
+| SELECT *                     |
+| FROM tab1;     +--------------transaction_tag = tx1
 |                              |
 | SET STATEMENT_TAG = "req2";  |
 |                              |

--- a/session.go
+++ b/session.go
@@ -299,6 +299,9 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 	opts.Options.OptimizerStatisticsPackage = s.systemVariables.OptimizerStatisticsPackage
 	opts.RequestTag = s.systemVariables.RequestTag
 
+	// Reset STATEMENT_TAG
+	s.systemVariables.RequestTag = ""
+
 	switch {
 	case s.InReadWriteTransaction():
 		// The current Go Spanner client library does not apply client-level directed read options to read-write transactions.
@@ -336,6 +339,9 @@ func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, useUpda
 			OptimizerStatisticsPackage: s.systemVariables.OptimizerStatisticsPackage,
 		},
 	}
+
+	// Reset STATEMENT_TAG
+	s.systemVariables.RequestTag = ""
 
 	// Workaround: Usually, we can execute DMLs using Query(ExecuteStreamingSql RPC),
 	// but spannertest doesn't support DMLs execution using ExecuteStreamingSql RPC.


### PR DESCRIPTION
The current `STATEMENT_TAG` is not yet compatible with Spanner JDBC driver.

https://cloud.google.com/spanner/docs/jdbc-session-mgmt-commands?hl=en#tags

> Sets the request tag for the next statement to be executed. Only one tag can be set per statement. The tag doesn't span multiple statements; it must be set on a per statement basis. A request tag can be removed by setting it to the empty string ('').
> `-- The statement tag property is cleared after each statement execution.`

Now `STATEMENT_TAG` is effective only in the next query.