### PR TITLE
Support formatting PROTO/ENUM values

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,47 @@ spanner> SYNC PROTO BUNDLE DELETE (`examples.shipping.OrderHistory`);
 Query OK, 0 rows affected (8.24 sec)
 ```
 
+### `PROTO`/`ENUM` value formatting
+
+Loaded proto descriptors are used for formatting `PROTO` and `ENUM` column values.
+
+```
+spanner> SELECT p, p.*
+         FROM (
+           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
+         ) AS p;
++----------------------------------+-----------+------------+-------------+-------+
+| p                                | singer_id | birth_date | nationality | genre |
++----------------------------------+-----------+------------+-------------+-------+
+| CAESCjE5NzAtMDEtMDEaBUphcGFuIAA= | 1         | 1970-01-01 | Japan       | 0     |
++----------------------------------+-----------+------------+-------------+-------+
+1 rows in set (2.22 msecs)
+
+spanner> SET CLI_PROTO_DESCRIPTOR_FILE += "testdata/protos/singer.proto";
+Empty set (0.00 sec)
+
+spanner> SHOW LOCAL PROTO;
++-----------------------------------------+-------+------------------------+------------------------------+
+| full_name                               | kind  | package                | file                         |
++-----------------------------------------+-------+------------------------+------------------------------+
+| examples.spanner.music.SingerInfo       | PROTO | examples.spanner.music | testdata/protos/singer.proto |
+| examples.spanner.music.CustomSingerInfo | PROTO | examples.spanner.music | testdata/protos/singer.proto |
+| examples.spanner.music.Genre            | ENUM  | examples.spanner.music | testdata/protos/singer.proto |
+| examples.spanner.music.CustomGenre      | ENUM  | examples.spanner.music | testdata/protos/singer.proto |
++-----------------------------------------+-------+------------------------+------------------------------+
+4 rows in set (0.00 sec)
+
+spanner> SELECT p, p.*
+         FROM (
+           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
+         ) AS p;
++-------------------------------------------------------------------+-----------+------------+-------------+-------+
+| p                                                                 | singer_id | birth_date | nationality | genre |
++-------------------------------------------------------------------+-----------+------------+-------------+-------+
+| singer_id:1 birth_date:"1970-01-01" nationality:"Japan" genre:POP | 1         | 1970-01-01 | Japan       | POP   |
++-------------------------------------------------------------------+-----------+------------+-------------+-------+
+1 rows in set (1.43 msecs)
+```
 ### memefish integration
 
 spanner-mycli utilizes [memefish](https://github.com/cloudspannerecosystem/memefish) as:

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/apstndb/spanvalue"
 	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/ngicks/go-iterator-helper/x/exp/xiter"
-	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	scxiter "spheric.cloud/xiter"
 
@@ -29,6 +29,11 @@ import (
 )
 
 func executeSQL(ctx context.Context, session *Session, sql string) (*Result, error) {
+	fc, err := formatConfigWithProto(session.systemVariables.ProtoDescriptor)
+	if err != nil {
+		return nil, err
+	}
+
 	params := session.systemVariables.Params
 	stmt, err := newStatement(sql, params, false)
 	if err != nil {
@@ -37,7 +42,7 @@ func executeSQL(ctx context.Context, session *Session, sql string) (*Result, err
 
 	iter, roTxn := session.RunQueryWithStats(ctx, stmt)
 
-	rows, stats, _, metadata, _, err := consumeRowIterCollect(iter, spannerRowToRowWithFDS(session.systemVariables.ProtoDescriptor))
+	rows, stats, _, metadata, _, err := consumeRowIterCollect(iter, spannerRowToRow(fc))
 	if err != nil {
 		if session.InReadWriteTransaction() && spanner.ErrCode(err) == codes.Aborted {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
@@ -373,8 +378,14 @@ func executeInformationSchemaBasedStatement(ctx context.Context, session *Sessio
 		return nil, fmt.Errorf(`%q can not be used in a read-write transaction`, stmtName)
 	}
 
+	fc, err := formatConfigWithProto(session.systemVariables.ProtoDescriptor)
+	if err != nil {
+		return nil, err
+	}
+
 	iter, _ := session.RunQuery(ctx, stmt)
-	rows, _, _, metadata, _, err := consumeRowIterCollect(iter, spannerRowToRowWithFDS(session.systemVariables.ProtoDescriptor))
+
+	rows, _, _, metadata, _, err := consumeRowIterCollect(iter, spannerRowToRow(fc))
 	if err != nil {
 		return nil, err
 	}
@@ -454,19 +465,12 @@ func consumeRowIterCollect[T any](iter *spanner.RowIterator, f func(*spanner.Row
 	return results, stats, count, metadata, plan, err
 }
 
-func spannerRowToRowWithFDS(fds *descriptorpb.FileDescriptorSet) func(row *spanner.Row) (Row, error) {
+func spannerRowToRow(fc *spanvalue.FormatConfig) func(row *spanner.Row) (Row, error) {
 	return func(row *spanner.Row) (Row, error) {
-		columns, err := DecodeRowExperimental(row, fds)
+		columns, err := fc.FormatRow(row)
 		if err != nil {
 			return Row{}, err
 		}
 		return toRow(columns...), nil
 	}
-}
-func spannerRowToRow(row *spanner.Row) (Row, error) {
-	columns, err := DecodeRow(row)
-	if err != nil {
-		return Row{}, err
-	}
-	return toRow(columns...), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/apstndb/memebridge v0.2.0
 	github.com/apstndb/spanemuboost v0.2.5
 	github.com/apstndb/spannerplanviz v0.3.2
-	github.com/apstndb/spantype v0.3.6
+	github.com/apstndb/spantype v0.3.7
 	github.com/apstndb/spanvalue v0.1.4
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/apstndb/spanemuboost v0.2.5
 	github.com/apstndb/spannerplanviz v0.3.2
 	github.com/apstndb/spantype v0.3.6
-	github.com/apstndb/spanvalue v0.1.3
+	github.com/apstndb/spanvalue v0.1.4
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.3.1
 	github.com/go-json-experiment/json v0.0.0-20250116043007-0640c115aea5

--- a/go.sum
+++ b/go.sum
@@ -2472,10 +2472,8 @@ github.com/apstndb/spanemuboost v0.2.5 h1:QGlmijFZ2GqbwQ2TCE2y/QDRvpVHd8kxBp5b4w
 github.com/apstndb/spanemuboost v0.2.5/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
 github.com/apstndb/spannerplanviz v0.3.2 h1:AeTNTdE05+7T4HWPV1yjLSYCbr51ZugtR3KCkw5SAD0=
 github.com/apstndb/spannerplanviz v0.3.2/go.mod h1:/tY1Y1tLTp3Czj9BI2/M02W3P/wJgmKwuDS5zARLhvc=
-github.com/apstndb/spantype v0.3.6 h1:vHMsjpuE2m+Y4Q2FJ1W11nFTd0vMHLzfBWISr6RWAX0=
-github.com/apstndb/spantype v0.3.6/go.mod h1:y0EmWJfRVoJEaZZfJS6j2Y9xXPyXoQwtngibq9A3RT8=
-github.com/apstndb/spanvalue v0.1.3 h1:tnCc773ics6T0AubugmzH4wmmailsdJEyqLSyHDFLrY=
-github.com/apstndb/spanvalue v0.1.3/go.mod h1:AMJG3EDYcWq2z6jVlHpwju/2GKhXJnkUWlu91W9bNyY=
+github.com/apstndb/spantype v0.3.7 h1:cJv8hZIPz6aSiFwJwMH/oXMzTtV1qL5483MEkCfHxm8=
+github.com/apstndb/spantype v0.3.7/go.mod h1:lgEkdDGqAzfWHY+JnkxnOlRgoCICu8ti5TH7LmYMXak=
 github.com/apstndb/spanvalue v0.1.4 h1:K+x5x2brDCCAIiyaPWRDD9/WJ3+y33NdBLJr9dco3s8=
 github.com/apstndb/spanvalue v0.1.4/go.mod h1:AMJG3EDYcWq2z6jVlHpwju/2GKhXJnkUWlu91W9bNyY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/go.sum
+++ b/go.sum
@@ -2476,6 +2476,8 @@ github.com/apstndb/spantype v0.3.6 h1:vHMsjpuE2m+Y4Q2FJ1W11nFTd0vMHLzfBWISr6RWAX
 github.com/apstndb/spantype v0.3.6/go.mod h1:y0EmWJfRVoJEaZZfJS6j2Y9xXPyXoQwtngibq9A3RT8=
 github.com/apstndb/spanvalue v0.1.3 h1:tnCc773ics6T0AubugmzH4wmmailsdJEyqLSyHDFLrY=
 github.com/apstndb/spanvalue v0.1.3/go.mod h1:AMJG3EDYcWq2z6jVlHpwju/2GKhXJnkUWlu91W9bNyY=
+github.com/apstndb/spanvalue v0.1.4 h1:K+x5x2brDCCAIiyaPWRDD9/WJ3+y33NdBLJr9dco3s8=
+github.com/apstndb/spanvalue v0.1.4/go.mod h1:AMJG3EDYcWq2z6jVlHpwju/2GKhXJnkUWlu91W9bNyY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/session.go
+++ b/session.go
@@ -464,7 +464,12 @@ func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement) ([]Row,
 	// Reset STATEMENT_TAG
 	s.systemVariables.RequestTag = ""
 
-	rows, _, count, metadata, _, err := consumeRowIterCollect(s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts), spannerRowToRowWithFDS(s.systemVariables.ProtoDescriptor))
+	fc, err := formatConfigWithProto(s.systemVariables.ProtoDescriptor)
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+
+	rows, _, count, metadata, _, err := consumeRowIterCollect(s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts), spannerRowToRow(fc))
 	s.tc.sendHeartbeat = true
 	return rows, extractColumnNames(metadata.GetRowType().GetFields()), count, metadata, err
 }

--- a/session.go
+++ b/session.go
@@ -464,7 +464,7 @@ func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement) ([]Row,
 	// Reset STATEMENT_TAG
 	s.systemVariables.RequestTag = ""
 
-	rows, _, count, metadata, _, err := consumeRowIterCollect(s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts), spannerRowToRow)
+	rows, _, count, metadata, _, err := consumeRowIterCollect(s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts), spannerRowToRowWithFDS(s.systemVariables.ProtoDescriptor))
 	s.tc.sendHeartbeat = true
 	return rows, extractColumnNames(metadata.GetRowType().GetFields()), count, metadata, err
 }


### PR DESCRIPTION
This PR adds support of `PROTO`/`ENUM` value formatting.

```
spanner> SELECT p, p.*
         FROM (
           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
         ) AS p;
