### PR TITLE
misc: Fix format for article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1412,22 +1412,22 @@ spanner> GRAPH FinGraph
 ```sql
 GRAPH FinGraph
 MATCH (n:Account)
-RETURN LABELS(n) AS labels, PROPERTY_NAMES(n) AS props, n.id
-/*--------------+------------------------------------------+-------+
-| labels        | props                                    | id    |
-| ARRAY<STRING> | ARRAY<STRING>                            | INT64 |
-+---------------+------------------------------------------+-------+
-| [Account]     | [create_time, id, is_blocked, nick_name] | 7     |
-| [Account]     | [create_time, id, is_blocked, nick_name] | 16    |
-| [Account]     | [create_time, id, is_blocked, nick_name] | 20    |
-+---------------+------------------------------------------+-------+
-3 rows in set (6.47 msecs)
-timestamp:            2025-02-02T10:22:04.867235+09:00
-cpu time:             4.66 msecs
+RETURN LABELS(n) AS labels, PROPERTY_NAMES(n) AS props, n.id;
+/*---------------+------------------------------------------+-------+
+ | labels        | props                                    | id    |
+ | ARRAY<STRING> | ARRAY<STRING>                            | INT64 |
+ +---------------+------------------------------------------+-------+
+ | [Account]     | [create_time, id, is_blocked, nick_name] | 7     |
+ | [Account]     | [create_time, id, is_blocked, nick_name] | 16    |
+ | [Account]     | [create_time, id, is_blocked, nick_name] | 20    |
+ +---------------+------------------------------------------+-------+
+3 rows in set (6.26 msecs)
+timestamp:            2025-02-09T23:28:26.088524+09:00
+cpu time:             4.45 msecs
 rows scanned:         3 rows
 deleted rows scanned: 0 rows
 optimizer version:    7
-optimizer statistics: auto_20250201_06_22_44UTC
+optimizer statistics: auto_20250207_09_19_31UTC
 */
 ```
 ````

--- a/cli.go
+++ b/cli.go
@@ -903,6 +903,11 @@ func adjustByHeader(headers []string, availableWidth int) []int {
 	return adjustWidths
 }
 
+var (
+	topLeftRe     = regexp.MustCompile(`^\+`)
+	bottomRightRe = regexp.MustCompile(`\+$`)
+)
+
 func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result, interactive bool, input string) {
 	mode := sysVars.CLIFormat
 
@@ -911,7 +916,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 	}
 
 	if sysVars.EchoInput && input != "" {
-		fmt.Fprintln(out, input)
+		fmt.Fprintln(out, input+";")
 	}
 
 	// screenWidth <= means no limit.
@@ -968,12 +973,11 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 
 		s := strings.TrimSpace(tableBuf.String())
 		if mode == DisplayModeTableComment || mode == DisplayModeTableDetailComment {
-			topLeftRe := regexp.MustCompile(`^\+-`)
+			s = strings.ReplaceAll(s, "\n", "\n ")
 			s = topLeftRe.ReplaceAllLiteralString(s, "/*")
 		}
 
 		if mode == DisplayModeTableComment {
-			bottomRightRe := regexp.MustCompile(`-\+$`)
 			s = bottomRightRe.ReplaceAllLiteralString(s, "*/")
 		}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -171,12 +171,12 @@ func TestPrintResult(t *testing.T) {
 					IsMutation: false,
 				},
 				want: strings.TrimPrefix(`
-/*----+-----+
-| foo | bar |
-+-----+-----+
-| 1   | 2   |
-| 3   | 4   |
-+-----+----*/
+/*-----+-----+
+ | foo | bar |
+ +-----+-----+
+ | 1   | 2   |
+ | 3   | 4   |
+ +-----+-----*/
 `, "\n"),
 			},
 			{
@@ -198,13 +198,13 @@ func TestPrintResult(t *testing.T) {
 				},
 				want: "```sql" + `
 SELECT foo, bar
-FROM input
-/*----+-----+
-| foo | bar |
-+-----+-----+
-| 1   | 2   |
-| 3   | 4   |
-+-----+-----+
+FROM input;
+/*-----+-----+
+ | foo | bar |
+ +-----+-----+
+ | 1   | 2   |
+ | 3   | 4   |
+ +-----+-----+
 Empty set
 */
 ` + "```\n",


### PR DESCRIPTION
This PR refines format for articles, which is introduced in #127.

- Add indentation to align border.
- Add semicolon to echo.