### PR TITLE
Use mpb.BarRemoveOnComplete and show progress bar only in interactive mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -343,6 +343,7 @@ func main() {
 
 	exitCode := lo.TernaryF(interactive,
 		func() int {
+			sysVars.EnableProgressBar = true
 			return cli.RunInteractive(ctx)
 		},
 		func() int {

--- a/system_variables.go
+++ b/system_variables.go
@@ -66,11 +66,15 @@ type systemVariables struct {
 	Params          map[string]ast.Node
 
 	// link to session
-	CurrentSession  *Session
+	CurrentSession *Session
+
 	ReadOnly        bool
 	VertexAIProject string
 	AutoWrap        bool
 	EchoExecutedDDL bool
+
+	// TODO: Expose as CLI_*
+	EnableProgressBar bool
 }
 
 var errIgnored = errors.New("ignored")


### PR DESCRIPTION
This PR improve progress bar control.

- Progress bars are removed on complete process
- Progress bar is only shown in interactive mode.