### PR TITLE
Support interactive DDL batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ and `{}` for a mutually exclusive keyword.
 | Show partition tokens of partition query | `PARTITION <sql>` ||
 | Perform write mutations | `MUTATE <table_fqn> {INSERT\|UPDATE\|REPLACE\|INSERT_OR_UPDATE} ...`||
 | Perform delete mutations | `MUTATE <table_fqn> DELETE ...`||
+| Start batch | `START BATCH DDL`||
+| Run active batch| `RUN BATCH`||
+| Abort active batch | `ABORT BATCH [TRANSACTION]`||
 | Exit CLI | `EXIT;`                                                                                        | |
 | Show variable | `SHOW VARIABLE <name>;`                                                                        | |
 | Set variable | `SET <name> = <value>;`                                                                        | |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can control your Spanner databases with idiomatic SQL commands.
   * Support [query parameters](#query-parameter-support)
   * Test root-partitionable with [`TRY PARTITIONED QUERY <sql>` command](#test-root-partitionable)
   * GenAI support(`GEMINI` statement).
+  * Interactive DDL batching
 * Respects training and verification use-cases.
   * gRPC logging(`--log-grpc`)
   * Support mutations
@@ -541,6 +542,41 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | CLI_USE_PAGER             | READ_WRITE | `"TRUE"`                                       |
 | CLI_AUTOWRAP              | READ_WRITE | `"TRUE"`                                       |
 | CLI_DATABASE_DIALECT      | READ_WRITE | `"TRUE"`                                       |
+
+### Batch statements
+
+You can batch DDL statements.
+
+Note: `SET CLI_ECHO_EXECUTED_DDL = TRUE` enables echo back of actual executed DDLs.
+
+```
+spanner> START BATCH DDL;
+Empty set (0.00 sec)
+
+spanner> DROP INDEX IF EXISTS BatchExampleByCol;
+Query OK, 0 rows affected (0.00 sec) (1 DDL in batch)
+
+spanner> DROP TABLE IF EXISTS BatchExample;
+Query OK, 0 rows affected (0.00 sec) (2 DDLs in batch)
+
+spanner> CREATE TABLE BatchExample (PK INT64 PRIMARY KEY, Col INT64);
+Query OK, 0 rows affected (0.00 sec) (3 DDLs in batch)
+
+spanner> CREATE INDEX BatchExampleByCol ON BatchExample(Col);
+Query OK, 0 rows affected (0.00 sec) (4 DDLs in batch)
+
+spanner> RUN BATCH;
++--------------------------------------------------------------+
+| executed                                                     |
++--------------------------------------------------------------+
+| DROP INDEX IF EXISTS BatchExampleByCol;                      |
+| DROP TABLE IF EXISTS BatchExample;                           |
+| CREATE TABLE BatchExample (PK INT64 PRIMARY KEY, Col INT64); |
+| CREATE INDEX BatchExampleByCol ON BatchExample(Col);         |
++--------------------------------------------------------------+
+Query OK, 0 rows affected (8.40 sec)
+timestamp:      2024-12-28T14:39:44.766959Z
+```
 
 ### Embedded Cloud Spanner Emulator
 

--- a/cli.go
+++ b/cli.go
@@ -309,16 +309,8 @@ func (c *Cli) RunInteractive(ctx context.Context) int {
 				continue
 			}
 		}
-
-		if _, ok := stmt.(*DdlStatement); ok {
-			disableSpinner = true
-		}
-
-		if _, ok := stmt.(*SyncProtoStatement); ok {
-			disableSpinner = true
-		}
-
-		if _, ok := stmt.(*BulkDdlStatement); ok {
+		switch stmt.(type) {
+		case *DdlStatement, *SyncProtoStatement, *BulkDdlStatement, *RunBatchStatement:
 			disableSpinner = true
 		}
 

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/ngicks/go-iterator-helper/x/exp/xiter"
@@ -73,10 +72,7 @@ func bufferOrExecuteDdlStatements(ctx context.Context, session *Session, ddls []
 		return nil, errors.New("there is active batch DML")
 	case *BulkDdlStatement:
 		b.Ddls = append(b.Ddls, ddls...)
-		return &Result{
-			ColumnNames: sliceOf("type", "count"),
-			Rows:        sliceOf(toRow("DDL", strconv.Itoa(len(b.Ddls)))),
-		}, nil
+		return &Result{IsMutation: true}, nil
 	default:
 		return executeDdlStatements(ctx, session, ddls)
 	}

--- a/session.go
+++ b/session.go
@@ -70,6 +70,8 @@ type Session struct {
 	tc              *transactionContext
 	tcMutex         sync.Mutex // Guard a critical section for transaction.
 	systemVariables *systemVariables
+
+	currentBatch Statement
 }
 
 type transactionMode string

--- a/session.go
+++ b/session.go
@@ -672,9 +672,31 @@ func (s *Session) failStatementIfReadOnly() error {
 	return nil
 }
 
+func extractBatchInfo(stmt Statement) *BatchInfo {
+	switch s := stmt.(type) {
+	case *BulkDdlStatement:
+		return &BatchInfo{
+			Mode: batchModeDDL,
+			Size: len(s.Ddls),
+		}
+	case *BatchDMLStatement:
+		return &BatchInfo{
+			Mode: batchModeDML,
+			Size: len(s.DMLs),
+		}
+	default:
+		return nil
+	}
+}
+
 // ExecuteStatement executes stmt.
 // If stmt is a MutationStatement, pending transaction is determined and fails if there is an active read-only transaction.
-func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (*Result, error) {
+func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result *Result, err error) {
+	defer func() {
+		if result != nil {
+			result.BatchInfo = extractBatchInfo(s.currentBatch)
+		}
+	}()
 	if _, ok := stmt.(MutationStatement); ok {
 		result := &Result{IsMutation: true}
 		_, err := s.DetermineTransaction(ctx)

--- a/statement.go
+++ b/statement.go
@@ -80,6 +80,11 @@ const (
 	rowCountTypeLowerBound
 )
 
+type BatchInfo struct {
+	Mode batchMode
+	Size int
+}
+
 type Result struct {
 	ColumnNames      []string
 	ColumnAlign      []int // optional
@@ -102,6 +107,8 @@ type Result struct {
 	ForceWrap   bool
 	LintResults []string
 	PreInput    string
+
+	BatchInfo *BatchInfo
 }
 
 type Row struct {

--- a/statement_test.go
+++ b/statement_test.go
@@ -599,6 +599,31 @@ func TestBuildStatement(t *testing.T) {
 			input: `GEMINI "Show all tables"`,
 			want:  &GeminiStatement{Text: "Show all tables"},
 		},
+		{
+			desc:  "START BATCH DDL statement",
+			input: `START BATCH DDL`,
+			want:  &StartBatchStatement{Mode: batchModeDDL},
+		},
+		{
+			desc:  "START BATCH DML statement",
+			input: `START BATCH DML`,
+			want:  &StartBatchStatement{Mode: batchModeDML},
+		},
+		{
+			desc:  "ABORT BATCH statement",
+			input: `ABORT BATCH`,
+			want:  &AbortBatchStatement{},
+		},
+		{
+			desc:  "ABORT BATCH statement",
+			input: `ABORT BATCH TRANSACTION`,
+			want:  &AbortBatchStatement{},
+		},
+		{
+			desc:  "RUN BATCH statement",
+			input: `RUN BATCH`,
+			want:  &RunBatchStatement{},
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			got, err := BuildStatement(test.input)


### PR DESCRIPTION
This PR implements interactive DDL batching using following statements:
- `START BATCH DDL`
- `RUN BATCH`
- `ABORT BATCH [TRANSACTION]`