### PR TITLE
Share Spanner Emulator in integration test using spanemuboost v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apstndb/gsqlutils v0.0.0-20241110011021-695697146792
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.0.0-20241212165435-0d019ccfde0a
-	github.com/apstndb/spanemuboost v0.1.0
+	github.com/apstndb/spanemuboost v0.2.2
 	github.com/apstndb/spannerplanviz v0.3.2
 	github.com/apstndb/spantype v0.3.4
 	github.com/apstndb/spanvalue v0.0.0-20241103175520-dc3408b8d84e

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,10 @@ github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0 h1:GTpRSSkLvj
 github.com/apstndb/spanemuboost v0.0.0-20241212232326-bcfa9a934cf0/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
 github.com/apstndb/spanemuboost v0.1.0 h1:NApvbBG5UBT+ebSMaEjcc9vjA/1Adn3E+9/NePpTwU8=
 github.com/apstndb/spanemuboost v0.1.0/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
+github.com/apstndb/spanemuboost v0.2.1 h1:UBpSDnvpqtIPjRoY3uzmpHuwk0wRWrZAZNh9M6fychE=
+github.com/apstndb/spanemuboost v0.2.1/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
+github.com/apstndb/spanemuboost v0.2.2 h1:xMloqUx++7TVjKkLwJjvtD9q8feMdY+HgcEd7g2cfzg=
+github.com/apstndb/spanemuboost v0.2.2/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
 github.com/apstndb/spannerplanviz v0.3.2 h1:AeTNTdE05+7T4HWPV1yjLSYCbr51ZugtR3KCkw5SAD0=
 github.com/apstndb/spannerplanviz v0.3.2/go.mod h1:/tY1Y1tLTp3Czj9BI2/M02W3P/wJgmKwuDS5zARLhvc=
 github.com/apstndb/spantype v0.3.4 h1:DJWbjfQyBLRiLWXe3RllAyCZaF1m6lvbIuui+esKNaU=

--- a/integration_test.go
+++ b/integration_test.go
@@ -815,9 +815,9 @@ func TestShowCreateTable(t *testing.T) {
 
 	compareResult(t, result, &Result{
 		ColumnNames: []string{"Table", "Create Table"},
-		Rows: []Row{
-			{[]string{"tbl", fmt.Sprintf("CREATE TABLE tbl (\n  id INT64 NOT NULL,\n  active BOOL NOT NULL,\n) PRIMARY KEY(id)")}},
-		},
+		Rows: sliceOf(
+			toRow("tbl", "CREATE TABLE tbl (\n  id INT64 NOT NULL,\n  active BOOL NOT NULL,\n) PRIMARY KEY(id)"),
+		),
 		AffectedRows: 1,
 		IsMutation:   false,
 	})


### PR DESCRIPTION
This PR refactor `integration_test.go`.

* Share Spanner Emulator container among test cases
* Test cases uses their own database.
  * It is a recommended setup of [cloud-spanner-emulator](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator?tab=readme-ov-file#what-is-the-recommended-test-setup).
    > What is the recommended test setup?
    > Use a single emulator process and create a Cloud Spanner instance within it. Since creating databases is cheap in the emulator, we recommend that each test bring up and tear down its own database. This ensures hermetic testing and allows the test suite to run tests in parallel if needed.
* Remove `generateUniqueTableId` based logics

There is no breaking changes.