### PR TITLE
feat: Support AUTO_PARTITION_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Please note that directed read options do not apply to queries within a read-wri
 > 
 > Please refer to [the Spanner documentation](https://cloud.google.com/spanner/docs/instance-configurations#available-configurations-multi-region) to verify the valid configurations.
 
-## Client Statement Syntax
+## Client-Side Statement Syntax
 
 spanner-mycli supports all Spanner GoogleSQL and Spanner Graph statements, as well as several client-side statements.
 
@@ -1252,7 +1252,26 @@ spanner> RUN PARTITIONED QUERY SELECT * FROM Singers;
 5 rows in set from 3 partitions (1.40 sec)
 ```
 
-Note: Any stats are not available.
+Or you can use `SET AUTO_PARTITION_MODE`.
+```
+spanner> SET AUTO_PARTITION_MODE = TRUE;
+
+Empty set (0.00 sec)
+
+spanner> SELECT * FROM Singers;
++----------+-----------+----------+------------+------------+
+| SingerId | FirstName | LastName | SingerInfo | BirthDate  |
++----------+-----------+----------+------------+------------+
+| 1        | Marc      | Richards | NULL       | 1970-09-03 |
+| 2        | Catalina  | Smith    | NULL       | 1990-08-17 |
+| 3        | Alice     | Trentor  | NULL       | 1991-10-02 |
+| 4        | Lea       | Martin   | NULL       | 1991-11-09 |
+| 5        | David     | Lomond   | NULL       | 1977-01-29 |
++----------+-----------+----------+------------+------------+
+5 rows in set from 3 partitions (1.40 sec)
+```
+
+Note: Any stats are not available in partitioned query.
 
 #### Show partition tokens.
 

--- a/system_variables.go
+++ b/system_variables.go
@@ -34,13 +34,14 @@ import (
 
 type systemVariables struct {
 	// java-spanner compatible
+	AutoPartitionMode           bool                         // AUTO_PARTITION_MODE
 	RPCPriority                 sppb.RequestOptions_Priority // RPC_PRIORITY
 	ReadOnlyStaleness           *spanner.TimestampBound      // READ_ONLY_STALENESS
 	ReadTimestamp               time.Time                    // READ_TIMESTAMP
 	OptimizerVersion            string                       // OPTIMIZER_VERSION
 	OptimizerStatisticsPackage  string                       // OPTIMIZER_STATISTICS_PACKAGE
 	CommitResponse              *sppb.CommitResponse         // COMMIT_RESPONSE
-	CommitTimestamp             time.Time                    // COMMIT_TIMESTAP
+	CommitTimestamp             time.Time                    // COMMIT_TIMESTAMP
 	TransactionTag              string                       // TRANSACTION_TAG
 	RequestTag                  string                       // STATEMENT_TAG
 	ReadOnly                    bool                         // READONLY
@@ -196,6 +197,9 @@ var accessorMap = map[string]accessor{
 		},
 		Getter: boolGetter(func(sysVars *systemVariables) *bool { return &sysVars.ReadOnly }),
 	},
+	"AUTO_PARTITION_MODE": boolAccessor(func(variables *systemVariables) *bool {
+		return &variables.AutoPartitionMode
+	}),
 	"AUTOCOMMIT":              {},
 	"RETRY_ABORTS_INTERNALLY": {},
 	"AUTOCOMMIT_DML_MODE":     {},


### PR DESCRIPTION
This PR implements `AUTO_PARTITION_MODE`.

- Inspired by https://cloud.google.com/spanner/docs/jdbc-session-mgmt-commands?hl=en#auto_partition_mode

```
spanner> SET AUTO_PARTITION_MODE = TRUE;

Empty set (0.00 sec)

spanner> SELECT * FROM Singers;
+----------+-----------+----------+------------+------------+
| SingerId | FirstName | LastName | SingerInfo | BirthDate  |
+----------+-----------+----------+------------+------------+
| 1        | Marc      | Richards | NULL       | 1970-09-03 |
| 2        | Catalina  | Smith    | NULL       | 1990-08-17 |
| 3        | Alice     | Trentor  | NULL       | 1991-10-02 |
| 4        | Lea       | Martin   | NULL       | 1991-11-09 |
| 5        | David     | Lomond   | NULL       | 1977-01-29 |
+----------+-----------+----------+------------+------------+
5 rows in set from 3 partitions (1.40 sec)
```
