### PR TITLE
Implement DATA_BOOST_ENABLED and misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | COMMIT_RESPONSE              | READ_ONLY  | `"2024-11-01T05:31:11.311894+09:00"`                |
 | TRANSACTION_TAG              | READ_WRITE | `"app=concert,env=dev,action=update"`               |
 | STATEMENT_TAG                | READ_WRITE | `"app=concert,env=dev,action=update,request=fetch"` |
+| DATA_BOOST_ENABLED           | READ_WRITE | `TRUE`                                              |
 
 #### spanner-mycli original variables
 

--- a/session.go
+++ b/session.go
@@ -735,6 +735,7 @@ func (s *Session) RunPartitionQuery(ctx context.Context, stmt spanner.Statement)
 
 	partitions, err := batchROTx.PartitionQueryWithOptions(ctx, stmt, spanner.PartitionOptions{}, spanner.QueryOptions{
 		DataBoostEnabled: s.systemVariables.DataBoostEnabled,
+		Priority:         s.systemVariables.RPCPriority,
 	})
 	if err != nil {
 		batchROTx.Cleanup(ctx)

--- a/session.go
+++ b/session.go
@@ -733,7 +733,9 @@ func (s *Session) RunPartitionQuery(ctx context.Context, stmt spanner.Statement)
 		return nil, nil, err
 	}
 
-	partitions, err := batchROTx.PartitionQueryWithOptions(ctx, stmt, spanner.PartitionOptions{}, spanner.QueryOptions{})
+	partitions, err := batchROTx.PartitionQueryWithOptions(ctx, stmt, spanner.PartitionOptions{}, spanner.QueryOptions{
+		DataBoostEnabled: s.systemVariables.DataBoostEnabled,
+	})
 	if err != nil {
 		batchROTx.Cleanup(ctx)
 		batchROTx.Close()

--- a/system_variables.go
+++ b/system_variables.go
@@ -82,6 +82,7 @@ type systemVariables struct {
 	ImpersonateServiceAccount string
 	EnableADCPlus             bool
 	MultilineProtoText        bool
+	DataBoostEnabled          bool
 }
 
 var errIgnored = errors.New("ignored")
@@ -244,6 +245,9 @@ var accessorMap = map[string]accessor{
 		return &sysVars.OptimizerStatisticsPackage
 	}),
 	"RETURN_COMMIT_STATS": {},
+	"DATA_BOOST_ENABLED": boolAccessor(func(sysVars *systemVariables) *bool {
+		return &sysVars.DataBoostEnabled
+	}),
 	"RPC_PRIORITY": {
 		Setter: func(this *systemVariables, name, value string) error {
 			s := unquoteString(value)
@@ -687,7 +691,7 @@ func boolAccessor(f func(variables *systemVariables) *bool) accessor {
 	}
 }
 
-func stringAccessor(f func(variables *systemVariables) *string) accessor {
+func stringAccessor(f func(sysVars *systemVariables) *string) accessor {
 	return accessor{
 		Setter: stringSetter(f),
 		Getter: stringGetter(f),


### PR DESCRIPTION
This PR implements:

- `DATA_BOOST_ENABLED`
- Respect `RPCPriority` in partition query