### PR TITLE
Implement SYNC PROTO BUNDLE statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ Query OK, 0 rows affected (8.27 sec)
 
 ##### `SYNC PROTO BUNDLE DELETE`
 
-`SYNC PROTO BUNDLE DELETE (<full_name>, ...)` executes `PROTO BUNDLE DELETE` only existing types.
+`SYNC PROTO BUNDLE DELETE (<full_name>, ...)` executes `PROTO BUNDLE DELETE` only existing types(`DELETE IF EXISTS` semantics).
 ```
 spanner> SHOW REMOTE PROTO;
 +--------------------------------+-------+-------------------+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can control your Spanner databases with idiomatic SQL commands.
 ## Differences from original spanner-cli
 
 * Respects my minor use cases
-  * `SHOW LOCAL PROTO` and `SHOW REMOTE PROTO` statement
+  * Protocol Buffere support as `SHOW LOCAL PROTO`, `SHOW REMOTE PROTO`, `SYNC PROTO BUNDLE` statement
   * Can use embedded emulator (`--embedded-emulator`)
   * Support [query parameters](#query-parameter-support)
   * Test root-partitionable with [`TRY PARTITIONED QUERY <sql>` command](#test-root-partitionable)
@@ -285,6 +285,7 @@ and `{}` for a mutually exclusive keyword.
 | Query | `SELECT ...;`                                                                                  | |
 | DML | `{INSERT\|UPDATE\|DELETE} ...;`                                                                | |
 | Partitioned DML | `PARTITIONED {UPDATE\|DELETE} ...;`                                                            | |
+| Manipulate PROTO BUNDLE | `SYNC PROTO BUNDLE [{UPSERT\|DELETE} (<type> ...)];`                                                                            | |
 | Show local proto descriptors | `SHOW LOCAL PROTO;`                                                                            | |
 | Show remote proto bundle | `SHOW REMOTE PROTO;`                                                                           | |
 | Show Query Execution Plan | `EXPLAIN SELECT ...;`                                                                          | |
@@ -688,6 +689,104 @@ spanner> SHOW LOCAL PROTO;
 | examples.shipping.OrderHistory  | PROTO | examples.shipping | order_protos.proto |
 +---------------------------------+-------+-------------------+--------------------+
 4 rows in set (0.00 sec)
+```
+
+#### `SYNC PROTO BUNDLE` statement
+
+
+Note: `SET CLI_ECHO_EXECUTED_DDL = TRUE` enables echo back of actual executed DDLs.
+
+```
+spanner> SET CLI_ECHO_EXECUTED_DDL = TRUE;
+Empty set (0.00 sec)
+```
+
+##### `SYNC PROTO BUNDLE UPSERT`
+
+`SYNC PROTO BUNDLE UPSERT (FullName, ...)` simplifies use of `CREATE PROTO BUNDLE` and `ALTER PROTO BUNDLE {INSERT|UPDATE}`.
+
+`SYNC PROTO BUNDLE` executes `ALTER PROTO BUNDLE INSERT` or `ALTER PROTO BUNDLE UPDATE` in `UPSERT` semantics.
+
+```
+spanner> SHOW REMOTE PROTO;
++-------------------------+-------+-------------------+
+| full_name               | kind  | package           |
++-------------------------+-------+-------------------+
+| examples.shipping.Order | PROTO | examples.shipping |
++-------------------------+-------+-------------------+
+1 rows in set (0.87 sec)
+
+spanner> SYNC PROTO BUNDLE UPSERT (`examples.shipping.Order`, examples.shipping.OrderHistory);
++------------------------------------------------------------------------------------------------+
+| executed                                                                                       |
++------------------------------------------------------------------------------------------------+
+| ALTER PROTO BUNDLE INSERT (examples.shipping.OrderHistory) UPDATE (examples.shipping.`Order`); |
++------------------------------------------------------------------------------------------------+
+Query OK, 0 rows affected (8.57 sec)
+
+```
+
+If `SYNC PROTO BUNDLE UPSERT` is executed on empty proto bundle,
+`CREATE PROTO BUNDLE` will be executed instead of `ALTER PROTO BUNDLE`.
+
+```
+spanner> SHOW REMOTE PROTO;
+Empty set (0.89 sec)
+
+spanner> SYNC PROTO BUNDLE UPSERT (`examples.shipping.Order`);
++--------------------------------------------------+
+| executed                                         |
++--------------------------------------------------+
+| CREATE PROTO BUNDLE (examples.shipping.`Order`); |
++--------------------------------------------------+
+Query OK, 0 rows affected (8.27 sec)
+```
+
+##### `SYNC PROTO BUNDLE DELETE`
+
+`SYNC PROTO BUNDLE DELETE (<full_name>, ...)` executes `PROTO BUNDLE DELETE` only existing types.
+```
+spanner> SHOW REMOTE PROTO;
++--------------------------------+-------+-------------------+
+| full_name                      | kind  | package           |
++--------------------------------+-------+-------------------+
+| examples.shipping.Order        | PROTO | examples.shipping |
+| examples.shipping.OrderHistory | PROTO | examples.shipping |
++--------------------------------+-------+-------------------+
+2 rows in set (0.87 sec)
+
+spanner> SYNC PROTO BUNDLE DELETE (`examples.shipping.Order`, examples.UnknownType);
++--------------------------------------------------------+
+| executed                                               |
++--------------------------------------------------------+
+| ALTER PROTO BUNDLE DELETE (examples.shipping.`Order`); |
++--------------------------------------------------------+
+Query OK, 0 rows affected (8.86 sec)
+
+spanner> SYNC PROTO BUNDLE DELETE (examples.UnknownType);
+Query OK, 0 rows affected (0.79 sec)
+```
+
+If `SYNC PROTO BUNDLE DELETE` will delete the last Protocol Buffers type in the proto bundle,
+`DROP PROTO BUNDLE` will be executed instead of `ALTER PROTO BUNDLE`.
+
+```
+spanner> SHOW REMOTE PROTO;
+
++-------------------------+-------+-------------------+
+| full_name               | kind  | package           |
++-------------------------+-------+-------------------+
+| examples.shipping.Order | PROTO | examples.shipping |
++-------------------------+-------+-------------------+
+1 rows in set (0.87 sec)
+
+spanner> SYNC PROTO BUNDLE DELETE (`examples.shipping.OrderHistory`);
++--------------------+
+| executed           |
++--------------------+
+| DROP PROTO BUNDLE; |
++--------------------+
+Query OK, 0 rows affected (8.24 sec)
 ```
 
 ### memefish integration

