### PR TITLE
Improve error desc

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -426,12 +426,17 @@ func (c *Cli) PrintInteractiveError(err error) {
 
 func printError(w io.Writer, err error) {
 	if code := spanner.ErrCode(err); code != codes.Unknown {
+		before, _, found := strings.Cut(err.Error(), " spanner:")
+		if !found {
+			fmt.Fprintf(w, "ERROR: %s\n", err)
+			return
+		}
+
 		desc := spanner.ErrDesc(err)
-		unquoted, err := strconv.Unquote(`"` + desc + `"`)
-		if err != nil {
-			fmt.Fprintf(w, "ERROR: code=%q, desc: %v\n", code, desc)
+		if unquoted, err := strconv.Unquote(`"` + desc + `"`); err != nil {
+			fmt.Fprintf(w, "ERROR: %v spanner: code=%q, desc: %v\n", before, code, desc)
 		} else {
-			fmt.Fprintf(w, "ERROR: code=%q, desc: %v\n", code, unquoted)
+			fmt.Fprintf(w, "ERROR: %v spanner: code=%q, desc: %v\n", before, code, unquoted)
 		}
 	} else {
 		fmt.Fprintf(w, "ERROR: %s\n", err)

--- a/cli.go
+++ b/cli.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/apstndb/adcplus"
 	"github.com/kballard/go-shellquote"
-
 	"github.com/nyaosorg/go-readline-ny"
 
 	"github.com/hymkor/go-multiline-ny"
@@ -417,16 +416,30 @@ func (c *Cli) Exit() int {
 
 func (c *Cli) ExitOnError(err error) int {
 	c.Session.Close()
-	fmt.Fprintf(c.ErrStream, "ERROR: %s\n", err)
+	printError(c.ErrStream, err)
 	return exitCodeError
 }
 
 func (c *Cli) PrintInteractiveError(err error) {
-	fmt.Fprintf(c.OutStream, "ERROR: %s\n", err)
+	printError(c.OutStream, err)
+}
+
+func printError(w io.Writer, err error) {
+	if code := spanner.ErrCode(err); code != codes.Unknown {
+		desc := spanner.ErrDesc(err)
+		unquoted, err := strconv.Unquote(`"` + desc + `"`)
+		if err != nil {
+			fmt.Fprintf(w, "ERROR: code=%q, desc: %v\n", code, desc)
+		} else {
+			fmt.Fprintf(w, "ERROR: code=%q, desc: %v\n", code, unquoted)
+		}
+	} else {
+		fmt.Fprintf(w, "ERROR: %s\n", err)
+	}
 }
 
 func (c *Cli) PrintBatchError(err error) {
-	fmt.Fprintf(c.ErrStream, "ERROR: %s\n", err)
+	printError(c.ErrStream, err)
 }
 
 func (c *Cli) PrintResult(screenWidth int, result *Result, mode DisplayMode, interactive bool) {


### PR DESCRIPTION
This PR improves error messages.

- Extract error desc using `spanner.ErrDesc()`
- Unquote description

## Before

```
spanner> UPDATE DMLSingers s
      -> SET (INSERT s.AlbumInfo.Song (SELECT AS googlesql.example.Album.Song {}))
      -> WHERE TRU;
ERROR: transaction was aborted: spanner: code = "InvalidArgument", desc = "Unrecognized name: TRU [at 3:7]\\nWHERE TRU\\n      ^"
```

## After

```
spanner> UPDATE DMLSingers s
      -> SET (INSERT s.AlbumInfo.Song (SELECT AS googlesql.example.Album.Song {}))
      -> WHERE TRU;
ERROR: transaction was aborted: spanner: code="InvalidArgument", desc: Unrecognized name: TRU [at 3:7]
WHERE TRU
      ^
```