+----------------------------------+-----------+------------+-------------+-------+
| p                                | singer_id | birth_date | nationality | genre |
| PROTO                            | INT64     | STRING     | STRING      | ENUM  |
+----------------------------------+-----------+------------+-------------+-------+
| CAESCjE5NzAtMDEtMDEaBUphcGFuIAA= | 1         | 1970-01-01 | Japan       | 0     |
+----------------------------------+-----------+------------+-------------+-------+
1 rows in set (0.15 msecs)
timestamp:            2025-01-22T01:11:22.810217+09:00
cpu time:             0.13 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    7
optimizer statistics: auto_20250120_18_51_29UTC

spanner> SET CLI_PROTO_DESCRIPTOR_FILE += "testdata/protos/singer.proto";
Empty set (0.00 sec)

spanner> SHOW LOCAL PROTO;
+-----------------------------------------+-------+------------------------+------------------------------+
| full_name                               | kind  | package                | file                         |
+-----------------------------------------+-------+------------------------+------------------------------+
| examples.spanner.music.SingerInfo       | PROTO | examples.spanner.music | testdata/protos/singer.proto |
| examples.spanner.music.CustomSingerInfo | PROTO | examples.spanner.music | testdata/protos/singer.proto |
| examples.spanner.music.Genre            | ENUM  | examples.spanner.music | testdata/protos/singer.proto |
| examples.spanner.music.CustomGenre      | ENUM  | examples.spanner.music | testdata/protos/singer.proto |
+-----------------------------------------+-------+------------------------+------------------------------+
4 rows in set (0.00 sec)

spanner> SELECT p, p.*
         FROM (
           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
         ) AS p;
+-------------------------------------------------------------------+-----------+------------+-------------+-------+
| p                                                                 | singer_id | birth_date | nationality | genre |
| PROTO                                                             | INT64     | STRING     | STRING      | ENUM  |
+-------------------------------------------------------------------+-----------+------------+-------------+-------+
| singer_id:1 birth_date:"1970-01-01" nationality:"Japan" genre:POP | 1         | 1970-01-01 | Japan       | POP   |
+-------------------------------------------------------------------+-----------+------------+-------------+-------+
1 rows in set (0.25 msecs)
timestamp:            2025-01-22T01:11:36.680126+09:00
cpu time:             0.2 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    7
optimizer statistics: auto_20250120_18_51_29UTC
```