### PR TITLE
Support multiline proto format

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | CLI_AUTOWRAP              | READ_WRITE | `"TRUE"`                                       |
 | CLI_DATABASE_DIALECT      | READ_WRITE | `"TRUE"`                                       |
 | CLI_ENABLE_HIGHLIGHT      | READ_WRITE | `"TRUE"`                                       |
+| CLI_PROTOTEXT_MULTILINE   | READ_WRITE | `"TRUE"`                                       |
 
 ### Batch statements
 
@@ -885,7 +886,7 @@ spanner> SYNC PROTO BUNDLE DELETE (`examples.shipping.OrderHistory`);
 Query OK, 0 rows affected (8.24 sec)
 ```
 
-### `PROTO`/`ENUM` value formatting
+#### `PROTO`/`ENUM` value formatting
 
 Loaded proto descriptors are used for formatting `PROTO` and `ENUM` column values.
 
@@ -925,6 +926,29 @@ spanner> SELECT p, p.*
 | singer_id:1 birth_date:"1970-01-01" nationality:"Japan" genre:POP | 1         | 1970-01-01 | Japan       | POP   |
 +-------------------------------------------------------------------+-----------+------------+-------------+-------+
 1 rows in set (1.43 msecs)
+```
+
+You can enable multiline format.
+
+```
+spanner> SET CLI_PROTOTEXT_MULTILINE=TRUE;
+Empty set (0.00 sec)
+
+spanner> SELECT p, p.*
+         FROM (
+           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
+         ) AS p;
++--------------------------+-----------+------------+-------------+-------------+
+| p                        | singer_id | birth_date | nationality | genre       |
+| PROTO<SingerInfo>        | INT64     | STRING     | STRING      | ENUM<Genre> |
++--------------------------+-----------+------------+-------------+-------------+
+| singer_id: 1             | 1         | 1970-01-01 | Japan       | POP         |
+| birth_date: "1970-01-01" |           |            |             |             |
+| nationality: "Japan"     |           |            |             |             |
+| genre: POP               |           |            |             |             |
++--------------------------+-----------+------------+-------------+-------------+
+1 rows in set (3.22 msecs)
+
 ```
 ### memefish integration
 

--- a/README.md
+++ b/README.md
@@ -895,12 +895,13 @@ spanner> SELECT p, p.*
          FROM (
            SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
          ) AS p;
-+----------------------------------+-----------+------------+-------------+-------+
-| p                                | singer_id | birth_date | nationality | genre |
-+----------------------------------+-----------+------------+-------------+-------+
-| CAESCjE5NzAtMDEtMDEaBUphcGFuIAA= | 1         | 1970-01-01 | Japan       | 0     |
-+----------------------------------+-----------+------------+-------------+-------+
-1 rows in set (2.22 msecs)
++----------------------------------+-----------+------------+-------------+-------------+
+| p                                | singer_id | birth_date | nationality | genre       |
+| PROTO<SingerInfo>                | INT64     | STRING     | STRING      | ENUM<Genre> |
++----------------------------------+-----------+------------+-------------+-------------+
+| CAESCjE5NzAtMDEtMDEaBUphcGFuIAA= | 1         | 1970-01-01 | Japan       | 0           |
++----------------------------------+-----------+------------+-------------+-------------+
+1 rows in set (0.33 msecs)
 
 spanner> SET CLI_PROTO_DESCRIPTOR_FILE += "testdata/protos/singer.proto";
 Empty set (0.00 sec)
@@ -920,12 +921,13 @@ spanner> SELECT p, p.*
          FROM (
            SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
          ) AS p;
