### PR TITLE
Bump spanemuboost to v0.2.6(emulator v1.5.30)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/apstndb/gsqlutils v0.0.0-20241220021154-62754cd04acc
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.3.0
-	github.com/apstndb/spanemuboost v0.2.5
+	github.com/apstndb/spanemuboost v0.2.6
 	github.com/apstndb/spannerplanviz v0.3.3
 	github.com/apstndb/spantype v0.3.8
 	github.com/apstndb/spanvalue v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -2471,8 +2471,8 @@ github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82 h1:l54uIOgcH4r0lTg8xKR
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82/go.mod h1:PbqzTjsPq7Xhn8D7Vk8g/em15kd8vvEL1Y2xkI9CgGs=
 github.com/apstndb/memebridge v0.3.0 h1:Rewbs9vmHKDFNdyLSP7j9202X6uHhomzy+Cw62rsuKg=
 github.com/apstndb/memebridge v0.3.0/go.mod h1:QmcdoK2Cp6Dg4vdFD2k7BF1bUlHuzvUkLNNxrAtEqIc=
-github.com/apstndb/spanemuboost v0.2.5 h1:QGlmijFZ2GqbwQ2TCE2y/QDRvpVHd8kxBp5b4wyLKII=
-github.com/apstndb/spanemuboost v0.2.5/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
+github.com/apstndb/spanemuboost v0.2.6 h1:Cw9U2FqoKrRBhVu/E3JqBN5UEDEMe4rVpkLZFlRCWu4=
+github.com/apstndb/spanemuboost v0.2.6/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
 github.com/apstndb/spannerplanviz v0.3.3 h1:ZJBbHTGusUMxqhHCtjgOnfuBopYjxDlrSOazU+1duQo=
 github.com/apstndb/spannerplanviz v0.3.3/go.mod h1:nog9R8IUexhSz0NDncp+g8XT/r1Ere9dv8i37EvnMS0=
 github.com/apstndb/spantype v0.3.8 h1:xy43Cclc2Hz6SL+3tZYuozOqJv6AML4Mv8cASgYo1O0=


### PR DESCRIPTION
This PR bumps spanemuboost to v0.2.6.

- https://github.com/apstndb/spanemuboost/releases/tag/v0.2.6