### PR TITLE
Implements READONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ and `{}` for a mutually exclusive keyword.
 | Show DML Result Shape | `DESCRIBE {INSERT\|UPDATE\|DELETE} ... THEN RETURN ...;`                                       | |
 | Start a new query optimizer statistics package construction | `ANALYZE;`                                                                                     | |
 | Start Transaction | `BEGIN [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | It respects `READONLY` system variable. See [Request Priority](#request-priority) for details on the priority.|
-| Start Read-Write Transaction | `BEGIN [RW] [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | See [Request Priority](#request-priority) for details on the priority.|
+| Start Read-Write Transaction | `BEGIN RW [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | See [Request Priority](#request-priority) for details on the priority.|
 | Commit Read-Write Transaction<br/>or end Read-OnlyTransaction | `COMMIT [TRANSACTION];`                                                                                      | |
 | Rollback Read-Write Transaction<br/>or end Read-Only Transaction | `ROLLBACK [TRANSACTION];`                                                                                    | `CLOSE` is a synonym of `ROLLBACK`.|
 | Start Read-Only Transaction | `BEGIN RO [TRANSACTION] [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority.|

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ and `{}` for a mutually exclusive keyword.
 | Show Query Result Shape | `DESCRIBE SELECT ...;`                                                                         | |
 | Show DML Result Shape | `DESCRIBE {INSERT\|UPDATE\|DELETE} ... THEN RETURN ...;`                                       | |
 | Start a new query optimizer statistics package construction | `ANALYZE;`                                                                                     | |
-| Start Read-Write Transaction | `BEGIN [RW] [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | See [Request Priority](#request-priority) for details on the priority. The tag you set is used as both transaction tag and request tag.|
+| Start Transaction | `BEGIN [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | It respects `READONLY` system variable. See [Request Priority](#request-priority) for details on the priority.|
+| Start Read-Write Transaction | `BEGIN [RW] [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | See [Request Priority](#request-priority) for details on the priority.|
 | Commit Read-Write Transaction<br/>or end Read-OnlyTransaction | `COMMIT [TRANSACTION];`                                                                                      | |
 | Rollback Read-Write Transaction<br/>or end Read-Only Transaction | `ROLLBACK [TRANSACTION];`                                                                                    | `CLOSE` is a synonym of `ROLLBACK`.|
 | Start Read-Only Transaction | `BEGIN RO [TRANSACTION] [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority.|
@@ -484,6 +485,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 
 | Name                         | Type       | Example                                             |
 |------------------------------|------------|-----------------------------------------------------|
+| READONLY                     | READ_WRITE | `TRUE`                                              |
 | READ_ONLY_STALENESS          | READ_WRITE | `"analyze_20241017_15_59_17UTC"`                    |
 | OPTIMIZER_VERSION            | READ_WRITE | `"7"`                                               |
 | OPTIMIZER_STATISTICS_PACKAGE | READ_WRITE | `"7"`                                               |

--- a/session.go
+++ b/session.go
@@ -69,12 +69,37 @@ type Session struct {
 	systemVariables *systemVariables
 }
 
+type transactionMode string
+
+const (
+	transactionModeUndetermined = "undetermined"
+	transactionModeReadOnly     = "read-only"
+	transactionModeReadWrite    = "read-write"
+)
+
 type transactionContext struct {
+	mode          transactionMode
 	tag           string
 	priority      sppb.RequestOptions_Priority
 	sendHeartbeat bool // Becomes true only after a user-driven query is executed on the transaction.
-	rwTxn         *spanner.ReadWriteStmtBasedTransaction
-	roTxn         *spanner.ReadOnlyTransaction
+
+	txn any
+	// rwTxn         *spanner.ReadWriteStmtBasedTransaction
+	// roTxn         *spanner.ReadOnlyTransaction
+}
+
+func (tc *transactionContext) RWTxn() *spanner.ReadWriteStmtBasedTransaction {
+	if tc.mode != transactionModeReadWrite {
+		panic(fmt.Sprintf("must be in read-write transaction, but: %v", tc.mode))
+	}
+	return tc.txn.(*spanner.ReadWriteStmtBasedTransaction)
+}
+
+func (tc *transactionContext) ROTxn() *spanner.ReadOnlyTransaction {
+	if tc.mode != transactionModeReadOnly {
+		panic(fmt.Sprintf("must be in read-only transaction, but: %v", tc.mode))
+	}
+	return tc.txn.(*spanner.ReadOnlyTransaction)
 }
 
 func logGrpcClientOptions() []option.ClientOption {
@@ -138,12 +163,12 @@ func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.Cl
 
 // InReadWriteTransaction returns true if the session is running read-write transaction.
 func (s *Session) InReadWriteTransaction() bool {
-	return s.tc != nil && s.tc.rwTxn != nil
+	return s.tc != nil && s.tc.mode == transactionModeReadWrite
 }
 
 // InReadOnlyTransaction returns true if the session is running read-only transaction.
 func (s *Session) InReadOnlyTransaction() bool {
-	return s.tc != nil && s.tc.roTxn != nil
+	return s.tc != nil && s.tc.mode == transactionModeReadOnly
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
@@ -173,9 +198,10 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority sppb.R
 		return err
 	}
 	s.tc = &transactionContext{
+		mode:     transactionModeReadWrite,
 		tag:      tag,
 		priority: priority,
-		rwTxn:    txn,
+		txn:      txn,
 	}
 	return nil
 }
@@ -189,7 +215,7 @@ func (s *Session) CommitReadWriteTransaction(ctx context.Context) (spanner.Commi
 	s.tcMutex.Lock()
 	defer s.tcMutex.Unlock()
 
-	resp, err := s.tc.rwTxn.CommitWithReturnResp(ctx)
+	resp, err := s.tc.RWTxn().CommitWithReturnResp(ctx)
 	s.tc = nil
 	return resp, err
 }
@@ -203,7 +229,7 @@ func (s *Session) RollbackReadWriteTransaction(ctx context.Context) error {
 	s.tcMutex.Lock()
 	defer s.tcMutex.Unlock()
 
-	s.tc.rwTxn.Rollback(ctx)
+	s.tc.RWTxn().Rollback(ctx)
 	s.tc = nil
 	return nil
 }
@@ -214,15 +240,21 @@ func (s *Session) BeginReadOnlyTransaction(ctx context.Context, typ timestampBou
 		return time.Time{}, errors.New("read-only transaction is already running")
 	}
 
-	txn := s.client.ReadOnlyTransaction()
+	tb := spanner.StrongRead()
 	switch typ {
 	case strong:
-		txn = txn.WithTimestampBound(spanner.StrongRead())
+		tb = spanner.StrongRead()
 	case exactStaleness:
-		txn = txn.WithTimestampBound(spanner.ExactStaleness(staleness))
+		tb = spanner.ExactStaleness(staleness)
 	case readTimestamp:
-		txn = txn.WithTimestampBound(spanner.ReadTimestamp(timestamp))
+		tb = spanner.ReadTimestamp(timestamp)
+	default:
+		if s.systemVariables.ReadOnlyStaleness != nil {
+			tb = *s.systemVariables.ReadOnlyStaleness
+		}
 	}
+
+	txn := s.client.ReadOnlyTransaction().WithTimestampBound(tb)
 
 	// Use session's priority if transaction priority is not set.
 	if priority == sppb.RequestOptions_PRIORITY_UNSPECIFIED {
@@ -237,8 +269,9 @@ func (s *Session) BeginReadOnlyTransaction(ctx context.Context, typ timestampBou
 	}
 
 	s.tc = &transactionContext{
+		mode:     transactionModeReadOnly,
 		priority: priority,
-		roTxn:    txn,
+		txn:      txn,
 	}
 
 	return txn.Timestamp()
@@ -250,7 +283,7 @@ func (s *Session) CloseReadOnlyTransaction() error {
 		return errors.New("read-only transaction is not running")
 	}
 
-	s.tc.roTxn.Close()
+	s.tc.ROTxn().Close()
 	s.tc = nil
 	return nil
 }
@@ -307,11 +340,11 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 		// The current Go Spanner client library does not apply client-level directed read options to read-write transactions.
 		// Therefore, we explicitly set query-level options here to fail the query during a read-write transaction.
 		opts.DirectedReadOptions = s.clientConfig.DirectedReadOptions
-		iter := s.tc.rwTxn.QueryWithOptions(ctx, stmt, opts)
+		iter := s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts)
 		s.tc.sendHeartbeat = true
 		return iter, nil
 	case s.InReadOnlyTransaction():
-		return s.tc.roTxn.QueryWithOptions(ctx, stmt, opts), s.tc.roTxn
+		return s.tc.ROTxn().QueryWithOptions(ctx, stmt, opts), s.tc.ROTxn()
 	default:
 		txn := s.client.Single()
 		if s.systemVariables.ReadOnlyStaleness != nil {
@@ -348,12 +381,12 @@ func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, useUpda
 	// It enforces to use ExecuteSql RPC.
 	// TODO: Remove useUpdate flag
 	if useUpdate {
-		rowCount, err := s.tc.rwTxn.UpdateWithOptions(ctx, stmt, opts)
+		rowCount, err := s.tc.RWTxn().UpdateWithOptions(ctx, stmt, opts)
 		s.tc.sendHeartbeat = true
 		return nil, nil, rowCount, nil, err
 	}
 
-	rows, _, count, metadata, _, err := consumeRowIterCollect(s.tc.rwTxn.QueryWithOptions(ctx, stmt, opts), spannerRowToRow)
+	rows, _, count, metadata, _, err := consumeRowIterCollect(s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts), spannerRowToRow)
 	s.tc.sendHeartbeat = true
 	return rows, extractColumnNames(metadata.GetRowType().GetFields()), count, metadata, err
 }
@@ -435,8 +468,8 @@ func (s *Session) startHeartbeat() {
 		func() {
 			s.tcMutex.Lock()
 			defer s.tcMutex.Unlock()
-			if s.tc != nil && s.tc.rwTxn != nil && s.tc.sendHeartbeat {
-				err := heartbeat(s.tc.rwTxn, s.currentPriority())
+			if s.tc != nil && s.tc.mode == transactionModeReadWrite && s.tc.sendHeartbeat {
+				err := heartbeat(s.tc.RWTxn(), s.currentPriority())
 				if err != nil {
 					log.Printf("heartbeat error: %v", err)
 				}

--- a/session.go
+++ b/session.go
@@ -523,3 +523,11 @@ func (s *Session) RunInNewOrExistRwTx(ctx context.Context,
 	}
 	return affected, resp, plan, metadata, nil
 }
+
+func (s *Session) failStatementIfReadOnly() error {
+	if s.systemVariables.ReadOnly {
+		return errors.New("can't execute this statement in READONLY mode")
+	}
+
+	return nil
+}

--- a/statement_test.go
+++ b/statement_test.go
@@ -264,12 +264,12 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "BEGIN statement",
 			input: "BEGIN",
-			want:  &BeginRwStatement{},
+			want:  &BeginStatement{},
 		},
 		{
 			desc:  "BEGIN TRANSACTION statement",
 			input: "BEGIN TRANSACTION",
-			want:  &BeginRwStatement{},
+			want:  &BeginStatement{},
 		},
 		{
 			desc:  "BEGIN RW statement",
@@ -279,7 +279,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "BEGIN PRIORITY statement",
 			input: "BEGIN PRIORITY MEDIUM",
-			want: &BeginRwStatement{
+			want: &BeginStatement{
 				Priority: sppb.RequestOptions_PRIORITY_MEDIUM,
 			},
 		},
@@ -293,7 +293,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "BEGIN RO statement",
 			input: "BEGIN RO",
-			want:  &BeginRoStatement{TimestampBoundType: strong},
+			want:  &BeginRoStatement{TimestampBoundType: unspecified},
 		},
 		{
 			desc:  "BEGIN RO staleness statement",
@@ -309,7 +309,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "BEGIN RO PRIORITY statement",
 			input: "BEGIN RO PRIORITY LOW",
-			want:  &BeginRoStatement{TimestampBoundType: strong, Priority: sppb.RequestOptions_PRIORITY_LOW},
+			want:  &BeginRoStatement{TimestampBoundType: unspecified, Priority: sppb.RequestOptions_PRIORITY_LOW},
 		},
 		{
 			desc:  "BEGIN RO staleness with PRIORITY statement",


### PR DESCRIPTION
This PR implements `READONLY` system variable.

- If `READONLY` is true, all non-readonly statements fail.
- If `READONLY` is true, `BEGIN` without `RW` or `RO` begins read-only transaction.

```
spanner> BEGIN;
Query OK, 0 rows affected (0.45 sec)

spanner(rw txn)> ROLLBACK;
Query OK, 0 rows affected (0.19 sec)

spanner> SET READONLY = TRUE;
Empty set (0.00 sec)

spanner> UPDATE MutationTest SET Col = Col WHERE TRUE;
ERROR: can't execute this statement in READONLY mode
spanner> BEGIN;
Query OK, 0 rows affected (0.44 sec)
timestamp:      2024-12-09T21:06:46.978077+09:00

spanner(ro txn)> ROLLBACK;
Query OK, 0 rows affected (0.00 sec)
```
## Breaking changes

There is a no breaking change.

## Related issues

- Part of #79 