### PR TITLE
Implement CLI_PAGER and CLI_AUTOWRAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ You can control your Spanner databases with idiomatic SQL commands.
     * Allow newlines in prompt using `%n`
     * System variables expansion
     * Prompt2 with margin and waiting status
-  * Autowrap and auto adjust column width to fit within terminal width.
+  * Autowrap and auto adjust column width to fit within terminal width when `CLI_AUTOWRAP = TRUE`).
+  * Pager support when `CLI_USE_PAGER = TRUE`
   * Progress bar of DDL execution.
 * Utilize other libraries
   * Dogfooding [`cloudspannerecosystem/memefish`](https://github.com/cloudspannerecosystem/memefish)
@@ -521,6 +522,8 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | CLI_INSECURE              | READ_WRITE | `"FALSE"`                                      |
 | CLI_QUERY_MODE            | READ_WRITE | `"PROFILE"`                                    |
 | CLI_LINT_PLAN             | READ_WRITE | `"TRUE"`                                       |
+| CLI_USE_PAGER             | READ_WRITE | `"TRUE"`                                       |
+| CLI_AUTOWRAP              | READ_WRITE | `"TRUE"`                                       |
 
 ### Embedded Cloud Spanner Emulator
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hymkor/go-multiline-ny v0.17.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/k0kubun/pp/v3 v3.4.1
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/ngicks/go-iterator-helper v0.0.15
 	github.com/nyaosorg/go-readline-ny v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -923,6 +923,7 @@ github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/k0kubun/pp/v3 v3.4.1 h1:1WdFZDRRqe8UsR61N/2RoOZ3ziTEqgTPVqKrHeb779Y=
 github.com/k0kubun/pp/v3 v3.4.1/go.mod h1:+SiNiqKnBfw1Nkj82Lh5bIeKQOAkPy6Xw9CAZUZ8npI=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/system_variables.go
+++ b/system_variables.go
@@ -47,6 +47,7 @@ type systemVariables struct {
 	LintPlan                    bool
 	TransactionTag              string
 	RequestTag                  string
+	UsePager                    bool
 
 	// it is internal variable and hidden from system variable statements
 	ProtoDescriptor *descriptorpb.FileDescriptorSet
@@ -58,6 +59,7 @@ type systemVariables struct {
 	CurrentSession  *Session
 	ReadOnly        bool
 	VertexAIProject string
+	AutoWrap        bool
 }
 
 var errIgnored = errors.New("ignored")
@@ -453,6 +455,12 @@ var accessorMap = map[string]accessor{
 		}),
 		Setter: boolSetter(func(sysVars *systemVariables) *bool { return &sysVars.LintPlan }),
 	},
+	"CLI_USE_PAGER": boolAccessor(func(variables *systemVariables) *bool {
+		return &variables.UsePager
+	}),
+	"CLI_AUTOWRAP": boolAccessor(func(variables *systemVariables) *bool {
+		return &variables.AutoWrap
+	}),
 	"CLI_QUERY_MODE": {
 		Getter: func(this *systemVariables, name string) (map[string]string, error) {
 			if this.QueryMode == nil {
@@ -546,6 +554,13 @@ func stringSetter(f func(sysVars *systemVariables) *string) setter {
 		s := unquoteString(value)
 		*ref = s
 		return nil
+	}
+}
+
+func boolAccessor(f func(variables *systemVariables) *bool) accessor {
+	return accessor{
+		Setter: boolSetter(f),
+		Getter: boolGetter(f),
 	}
 }
 


### PR DESCRIPTION
This PR introdues `CLI_PAGER` and `CLI_AUTOWRAP` system variables
If you set `CLI_PAGER`, spanner-mycli uses `PAGER` environment variable.

## Breaking changes

- Autowrap is not default behavior (`CLI_AUTOWRAP` is false)