### PR TITLE
Improve error message

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -532,22 +532,16 @@ func (c *Cli) PrintInteractiveError(err error) {
 }
 
 func printError(w io.Writer, err error) {
-	if code := spanner.ErrCode(err); code != codes.Unknown {
-		before, _, found := strings.Cut(err.Error(), "spanner:")
-		if !found {
-			fmt.Fprintf(w, "ERROR: %s\n", err)
-			return
-		}
-
-		desc := spanner.ErrDesc(err)
-		if unquoted, err := strconv.Unquote(`"` + desc + `"`); err != nil {
-			fmt.Fprintf(w, "ERROR: %vspanner: code=%q, desc: %v\n", before, code, desc)
-		} else {
-			fmt.Fprintf(w, "ERROR: %vspanner: code=%q, desc: %v\n", before, code, unquoted)
-		}
-	} else {
+	code := spanner.ErrCode(err)
+	before, _, found := strings.Cut(err.Error(), "spanner:")
+	if code == codes.Unknown || !found {
 		fmt.Fprintf(w, "ERROR: %s\n", err)
+		return
 	}
+
+	desc := spanner.ErrDesc(err)
+	unquoted, err := strconv.Unquote(`"` + desc + `"`)
+	fmt.Fprintf(w, "ERROR: %vspanner: code=%q, desc: %v\n", before, code, lo.Ternary(err != nil, desc, unquoted))
 }
 
 func (c *Cli) PrintBatchError(err error) {

--- a/cli.go
+++ b/cli.go
@@ -533,7 +533,7 @@ func (c *Cli) PrintInteractiveError(err error) {
 
 func printError(w io.Writer, err error) {
 	if code := spanner.ErrCode(err); code != codes.Unknown {
-		before, _, found := strings.Cut(err.Error(), " spanner:")
+		before, _, found := strings.Cut(err.Error(), "spanner:")
 		if !found {
 			fmt.Fprintf(w, "ERROR: %s\n", err)
 			return
@@ -541,9 +541,9 @@ func printError(w io.Writer, err error) {
 
 		desc := spanner.ErrDesc(err)
 		if unquoted, err := strconv.Unquote(`"` + desc + `"`); err != nil {
-			fmt.Fprintf(w, "ERROR: %v spanner: code=%q, desc: %v\n", before, code, desc)
+			fmt.Fprintf(w, "ERROR: %vspanner: code=%q, desc: %v\n", before, code, desc)
 		} else {
-			fmt.Fprintf(w, "ERROR: %v spanner: code=%q, desc: %v\n", before, code, unquoted)
+			fmt.Fprintf(w, "ERROR: %vspanner: code=%q, desc: %v\n", before, code, unquoted)
 		}
 	} else {
 		fmt.Fprintf(w, "ERROR: %s\n", err)


### PR DESCRIPTION
This PR improve error message.

- #113 didn't improve `*spanner.Error` without wrapped.

Before

```
spanner> SELECT p, p.*
      -> FROM (
      ->   SELECT AS VALUE NEW examples.spanner.music.SingerInf{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
      -> ) AS p;
ERROR: spanner: code = "InvalidArgument", desc = "Type not found: examples.spanner.music.SingerInf [at 3:23]\\n  SELECT AS VALUE NEW examples.spanner.music.SingerInf{singer_id: 1, birth_da...\\n                      ^"
```

After

```
spanner> SELECT p, p.*
      -> FROM (
      ->   SELECT AS VALUE NEW examples.spanner.music.SingerInf{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
      -> ) AS p;
ERROR: spanner: code="InvalidArgument", desc: Type not found: examples.spanner.music.SingerInf [at 3:23]
  SELECT AS VALUE NEW examples.spanner.music.SingerInf{singer_id: 1, birth_da...
                      ^
```