### PR TITLE
Support formatting INTERVAL typed value (Experimental)

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -59,7 +59,8 @@ func formatConfigWithProto(fds *descriptorpb.FileDescriptorSet, multiline bool) 
 			FormatStructParen: spanvalue.FormatBracketStruct,
 		},
 		FormatComplexPlugins: []spanvalue.FormatComplexFunc{
-			formatUUID(), // workaround
+			formatInterval(), // workaround
+			formatUUID(),     // workaround
 			formatProto(types, multiline),
 			formatEnum(types),
 		},
@@ -138,10 +139,24 @@ func formatEnum(types protoEnumResolver) func(formatter spanvalue.Formatter, val
 	}
 }
 
-// formatUUID is workaround because google-cloud-go/spanner doesn't support UUID type.
+// formatUUID is workaround because google-cloud-go/spanner doesn't yet support UUID type.
 func formatUUID() spanvalue.FormatComplexFunc {
 	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
 		if value.Type.GetCode() != sppb.TypeCode_UUID {
+			return "", spanvalue.ErrFallthrough
+		}
+
+		if _, ok := value.Value.Kind.(*structpb.Value_NullValue); ok {
+			return "NULL", nil
+		}
+		return value.Value.GetStringValue(), nil
+	}
+}
+
+// formatInterval is workaround because google-cloud-go/spanner doesn't yet support INTERVAL type.
+func formatInterval() spanvalue.FormatComplexFunc {
+	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
+		if value.Type.GetCode() != sppb.TypeCode_INTERVAL {
 			return "", spanvalue.ErrFallthrough
 		}
 

--- a/params.go
+++ b/params.go
@@ -19,11 +19,7 @@ func generateParams(paramsNodeMap map[string]ast.Node, includeType bool) (map[st
 			if err != nil {
 				return nil, err
 			}
-			nullValue := gcvctor.TypedNull(typ)
-			if err != nil {
-				return nil, err
-			}
-			result[k] = nullValue
+			result[k] = gcvctor.TypedNull(typ)
 		case ast.Expr:
 			expr, err := memebridge.MemefishExprToGCV(v)
 			if err != nil {


### PR DESCRIPTION
This PR implements experimental `INTERVAL` typed value format. This implementation will be replaced when google-cloud-go/spanner supports decoding `INTERVAL` values.
```
spanner> SELECT CAST("P1Y2M3DT4H5M6.5S" AS INTERVAL) AS IntervalCol;
+------------------+
| IntervalCol      |
| INTERVAL         |
+------------------+
| P1Y2M3DT4H5M6.5S |
+------------------+
1 rows in set (2 msecs)
```