### PR TITLE
Implement Spanner JDBC driver style BEGIN, SET TRANSACTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,9 @@ and `{}` for a mutually exclusive keyword.
 | Show Query Result Shape | `DESCRIBE SELECT ...;`                                                                         | |
 | Show DML Result Shape | `DESCRIBE {INSERT\|UPDATE\|DELETE} ... THEN RETURN ...;`                                       | |
 | Start a new query optimizer statistics package construction | `ANALYZE;`                                                                                     | |
-| Start Transaction | `BEGIN [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | It respects `READONLY` system variable. See [Request Priority](#request-priority) for details on the priority.|
-| Start Read-Write Transaction | `BEGIN RW [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | See [Request Priority](#request-priority) for details on the priority.|
+| Start Transaction | `BEGIN [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | (Spanner JDBC driver style); It respects `READONLY` system variable. See [Request Priority](#request-priority) for details on the priority.|
+| Set transaction mode| `SET TRANSACTION {READ ONLY\|READ WRITE};`                                       | (Spanner JDBC driver style); Set transaction mode for the current transaction.|
+| Start Read-Write Transaction | `BEGIN RW [TRANSACTION] [PRIORITY {HIGH\|MEDIUM\|LOW}];`                                       | (spanner-cli style);  See [Request Priority](#request-priority) for details on the priority.|
 | Commit Read-Write Transaction<br/>or end Read-OnlyTransaction | `COMMIT [TRANSACTION];`                                                                                      | |
 | Rollback Read-Write Transaction<br/>or end Read-Only Transaction | `ROLLBACK [TRANSACTION];`                                                                                    | `CLOSE` is a synonym of `ROLLBACK`.|
 | Start Read-Only Transaction | `BEGIN RO [TRANSACTION] [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority.|
@@ -432,12 +433,12 @@ Note that transaction-level priority takes precedence over command-level priorit
 ## Transaction Tags and Request Tags
 
 You can set transaction tag using `SET TRANSACTION_TAG = "<tag>"`, and request tag using `SET STATEMENT_TAG = "<tag>"`.
-Note: `STATEMENT_TAG` is effective only in the next query.
+Note: `TRANSACTION_TAG` is effective only in the current transaction and `STATEMENT_TAG` is effective only in the next query.
 
 ```
 +------------------------------+
+| BEGIN;                       |
 | SET TRANSACTION_TAG = "tx1"; |
-| BEGIN RW;                    |
 |                              |
 | SET STATEMENT_TAG = "req1";  |
 | SELECT val                   |
@@ -454,6 +455,10 @@ Note: `STATEMENT_TAG` is effective only in the next query.
 | WHERE id = 1;                |
 |                              |
 | COMMIT;        +--------------transaction_tag = tx1
+|                              |
+| BEGIN;                       |
+| SELECT 1;                    |
+| COMMIT;        +--------------no transaction_tag
 +------------------------------+
 ```
 

--- a/statement.go
+++ b/statement.go
@@ -1091,14 +1091,14 @@ func (s *SetTransactionStatement) Execute(ctx context.Context, session *Session)
 	}
 
 	if s.IsReadOnly {
-		ts, err := session.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, sppb.RequestOptions_PRIORITY_UNSPECIFIED)
+		ts, err := session.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, session.tc.priority)
 		if err != nil {
 			return nil, err
 		}
 		result.Timestamp = ts
 		return result, nil
 	} else {
-		err := session.BeginReadWriteTransaction(ctx, sppb.RequestOptions_PRIORITY_UNSPECIFIED)
+		err := session.BeginReadWriteTransaction(ctx, session.tc.priority)
 		if err != nil {
 			return nil, err
 		}

--- a/statement_test.go
+++ b/statement_test.go
@@ -293,7 +293,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "BEGIN RO statement",
 			input: "BEGIN RO",
-			want:  &BeginRoStatement{TimestampBoundType: unspecified},
+			want:  &BeginRoStatement{TimestampBoundType: timestampBoundUnspecified},
 		},
 		{
 			desc:  "BEGIN RO staleness statement",
@@ -309,7 +309,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "BEGIN RO PRIORITY statement",
 			input: "BEGIN RO PRIORITY LOW",
-			want:  &BeginRoStatement{TimestampBoundType: unspecified, Priority: sppb.RequestOptions_PRIORITY_LOW},
+			want:  &BeginRoStatement{TimestampBoundType: timestampBoundUnspecified, Priority: sppb.RequestOptions_PRIORITY_LOW},
 		},
 		{
 			desc:  "BEGIN RO staleness with PRIORITY statement",

--- a/statement_test.go
+++ b/statement_test.go
@@ -321,6 +321,16 @@ func TestBuildStatement(t *testing.T) {
 			},
 		},
 		{
+			desc:  "SET TRANSACTION READ ONLY statement",
+			input: "SET TRANSACTION READ ONLY",
+			want:  &SetTransactionStatement{IsReadOnly: true},
+		},
+		{
+			desc:  "SET TRANSACTION READ WRITE statement",
+			input: "SET TRANSACTION READ WRITE",
+			want:  &SetTransactionStatement{IsReadOnly: false},
+		},
+		{
 			desc:  "COMMIT statement",
 			input: "COMMIT",
 			want:  &CommitStatement{},

--- a/system_variables.go
+++ b/system_variables.go
@@ -249,15 +249,19 @@ var accessorMap = map[string]accessor{
 				return errors.New("can't set transaction tag in read-write transaction")
 			}
 
-			this.TransactionTag = unquoteString(value)
+			if this.CurrentSession.tc != nil {
+				return errors.New("there is no pending transaction")
+			}
+
+			this.CurrentSession.tc.tag = unquoteString(value)
 			return nil
 		},
 		Getter: func(this *systemVariables, name string) (map[string]string, error) {
-			if this.TransactionTag == "" {
-				return nil, errIgnored
+			if this.CurrentSession == nil || this.CurrentSession.tc != nil || this.CurrentSession.tc.tag == "" {
+				return singletonMap(name, ""), errIgnored
 			}
 
-			return singletonMap(name, this.TransactionTag), nil
+			return singletonMap(name, this.CurrentSession.tc.tag), nil
 		},
 	},
 	"STATEMENT_TAG": {

--- a/system_variables.go
+++ b/system_variables.go
@@ -241,15 +241,7 @@ var accessorMap = map[string]accessor{
 				return errors.New("invalid state: current session is not populated")
 			}
 
-			if this.CurrentSession.InReadOnlyTransaction() {
-				return errors.New("can't set transaction tag in read-only transaction")
-			}
-
-			if this.CurrentSession.InReadWriteTransaction() {
-				return errors.New("can't set transaction tag in read-write transaction")
-			}
-
-			if this.CurrentSession.tc != nil {
+			if !this.CurrentSession.InPendingTransaction() {
 				return errors.New("there is no pending transaction")
 			}
 
@@ -257,7 +249,7 @@ var accessorMap = map[string]accessor{
 			return nil
 		},
 		Getter: func(this *systemVariables, name string) (map[string]string, error) {
-			if this.CurrentSession == nil || this.CurrentSession.tc != nil || this.CurrentSession.tc.tag == "" {
+			if this.CurrentSession == nil || this.CurrentSession.tc == nil || this.CurrentSession.tc.tag == "" {
 				return singletonMap(name, ""), errIgnored
 			}
 


### PR DESCRIPTION
This PR implements Spanner JDBC driver style `BEGIN` and `SET TRANSACTION`.

- `SET TRANSACTION_TAG` is only valid in `BEGIN`.  
- Transaction mode is determined on the first operation or `SET TRANSACTION` or `READONLY` mode.