--- a/cli.go
+++ b/cli.go
@@ -312,6 +312,10 @@ func (c *Cli) RunInteractive(ctx context.Context) int {
 			disableSpinner = true
 		}
 
+		if _, ok := stmt.(*SyncProtoStatement); ok {
+			disableSpinner = true
+		}
+
 		if _, ok := stmt.(*BulkDdlStatement); ok {
 			disableSpinner = true
 		}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"maps"
 	"os"
 	"os/user"
@@ -116,10 +115,12 @@ func getVersion() string {
 
 // Overwrite genkit/logger's init
 func init() {
-	h := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelWarn,
-	}))
-	slog.SetDefault(h)
+	/*
+		h := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelWarn,
+		}))
+		slog.SetDefault(h)
+	*/
 }
 
 func main() {

--- a/memefish.go
+++ b/memefish.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/ngicks/go-iterator-helper/x/exp/xiter"
+	xiter2 "spheric.cloud/xiter"
+)
+
+func toNamedType(fullName string) *ast.NamedType {
+	return &ast.NamedType{Path: slices.Collect(xiter.Map(
+		func(s string) *ast.Ident {
+			return &ast.Ident{Name: s}
+		},
+		slices.Values(strings.Split(fullName, ".")))),
+	}
+}
+
+func toNamedTypes(fullNames []string) []*ast.NamedType {
+	return slices.Collect(xiter.Map(toNamedType, slices.Values(fullNames)))
+}
+
+func exprToFullName(expr ast.Expr) (string, error) {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name, nil
+	case *ast.Path:
+		return xiter2.Join(xiter.Map(func(ident *ast.Ident) string { return ident.Name }, slices.Values(e.Idents)), "."), nil
+	default:
+		return "", fmt.Errorf("must be ident or path, but: %T", expr)
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	_ "embed"
 	"testing"
 
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
-
-	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 )
 
 func TestParseDirectedReadOption(t *testing.T) {

--- a/system_variables.go
+++ b/system_variables.go
@@ -68,6 +68,7 @@ type systemVariables struct {
 	ReadOnly        bool
 	VertexAIProject string
 	AutoWrap        bool
+	EchoExecutedDDL bool
 }
 
 var errIgnored = errors.New("ignored")
@@ -342,6 +343,17 @@ var accessorMap = map[string]accessor{
 				return err
 			}
 			this.Verbose = b
+			return nil
+		},
+	},
+	"CLI_ECHO_EXECUTED_DDL": {
+		Getter: boolGetter(func(sysVars *systemVariables) *bool { return &sysVars.EchoExecutedDDL }),
+		Setter: func(this *systemVariables, name, value string) error {
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+			this.EchoExecutedDDL = b
 			return nil
 		},
 	},


### PR DESCRIPTION
This PR implements `SYNC PROTO BUNDLE` statement with `UPSERT` and `DELETE` (`IF EXISTS`) semantics.

Detailed spec is written in README.md.
```
spanner> SYNC PROTO BUNDLE UPSERT (`examples.shipping.Order`, examples.shipping.OrderHistory);
+------------------------------------------------------------------------------------------------+
| executed                                                                                       |
+------------------------------------------------------------------------------------------------+
| ALTER PROTO BUNDLE INSERT (examples.shipping.OrderHistory) UPDATE (examples.shipping.`Order`); |
+------------------------------------------------------------------------------------------------+
Query OK, 0 rows affected (8.57 sec)

spanner> SYNC PROTO BUNDLE DELETE (`examples.shipping.Order`, examples.UnknownType);
+--------------------------------------------------------+
| executed                                               |
+--------------------------------------------------------+
| ALTER PROTO BUNDLE DELETE (examples.shipping.`Order`); |
+--------------------------------------------------------+
Query OK, 0 rows affected (8.86 sec)
```

There is no breaking changes.

- part of #23 