### PR TITLE
Some refactor and bump spanemuboost

### DIFF
--- a/execute_sql.go
+++ b/execute_sql.go
@@ -202,7 +202,7 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 	var rows []Row
 	var columnNames []string
 	affected, commitResp, _, metadata, err := session.RunInNewOrExistRwTx(ctx, func() (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error) {
-		rs, columns, num, meta, err := session.RunUpdate(ctx, stmt, false)
+		rs, columns, num, meta, err := session.RunUpdate(ctx, stmt)
 		rows = rs
 		columnNames = columns
 		return num, nil, meta, err

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apstndb/gsqlutils v0.0.0-20241110011021-695697146792
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.0.0-20241212165435-0d019ccfde0a
-	github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0
+	github.com/apstndb/spanemuboost v0.1.0
 	github.com/apstndb/spannerplanviz v0.3.2
 	github.com/apstndb/spantype v0.3.4
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apstndb/gsqlutils v0.0.0-20241110011021-695697146792
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.0.0-20241212165435-0d019ccfde0a
-	github.com/apstndb/spanemuboost v0.0.0-20241212224516-c930dae5e547
+	github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0
 	github.com/apstndb/spannerplanviz v0.3.2
 	github.com/apstndb/spantype v0.3.4
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e

--- a/go.sum
+++ b/go.sum
@@ -672,6 +672,8 @@ github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10 h1:Ea5al1Su3Z
 github.com/apstndb/spanemuboost v0.0.0-20241212215948-d4eb945c8f10/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
 github.com/apstndb/spanemuboost v0.0.0-20241212224516-c930dae5e547 h1:AMGzRKfgfJNjTdRKvNOmtBqzvNu7NjcpMLO3HdAvdVg=
 github.com/apstndb/spanemuboost v0.0.0-20241212224516-c930dae5e547/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
+github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0 h1:GTpRSSkLvjBsQsgCdHeUzBqEFSb4NDbI5ypvXxq8oPo=
+github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
 github.com/apstndb/spannerplanviz v0.3.2 h1:AeTNTdE05+7T4HWPV1yjLSYCbr51ZugtR3KCkw5SAD0=
 github.com/apstndb/spannerplanviz v0.3.2/go.mod h1:/tY1Y1tLTp3Czj9BI2/M02W3P/wJgmKwuDS5zARLhvc=
 github.com/apstndb/spantype v0.3.4 h1:DJWbjfQyBLRiLWXe3RllAyCZaF1m6lvbIuui+esKNaU=

--- a/go.sum
+++ b/go.sum
@@ -674,6 +674,8 @@ github.com/apstndb/spanemuboost v0.0.0-20241212224516-c930dae5e547 h1:AMGzRKfgfJ
 github.com/apstndb/spanemuboost v0.0.0-20241212224516-c930dae5e547/go.mod h1:JtIpejiunpnBufWCwhEun+ayfd0JWnPp9kqbcNJkU+E=
 github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0 h1:GTpRSSkLvjBsQsgCdHeUzBqEFSb4NDbI5ypvXxq8oPo=
 github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
+github.com/apstndb/spanemuboost v0.1.0 h1:NApvbBG5UBT+ebSMaEjcc9vjA/1Adn3E+9/NePpTwU8=
+github.com/apstndb/spanemuboost v0.1.0/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
 github.com/apstndb/spannerplanviz v0.3.2 h1:AeTNTdE05+7T4HWPV1yjLSYCbr51ZugtR3KCkw5SAD0=
 github.com/apstndb/spannerplanviz v0.3.2/go.mod h1:/tY1Y1tLTp3Czj9BI2/M02W3P/wJgmKwuDS5zARLhvc=
 github.com/apstndb/spantype v0.3.4 h1:DJWbjfQyBLRiLWXe3RllAyCZaF1m6lvbIuui+esKNaU=

--- a/session_slow_test.go
+++ b/session_slow_test.go
@@ -1,0 +1,174 @@
+//go:build !skip_slow_test
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apstndb/spanemuboost"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+)
+
+func TestRequestPriority(t *testing.T) {
+	const (
+		project  = "project"
+		instance = "instance"
+		database = "database"
+	)
+
+	ctx := context.Background()
+
+	emulator, teardown, err := spanemuboost.NewEmulator(ctx,
+		spanemuboost.WithProjectID(project),
+		spanemuboost.WithInstanceID(instance),
+		spanemuboost.WithDatabaseID(database),
+		spanemuboost.WithSetupDDLs(sliceOf("CREATE TABLE t1 (Id INT64) PRIMARY KEY (Id)")),
+	)
+	if err != nil {
+		t.Fatalf("failed to start emulator: %v", err)
+	}
+	defer teardown()
+
+	var recorder requestRecorder
+	unaryInterceptor, streamInterceptor := recordRequestsInterceptors(&recorder)
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(unaryInterceptor),
+		grpc.WithStreamInterceptor(streamInterceptor),
+	}
+	conn, err := grpc.NewClient(emulator.URI, opts...)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	for _, test := range []struct {
+		desc                string
+		sessionPriority     sppb.RequestOptions_Priority
+		transactionPriority sppb.RequestOptions_Priority
+		want                sppb.RequestOptions_Priority
+	}{
+		{
+			desc:                "use default priority",
+			sessionPriority:     sppb.RequestOptions_PRIORITY_UNSPECIFIED,
+			transactionPriority: sppb.RequestOptions_PRIORITY_UNSPECIFIED,
+			want:                sppb.RequestOptions_PRIORITY_UNSPECIFIED,
+		},
+		{
+			desc:                "use session priority",
+			sessionPriority:     sppb.RequestOptions_PRIORITY_LOW,
+			transactionPriority: sppb.RequestOptions_PRIORITY_UNSPECIFIED,
+			want:                sppb.RequestOptions_PRIORITY_LOW,
+		},
+		{
+			desc:                "use transaction priority",
+			sessionPriority:     sppb.RequestOptions_PRIORITY_UNSPECIFIED,
+			transactionPriority: sppb.RequestOptions_PRIORITY_HIGH,
+			want:                sppb.RequestOptions_PRIORITY_HIGH,
+		},
+		{
+			desc:                "transaction priority takes over session priority",
+			sessionPriority:     sppb.RequestOptions_PRIORITY_HIGH,
+			transactionPriority: sppb.RequestOptions_PRIORITY_LOW,
+			want:                sppb.RequestOptions_PRIORITY_LOW,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			defer recorder.flush()
+
+			session, err := NewSession(ctx, &systemVariables{
+				Project:     project,
+				Instance:    instance,
+				Database:    database,
+				RPCPriority: test.sessionPriority,
+				Role:        "role",
+			}, option.WithGRPCConn(conn))
+			if err != nil {
+				t.Fatalf("failed to create spanner-cli session: %v", err)
+			}
+
+			// Read-Write Transaction.
+			if err := session.BeginReadWriteTransaction(ctx, test.transactionPriority); err != nil {
+				t.Fatalf("failed to begin read write transaction: %v", err)
+			}
+			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
+			if err := iter.Do(func(r *spanner.Row) error {
+				return nil
+			}); err != nil {
+				t.Fatalf("failed to run query: %v", err)
+			}
+			if _, _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1")); err != nil {
+				t.Fatalf("failed to run update: %v", err)
+			}
+			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {
+				t.Fatalf("failed to commit: %v", err)
+			}
+
+			// Read-Only Transaction.
+			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority); err != nil {
+				t.Fatalf("failed to begin read only transaction: %v", err)
+			}
+			iter, _ = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"))
+			if err := iter.Do(func(r *spanner.Row) error {
+				return nil
+			}); err != nil {
+				t.Fatalf("failed to run query with stats: %v", err)
+			}
+			if err := session.CloseReadOnlyTransaction(); err != nil {
+				t.Fatalf("failed to close read only transaction: %v", err)
+			}
+
+			// Check request priority.
+			for _, r := range recorder.requests {
+				switch v := r.(type) {
+				case *sppb.ExecuteSqlRequest:
+					if got := v.GetRequestOptions().GetPriority(); got != test.want {
+						t.Errorf("priority mismatch: got = %v, want = %v", got, test.want)
+					}
+				case *sppb.CommitRequest:
+					if got := v.GetRequestOptions().GetPriority(); got != test.want {
+						t.Errorf("priority mismatch: got = %v, want = %v", got, test.want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// requestRecorder is a recorder to retain gRPC requests for spannertest.Server.
+type requestRecorder struct {
+	requests []interface{}
+}
+
+func (r *requestRecorder) flush() {
+	r.requests = nil
+}
+
+func recordRequestsInterceptors(recorder *requestRecorder) (grpc.UnaryClientInterceptor, grpc.StreamClientInterceptor) {
+	unary := func(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		recorder.requests = append(recorder.requests, req)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+	stream := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		s, err := streamer(ctx, desc, cc, method, opts...)
+		return &recordRequestsStream{recorder, s}, err
+	}
+	return unary, stream
+}
+
+type recordRequestsStream struct {
+	recorder *requestRecorder
+	grpc.ClientStream
+}
+
+func (s *recordRequestsStream) SendMsg(m interface{}) error {
+	s.recorder.requests = append(s.recorder.requests, m)
+	return s.ClientStream.SendMsg(m)
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1,146 +1,13 @@
 package main
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"github.com/apstndb/spanemuboost"
-	"google.golang.org/grpc/credentials/insecure"
-
-	"cloud.google.com/go/spanner"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
-
-func TestRequestPriority(t *testing.T) {
-	const (
-		project  = "project"
-		instance = "instance"
-		database = "database"
-	)
-
-	ctx := context.Background()
-
-	emulator, teardown, err := spanemuboost.NewEmulator(ctx,
-		spanemuboost.WithProjectID(project),
-		spanemuboost.WithInstanceID(instance),
-		spanemuboost.WithDatabaseID(database),
-		spanemuboost.WithSetupDDLs(sliceOf("CREATE TABLE t1 (Id INT64) PRIMARY KEY (Id)")),
-	)
-	if err != nil {
-		t.Fatalf("failed to start emulator: %v", err)
-	}
-	defer teardown()
-
-	var recorder requestRecorder
-	unaryInterceptor, streamInterceptor := recordRequestsInterceptors(&recorder)
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(unaryInterceptor),
-		grpc.WithStreamInterceptor(streamInterceptor),
-	}
-	conn, err := grpc.NewClient(emulator.URI, opts...)
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
-	}
-
-	for _, test := range []struct {
-		desc                string
-		sessionPriority     sppb.RequestOptions_Priority
-		transactionPriority sppb.RequestOptions_Priority
-		want                sppb.RequestOptions_Priority
-	}{
-		{
-			desc:                "use default priority",
-			sessionPriority:     sppb.RequestOptions_PRIORITY_UNSPECIFIED,
-			transactionPriority: sppb.RequestOptions_PRIORITY_UNSPECIFIED,
-			want:                sppb.RequestOptions_PRIORITY_UNSPECIFIED,
-		},
-		{
-			desc:                "use session priority",
-			sessionPriority:     sppb.RequestOptions_PRIORITY_LOW,
-			transactionPriority: sppb.RequestOptions_PRIORITY_UNSPECIFIED,
-			want:                sppb.RequestOptions_PRIORITY_LOW,
-		},
-		{
-			desc:                "use transaction priority",
-			sessionPriority:     sppb.RequestOptions_PRIORITY_UNSPECIFIED,
-			transactionPriority: sppb.RequestOptions_PRIORITY_HIGH,
-			want:                sppb.RequestOptions_PRIORITY_HIGH,
-		},
-		{
-			desc:                "transaction priority takes over session priority",
-			sessionPriority:     sppb.RequestOptions_PRIORITY_HIGH,
-			transactionPriority: sppb.RequestOptions_PRIORITY_LOW,
-			want:                sppb.RequestOptions_PRIORITY_LOW,
-		},
-	} {
-		t.Run(test.desc, func(t *testing.T) {
-			defer recorder.flush()
-
-			session, err := NewSession(ctx, &systemVariables{
-				Project:     project,
-				Instance:    instance,
-				Database:    database,
-				RPCPriority: test.sessionPriority,
-				Role:        "role",
-			}, option.WithGRPCConn(conn))
-			if err != nil {
-				t.Fatalf("failed to create spanner-cli session: %v", err)
-			}
-
-			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(ctx, test.transactionPriority); err != nil {
-				t.Fatalf("failed to begin read write transaction: %v", err)
-			}
-			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
-			if err := iter.Do(func(r *spanner.Row) error {
-				return nil
-			}); err != nil {
-				t.Fatalf("failed to run query: %v", err)
-			}
-			if _, _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), true); err != nil {
-				t.Fatalf("failed to run update: %v", err)
-			}
-			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {
-				t.Fatalf("failed to commit: %v", err)
-			}
-
-			// Read-Only Transaction.
-			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority); err != nil {
-				t.Fatalf("failed to begin read only transaction: %v", err)
-			}
-			iter, _ = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"))
-			if err := iter.Do(func(r *spanner.Row) error {
-				return nil
-			}); err != nil {
-				t.Fatalf("failed to run query with stats: %v", err)
-			}
-			if err := session.CloseReadOnlyTransaction(); err != nil {
-				t.Fatalf("failed to close read only transaction: %v", err)
-			}
-
-			// Check request priority.
-			for _, r := range recorder.requests {
-				switch v := r.(type) {
-				case *sppb.ExecuteSqlRequest:
-					if got := v.GetRequestOptions().GetPriority(); got != test.want {
-						t.Errorf("priority mismatch: got = %v, want = %v", got, test.want)
-					}
-				case *sppb.CommitRequest:
-					if got := v.GetRequestOptions().GetPriority(); got != test.want {
-						t.Errorf("priority mismatch: got = %v, want = %v", got, test.want)
-					}
-				}
-			}
-		})
-	}
-}
 
 func TestParseDirectedReadOption(t *testing.T) {
 	for _, tt := range []struct {
@@ -212,35 +79,4 @@ func TestParseDirectedReadOption(t *testing.T) {
 			}
 		})
 	}
-}
-
-// requestRecorder is a recorder to retain gRPC requests for spannertest.Server.
-type requestRecorder struct {
-	requests []interface{}
-}
-
-func (r *requestRecorder) flush() {
-	r.requests = nil
-}
-
-func recordRequestsInterceptors(recorder *requestRecorder) (grpc.UnaryClientInterceptor, grpc.StreamClientInterceptor) {
-	unary := func(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		recorder.requests = append(recorder.requests, req)
-		return invoker(ctx, method, req, reply, cc, opts...)
-	}
-	stream := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		s, err := streamer(ctx, desc, cc, method, opts...)
-		return &recordRequestsStream{recorder, s}, err
-	}
-	return unary, stream
-}
-
-type recordRequestsStream struct {
-	recorder *requestRecorder
-	grpc.ClientStream
-}
-
-func (s *recordRequestsStream) SendMsg(m interface{}) error {
-	s.recorder.requests = append(s.recorder.requests, m)
-	return s.ClientStream.SendMsg(m)
 }


### PR DESCRIPTION
* Do some refactor to suppress golangci-lint.
* Drop spannertest support.
  * `useUpdate` flag of `(*Session).RunUpdate()` is dropped. It always use `QueryWithOptions`. 
* Spin out slow test in `session_test.go` 
* Bump spanemuboost v0.1.0

## Breaking changes

* spanrer-mycli doesn't support spannertest anymore.
* (I think handy-spanner is already not supported)
  * https://github.com/gcpug/handy-spanner/issues/92