-+-------------------------------------------------------------------+-----------+------------+-------------+-------+
-| p                                                                 | singer_id | birth_date | nationality | genre |
-+-------------------------------------------------------------------+-----------+------------+-------------+-------+
-| singer_id:1 birth_date:"1970-01-01" nationality:"Japan" genre:POP | 1         | 1970-01-01 | Japan       | POP   |
-+-------------------------------------------------------------------+-----------+------------+-------------+-------+
-1 rows in set (1.43 msecs)
++-------------------------------------------------------------------+-----------+------------+-------------+-------------+
+| p                                                                 | singer_id | birth_date | nationality | genre       |
+| PROTO<SingerInfo>                                                 | INT64     | STRING     | STRING      | ENUM<Genre> |
++-------------------------------------------------------------------+-----------+------------+-------------+-------------+
+| singer_id:1 birth_date:"1970-01-01" nationality:"Japan" genre:POP | 1         | 1970-01-01 | Japan       | POP         |
++-------------------------------------------------------------------+-----------+------------+-------------+-------------+
+1 rows in set (0.87 msecs)
 ```
 
 You can enable multiline format.
@@ -947,8 +949,7 @@ spanner> SELECT p, p.*
 | nationality: "Japan"     |           |            |             |             |
 | genre: POP               |           |            |             |             |
 +--------------------------+-----------+------------+-------------+-------------+
-1 rows in set (3.22 msecs)
-
+1 rows in set (3.37 msecs)
 ```
 ### memefish integration
 

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -29,7 +29,7 @@ import (
 )
 
 func executeSQL(ctx context.Context, session *Session, sql string) (*Result, error) {
-	fc, err := formatConfigWithProto(session.systemVariables.ProtoDescriptor)
+	fc, err := formatConfigWithProto(session.systemVariables.ProtoDescriptor, session.systemVariables.MultilineProtoText)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func executeInformationSchemaBasedStatement(ctx context.Context, session *Sessio
 		return nil, fmt.Errorf(`%q can not be used in a read-write transaction`, stmtName)
 	}
 
-	fc, err := formatConfigWithProto(session.systemVariables.ProtoDescriptor)
+	fc, err := formatConfigWithProto(session.systemVariables.ProtoDescriptor, session.systemVariables.MultilineProtoText)
 	if err != nil {
 		return nil, err
 	}

--- a/session.go
+++ b/session.go
@@ -453,7 +453,7 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 // RunUpdate executes a DML statement on the running read-write transaction.
 // It returns error if there is no running read-write transaction.
 func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement) ([]Row, []string, int64, *sppb.ResultSetMetadata, error) {
-	fc, err := formatConfigWithProto(s.systemVariables.ProtoDescriptor)
+	fc, err := formatConfigWithProto(s.systemVariables.ProtoDescriptor, s.systemVariables.MultilineProtoText)
 	if err != nil {
 		return nil, nil, 0, nil, err
 	}

--- a/system_variables.go
+++ b/system_variables.go
@@ -78,6 +78,7 @@ type systemVariables struct {
 	EnableProgressBar         bool
 	ImpersonateServiceAccount string
 	EnableADCPlus             bool
+	MultilineProtoText        bool
 }
 
 var errIgnored = errors.New("ignored")
@@ -505,6 +506,9 @@ var accessorMap = map[string]accessor{
 	}),
 	"CLI_ENABLE_HIGHLIGHT": boolAccessor(func(variables *systemVariables) *bool {
 		return &variables.EnableHighlight
+	}),
+	"CLI_PROTOTEXT_MULTILINE": boolAccessor(func(variables *systemVariables) *bool {
+		return &variables.MultilineProtoText
 	}),
 	"CLI_QUERY_MODE": {
 		Getter: func(this *systemVariables, name string) (map[string]string, error) {


### PR DESCRIPTION
This PR implements `CLI_PROTOTEXT_MULTILINE` system variable to enable multiline prototext format.

```
spanner> SELECT p, p.*
         FROM (
           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
         ) AS p;
+-------------------------------------------------------------------+-----------+------------+-------------+-------------+
| p                                                                 | singer_id | birth_date | nationality | genre       |
| PROTO<SingerInfo>                                                 | INT64     | STRING     | STRING      | ENUM<Genre> |
+-------------------------------------------------------------------+-----------+------------+-------------+-------------+
| singer_id:1 birth_date:"1970-01-01" nationality:"Japan" genre:POP | 1         | 1970-01-01 | Japan       | POP         |
+-------------------------------------------------------------------+-----------+------------+-------------+-------------+
1 rows in set (0.87 msecs)

spanner> SET CLI_PROTOTEXT_MULTILINE=TRUE;
Empty set (0.00 sec)

spanner> SELECT p, p.*
         FROM (
           SELECT AS VALUE NEW examples.spanner.music.SingerInfo{singer_id: 1, birth_date: "1970-01-01", nationality: "Japan", genre: "POP"}
         ) AS p;
+--------------------------+-----------+------------+-------------+-------------+
| p                        | singer_id | birth_date | nationality | genre       |
| PROTO<SingerInfo>        | INT64     | STRING     | STRING      | ENUM<Genre> |
+--------------------------+-----------+------------+-------------+-------------+
| singer_id: 1             | 1         | 1970-01-01 | Japan       | POP         |
| birth_date: "1970-01-01" |           |            |             |             |
| nationality: "Japan"     |           |            |             |             |
| genre: POP               |           |            |             |             |
+--------------------------+-----------+------------+-------------+-------------+
1 rows in set (3.37 msecs)
```