### PR TITLE
Simplify Row type

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -747,7 +747,7 @@ func calculateOptimalWidth(debug bool, screenWidth int, header []string, rows []
 		transposedRows = append(transposedRows, slices.Collect(
 			xiter.Map(
 				func(in Row) string {
-					return lo.Must(lo.Nth(in.Columns, columnIdx))
+					return lo.Must(lo.Nth(in, columnIdx))
 				},
 				xiter.Concat(hiter.Once(toRow(header...)), slices.Values(rows)),
 			)))
@@ -925,7 +925,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		for _, row := range result.Rows {
 			wrappedColumns := slices.Collect(hiter.Unify(
 				runewidth.Wrap,
-				hiter.Pairs(slices.Values(row.Columns), slices.Values(adjustedWidths))),
+				hiter.Pairs(slices.Values(row), slices.Values(adjustedWidths))),
 			)
 			table.Append(wrappedColumns)
 		}
@@ -954,7 +954,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		format := fmt.Sprintf("%%%ds: %%s\n", maxLen)
 		for i, row := range result.Rows {
 			fmt.Fprintf(out, "*************************** %d. row ***************************\n", i+1)
-			for j, column := range row.Columns {
+			for j, column := range row {
 				fmt.Fprintf(out, format, result.ColumnNames[j], column)
 			}
 		}
@@ -962,7 +962,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		if len(result.ColumnNames) > 0 {
 			fmt.Fprintln(out, strings.Join(result.ColumnNames, "\t"))
 			for _, row := range result.Rows {
-				fmt.Fprintln(out, strings.Join(row.Columns, "\t"))
+				fmt.Fprintln(out, strings.Join(row, "\t"))
 			}
 		}
 	}

