### PR TITLE
Change PROTO/ENUM type format

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -139,8 +139,8 @@ func formatEnum(types protoEnumResolver) func(formatter spanvalue.Formatter, val
 func formatTypeSimple(typ *sppb.Type) string {
 	return spantype.FormatType(typ, spantype.FormatOption{
 		Struct: spantype.StructModeBase,
-		Proto:  spantype.ProtoEnumModeBase,
-		Enum:   spantype.ProtoEnumModeBase,
+		Proto:  spantype.ProtoEnumModeLeafWithKind,
+		Enum:   spantype.ProtoEnumModeLeafWithKind,
 		Array:  spantype.ArrayModeRecursive,
 	})
 }


### PR DESCRIPTION
This PR changes `PROTO` and `ENUM` format in headers.

||`PROTO` with FQN `examples.ProtoType`|`ENUM` with FQN `examples.EnumType`|
|---|---|---|
|Before|`PROTO`|`ENUM`|
|After|`PROTO<ProtoType>`|`ENUM<EnumType>`|

Note: package is still only printed in `DESCRIBE`.