### PR TITLE
Support  PENDING_COMMIT_TIMESTAMP() in MUTATE statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,17 @@ spanner> SELECT """
 
 The default prompt2 is `%P%R> `.
 
+If you set only `%P` to `prompt2`, continuation prompt is only indentations.
+It is convenient because of copy-and-paste friendly.
+
+```
+spanner> SET CLI_PROMPT2 = "%P";
+Empty set (0.00 sec)
+
+spanner> SELECT """
+         test
+         """ AS s;
+```
 ## Config file
 
 This tool supports a configuration file called `spanner_mycli.cnf`, similar to `my.cnf`.  
@@ -724,6 +735,32 @@ Insert or update four rows with keys(`1, "foo"`, `1, "n"`, `1, "m"`, `50, "fooba
 
 ```
 MUTATE MutationTest2 INSERT_OR_UPDATE [STRUCT(1 AS PK1, "foo" AS PK2, 0 AS Col), (1, "n", 1), (1, "m", 3), (50, "foobar", 4)];
+```
+
+You can set commit timestamps using `PENDING_COMMIT_TIMESTAMP()`.
+```
+spanner> MUTATE Performances INSERT_OR_UPDATE STRUCT(
+                1 AS SingerId, 1 AS VenueId,
+                DATE "2024-12-25" AS EventDate,
+                PENDING_COMMIT_TIMESTAMP() AS LastUpdateTime);
+Query OK, 0 rows affected (1.18 sec)
+timestamp:      2024-12-13T02:40:46.253698+09:00
+mutation_count: 4
+
+spanner> SELECT * FROM Performances;
++----------+---------+------------+---------+-----------------------------+
+| SingerId | VenueId | EventDate  | Revenue | LastUpdateTime              |
+| INT64    | INT64   | DATE       | INT64   | TIMESTAMP                   |
++----------+---------+------------+---------+-----------------------------+
+| 1        | 1       | 2024-12-25 | NULL    | 2024-12-12T17:40:46.253698Z |
++----------+---------+------------+---------+-----------------------------+
+1 rows in set (14.89 msecs)
+timestamp:            2024-12-13T02:40:57.15133+09:00
+cpu time:             13.35 msecs
+rows scanned:         1 rows
+deleted rows scanned: 0 rows
+optimizer version:    7
+optimizer statistics: auto_20241212_12_01_00UTC
 ```
 
 ##### Examples of Delete mutations

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/apstndb/go-spannulls v0.0.0-20241108213137-ec54277850d4
 	github.com/apstndb/gsqlutils v0.0.0-20241110011021-695697146792
 	github.com/apstndb/lox v0.0.0-20241102092239-40172f618f5c
-	github.com/apstndb/memebridge v0.0.0-20241123172322-a745771fe5be
+	github.com/apstndb/memebridge v0.0.0-20241212165435-0d019ccfde0a
 	github.com/apstndb/spannerplanviz v0.3.2
-	github.com/apstndb/spantype v0.3.2
+	github.com/apstndb/spantype v0.3.4
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e
 	github.com/cloudspannerecosystem/memefish v0.0.0-20241203074241-66dfc61aa2dd
 	github.com/go-json-experiment/json v0.0.0-20241127185351-9802db03f36a

--- a/go.sum
+++ b/go.sum
@@ -668,10 +668,14 @@ github.com/apstndb/lox v0.0.0-20241102092239-40172f618f5c h1:qY6RWLulQDcbGy18LT3
 github.com/apstndb/lox v0.0.0-20241102092239-40172f618f5c/go.mod h1:PbqzTjsPq7Xhn8D7Vk8g/em15kd8vvEL1Y2xkI9CgGs=
 github.com/apstndb/memebridge v0.0.0-20241123172322-a745771fe5be h1:nkxHsdoFzh9mSoXMN7SA/9dsjnmqYCH3+V1GNLsOtaM=
 github.com/apstndb/memebridge v0.0.0-20241123172322-a745771fe5be/go.mod h1:FaufbBYU/dQaQChu/b62igLoLJmT2Qj8lPEdbxRls2c=
+github.com/apstndb/memebridge v0.0.0-20241212165435-0d019ccfde0a h1:kUx1T7uOj9+j9dk3IlhMWYPHxnbjR1ZO7nlDBPAj12g=
+github.com/apstndb/memebridge v0.0.0-20241212165435-0d019ccfde0a/go.mod h1:cnE5c3secrDTWIUV4SDHfm+xLpfOXbLKsQ/K0oX5kj0=
 github.com/apstndb/spannerplanviz v0.3.2 h1:AeTNTdE05+7T4HWPV1yjLSYCbr51ZugtR3KCkw5SAD0=
 github.com/apstndb/spannerplanviz v0.3.2/go.mod h1:/tY1Y1tLTp3Czj9BI2/M02W3P/wJgmKwuDS5zARLhvc=
 github.com/apstndb/spantype v0.3.2 h1:QScfFNjW0KoPcqnn3tSZ15p+cRDVF0u6g/KJIqQNWuM=
 github.com/apstndb/spantype v0.3.2/go.mod h1:zn3qR4ebyy3HumRKRG0COMRSf4tmaR1HptQwe7/Xu7g=
+github.com/apstndb/spantype v0.3.4 h1:DJWbjfQyBLRiLWXe3RllAyCZaF1m6lvbIuui+esKNaU=
+github.com/apstndb/spantype v0.3.4/go.mod h1:zn3qR4ebyy3HumRKRG0COMRSf4tmaR1HptQwe7/Xu7g=
 github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e h1:uWViNQM3/1RPtJcw6+4l3XHAm4uCWCWe0xVQvpXj8mM=
 github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e/go.mod h1:NV6r4opNnDtM+cU6IjbMyAtNbV/oIX8X9xknIGJ1B8k=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/integration_test.go
+++ b/integration_test.go
@@ -52,7 +52,7 @@ import (
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 
 	// Use dot import to simplify tests
-	. "github.com/apstndb/spantype/testutil"
+	. "github.com/apstndb/spantype/typector"
 	"github.com/testcontainers/testcontainers-go/modules/gcloud"
 	"spheric.cloud/xiter"
 )


### PR DESCRIPTION
This PR add support of `PENDING_COMMIT_TIMESTAMP()` in `MUTATE`.

Note: This PR includes some description of `CLI_PROMPT2`.

There is no breaking changes.