--- a/cli.go
+++ b/cli.go
@@ -747,7 +747,7 @@ func calculateOptimalWidth(debug bool, screenWidth int, header []string, rows []
 		transposedRows = append(transposedRows, slices.Collect(
 			xiter.Map(
 				func(in Row) string {
-					return lo.Must(lo.Nth(in, columnIdx))
+					return lo.Must(lo.Nth(in, columnIdx)) // columnIdx represents the index of the column in the row
 				},
 				xiter.Concat(hiter.Once(toRow(header...)), slices.Values(rows)),
 			)))
@@ -954,7 +954,8 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		format := fmt.Sprintf("%%%ds: %%s\n", maxLen)
 		for i, row := range result.Rows {
 			fmt.Fprintf(out, "*************************** %d. row ***************************\n", i+1)
-			for j, column := range row {
+			for j, column := range row { // j represents the index of the column in the row
+
 				fmt.Fprintf(out, format, result.ColumnNames[j], column)
 			}
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -140,8 +140,8 @@ func TestPrintResult(t *testing.T) {
 				result: &Result{
 					ColumnNames: []string{"foo", "bar"},
 					Rows: []Row{
-						{[]string{"1", "2"}},
-						{[]string{"3", "4"}},
+						{"1", "2"},
+						{"3", "4"},
 					},
 					IsMutation: false,
 				},
@@ -162,8 +162,8 @@ func TestPrintResult(t *testing.T) {
 				result: &Result{
 					ColumnNames: []string{"foo", "bar"},
 					Rows: []Row{
-						{[]string{"1", "2"}},
-						{[]string{"3", "4"}},
+						{"1", "2"},
+						{"3", "4"},
 					},
 					IsMutation: false,
 				},
@@ -188,8 +188,8 @@ func TestPrintResult(t *testing.T) {
 				result: &Result{
 					ColumnNames: []string{"foo", "bar"},
 					Rows: []Row{
-						{[]string{"1", "2"}},
-						{[]string{"3", "4"}},
+						{"1", "2"},
+						{"3", "4"},
 					},
 					IsMutation: false,
 				},

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -91,9 +91,7 @@ type Result struct {
 	PartitionCount int
 }
 
-type Row struct {
-	Columns []string
-}
+type Row []string
 
 // QueryStats contains query statistics.
 // Some fields may not have a valid value depending on the environment.

--- a/statements_params.go
+++ b/statements_params.go
@@ -24,7 +24,7 @@ func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*R
 		scxiter.MapLower(maps.All(session.systemVariables.Params), func(k string, v ast.Node) Row {
 			return toRow(k, lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"), v.SQL())
 		}),
-		ToSortFunc(func(r Row) string { return r.Columns[0] }))
+		ToSortFunc(func(r Row) string { return r[0] }))
 
 	return &Result{
 		ColumnNames:   []string{"Param_Name", "Param_Kind", "Param_Value"},

--- a/statements_params.go
+++ b/statements_params.go
@@ -24,7 +24,7 @@ func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*R
 		scxiter.MapLower(maps.All(session.systemVariables.Params), func(k string, v ast.Node) Row {
 			return toRow(k, lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"), v.SQL())
 		}),
-		ToSortFunc(func(r Row) string { return r[0] }))
+		ToSortFunc(func(r Row) string { return r[0] /* parameter name */ }))
 
 	return &Result{
 		ColumnNames:   []string{"Param_Name", "Param_Kind", "Param_Value"},

--- a/statements_query_profile.go
+++ b/statements_query_profile.go
@@ -81,14 +81,14 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 			return nil, err
 		}
 
-		maxIDLength := max(hiter.Max(xiter.Map(func(row Row) int { return len(row[0]) }, slices.Values(rows))), 2)
+		maxIDLength := max(hiter.Max(xiter.Map(func(row Row) int { return len(row[0]) /* ID */ }, slices.Values(rows))), 2)
 
 		pprinter := pp.New()
 		pprinter.SetColoringEnabled(false)
 
 		tree := strings.Join(slices.Collect(xiter.Map(
 			func(r Row) string {
-				return runewidth.FillLeft(r[0], maxIDLength) + " | " + r[1]
+				return runewidth.FillLeft(r[0] /* ID */, maxIDLength) + " | " + r[1] /* Plan */
 			},
 			slices.Values(rows))), "\n")
 

--- a/statements_query_profile.go
+++ b/statements_query_profile.go
@@ -81,14 +81,14 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 			return nil, err
 		}
 
-		maxIDLength := max(hiter.Max(xiter.Map(func(row Row) int { return len(row.Columns[0]) }, slices.Values(rows))), 2)
+		maxIDLength := max(hiter.Max(xiter.Map(func(row Row) int { return len(row[0]) }, slices.Values(rows))), 2)
 
 		pprinter := pp.New()
 		pprinter.SetColoringEnabled(false)
 
 		tree := strings.Join(slices.Collect(xiter.Map(
 			func(r Row) string {
-				return runewidth.FillLeft(r.Columns[0], maxIDLength) + " | " + r.Columns[1]
+				return runewidth.FillLeft(r[0], maxIDLength) + " | " + r[1]
 			},
 			slices.Values(rows))), "\n")
 

--- a/statements_system_variable.go
+++ b/statements_system_variable.go
@@ -54,7 +54,7 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 
 	rows := slices.SortedFunc(
 		scxiter.MapLower(maps.All(merged), func(k, v string) Row { return toRow(k, v) }),
-		ToSortFunc(func(r Row) string { return r[0] }))
+		ToSortFunc(func(r Row) string { return r[0] /* name */ }))
 
 	return &Result{
 		ColumnNames:   []string{"name", "value"},

--- a/statements_system_variable.go
+++ b/statements_system_variable.go
@@ -54,7 +54,7 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 
 	rows := slices.SortedFunc(
 		scxiter.MapLower(maps.All(merged), func(k, v string) Row { return toRow(k, v) }),
-		ToSortFunc(func(r Row) string { return r.Columns[0] }))
+		ToSortFunc(func(r Row) string { return r[0] }))
 
 	return &Result{
 		ColumnNames:   []string{"name", "value"},

--- a/util.go
+++ b/util.go
@@ -38,7 +38,7 @@ func ToSortFunc[T any, R constraints.Ordered](f func(T) R) func(T, T) int {
 }
 
 func toRow(vs ...string) Row {
-	return Row{Columns: vs}
+	return vs
 }
 
 func ignoreError[T1, T2 any](v1 T1, _ T2) T1 {


### PR DESCRIPTION
This PR simplifies underlying of `Row` type from `struct` to `[]string`.