### PR TITLE
fix: Enable to use --embedded-emulator without authentication

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -600,16 +600,17 @@ func createSession(ctx context.Context, credential []byte, sysVars *systemVariab
 		opts = append(opts, option.WithEndpoint(sysVars.Endpoint))
 	}
 
-	if sysVars.EnableADCPlus {
+	switch {
+	case sysVars.WithoutAuthentication:
+		opts = append(opts, option.WithoutAuthentication())
+	case sysVars.EnableADCPlus:
 		source, err := tokensource.SmartAccessTokenSource(ctx, adcplus.WithCredentialsJSON(credential), adcplus.WithTargetPrincipal(sysVars.ImpersonateServiceAccount))
 		if err != nil {
 			return nil, err
 		}
 		opts = append(opts, option.WithTokenSource(source))
-	} else {
-		if len(credential) > 0 {
-			opts = append(opts, option.WithCredentialsJSON(credential))
-		}
+	case len(credential) > 0:
+		opts = append(opts, option.WithCredentialsJSON(credential))
 	}
 
 	return NewSession(ctx, sysVars, opts...)

--- a/main.go
+++ b/main.go
@@ -305,7 +305,7 @@ func main() {
 		defer teardown()
 
 		sysVars.Endpoint = container.URI
-
+		sysVars.WithoutAuthentication = true
 	}
 
 	cli, err := NewCli(ctx, cred, os.Stdin, os.Stdout, os.Stderr, &sysVars)

--- a/main_slow_test.go
+++ b/main_slow_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRun ensure that --embedded-emulator doesn't need ADC.
+func TestRun(t *testing.T) {
+	exitCode := run(context.Background(), &spannerOptions{Execute: "SELECT 1", EmbeddedEmulator: true})
+	if exitCode != exitCodeSuccess {
+		t.Errorf("exitCode != exitCodeSuccess, exitCode: %v", exitCode)
+	}
+}

--- a/main_slow_test.go
+++ b/main_slow_test.go
@@ -1,3 +1,5 @@
+//go:build !skip_slow_test
+
 package main
 
 import (

--- a/system_variables.go
+++ b/system_variables.go
@@ -61,10 +61,11 @@ type systemVariables struct {
 	MarkdownCodeblock           bool
 
 	// it is internal variable and hidden from system variable statements
-	ProtoDescriptor *descriptorpb.FileDescriptorSet
-	Insecure        bool
-	Debug           bool
-	Params          map[string]ast.Node
+	ProtoDescriptor       *descriptorpb.FileDescriptorSet
+	Insecure              bool
+	WithoutAuthentication bool
+	Debug                 bool
+	Params                map[string]ast.Node
 
 	// link to session
 	CurrentSession *Session


### PR DESCRIPTION
This PR fixes that unintended dependency on ADC even if `--embedded-emulator` is set.
Additionally, it adds initial version of test of `main.go`.