### PR TITLE
Implement BEGIN [RW] ISOLATION LEVEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,15 @@ spanner> SELECT * FROM Singers;
 
 Note: Any stats are not available in partitioned query.
 
+##### Isolation Level
+
+You can set session-level default isolation level and transaction-level isolation level.
+
+```
+spanner> SET DEFAULT_ISOLATION_LEVEL = "REPEATABLE_READ";
+spanner> BEGIN ISOLATION LEVEL REPEATABLE READ;
+```
+
 ##### Enable Data Boost
 
 You can enable Data Boost using `DATA_BOOST_ENABLED`.

--- a/session.go
+++ b/session.go
@@ -92,7 +92,8 @@ type transactionContext struct {
 	priority      sppb.RequestOptions_Priority
 	sendHeartbeat bool // Becomes true only after a user-driven query is executed on the transaction.
 
-	txn any
+	txn            any
+	isolationLevel sppb.TransactionOptions_IsolationLevel
 
 	// rwTxn         *spanner.ReadWriteStmtBasedTransaction
 	// roTxn         *spanner.ReadOnlyTransaction
@@ -217,7 +218,7 @@ func (s *Session) InTransaction() bool {
 
 // BeginPendingTransaction starts pending transaction.
 // The actual start of the transaction is delayed until the first operation in the transaction is executed.
-func (s *Session) BeginPendingTransaction(ctx context.Context, priority sppb.RequestOptions_Priority) error {
+func (s *Session) BeginPendingTransaction(ctx context.Context, isolationLevel sppb.TransactionOptions_IsolationLevel, priority sppb.RequestOptions_Priority) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
@@ -226,14 +227,20 @@ func (s *Session) BeginPendingTransaction(ctx context.Context, priority sppb.Req
 		return errors.New("read-only transaction is already running")
 	}
 
+	// Use session's default isolation level if transaction priority is not set.
+	if isolationLevel == sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED {
+		isolationLevel = s.systemVariables.DefaultIsolationLevel
+	}
+
 	// Use session's priority if transaction priority is not set.
 	if priority == sppb.RequestOptions_PRIORITY_UNSPECIFIED {
 		priority = s.systemVariables.RPCPriority
 	}
 
 	s.tc = &transactionContext{
-		mode:     transactionModePending,
-		priority: priority,
+		mode:           transactionModePending,
+		priority:       priority,
+		isolationLevel: isolationLevel,
 	}
 	return nil
 }
@@ -248,11 +255,11 @@ func (s *Session) DetermineTransaction(ctx context.Context) (time.Time, error) {
 		return s.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, s.tc.priority)
 	}
 
-	return zeroTime, s.BeginReadWriteTransaction(ctx, s.tc.priority)
+	return zeroTime, s.BeginReadWriteTransaction(ctx, s.tc.isolationLevel, s.tc.priority)
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
-func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority sppb.RequestOptions_Priority) error {
+func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolationLevel sppb.TransactionOptions_IsolationLevel, priority sppb.RequestOptions_Priority) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
@@ -271,12 +278,17 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority sppb.R
 		priority = s.systemVariables.RPCPriority
 	}
 
+	// Use session's isolation level if transaction isolation level is not set.
+	if isolationLevel == sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED {
+		isolationLevel = s.systemVariables.DefaultIsolationLevel
+	}
+
 	opts := spanner.TransactionOptions{
 		CommitOptions:               spanner.CommitOptions{ReturnCommitStats: true, MaxCommitDelay: s.systemVariables.MaxCommitDelay},
 		CommitPriority:              priority,
 		TransactionTag:              tag,
 		ExcludeTxnFromChangeStreams: s.systemVariables.ExcludeTxnFromChangeStreams,
-		IsolationLevel:              s.systemVariables.DefaultIsolationLevel,
+		IsolationLevel:              isolationLevel,
 	}
 
 	txn, err := spanner.NewReadWriteStmtBasedTransactionWithOptions(ctx, s.client, opts)
@@ -284,10 +296,11 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority sppb.R
 		return err
 	}
 	s.tc = &transactionContext{
-		mode:     transactionModeReadWrite,
-		tag:      tag,
-		priority: priority,
-		txn:      txn,
+		mode:           transactionModeReadWrite,
+		tag:            tag,
+		priority:       priority,
+		txn:            txn,
+		isolationLevel: isolationLevel,
 	}
 	return nil
 }
@@ -671,7 +684,7 @@ func (s *Session) RunInNewOrExistRwTx(ctx context.Context,
 	var implicitRWTx bool
 	if !s.InReadWriteTransaction() {
 		// Start implicit transaction.
-		if err := s.BeginReadWriteTransaction(ctx, s.currentPriority()); err != nil {
+		if err := s.BeginReadWriteTransaction(ctx, 0, s.currentPriority()); err != nil {
 			return 0, spanner.CommitResponse{}, nil, nil, err
 		}
 		implicitRWTx = true

--- a/session.go
+++ b/session.go
@@ -278,7 +278,7 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolationLevel 
 		priority = s.systemVariables.RPCPriority
 	}
 
-	// Use session's isolation level if transaction isolation level is not set.
+	// Use default isolation level if transaction isolation level is not set.
 	if isolationLevel == sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED {
 		isolationLevel = s.systemVariables.DefaultIsolationLevel
 	}
@@ -684,7 +684,8 @@ func (s *Session) RunInNewOrExistRwTx(ctx context.Context,
 	var implicitRWTx bool
 	if !s.InReadWriteTransaction() {
 		// Start implicit transaction.
-		if err := s.BeginReadWriteTransaction(ctx, 0, s.currentPriority()); err != nil {
+		// Note: isolation level is not session level property so it is left as unspecified.
+		if err := s.BeginReadWriteTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, s.currentPriority()); err != nil {
 			return 0, spanner.CommitResponse{}, nil, nil, err
 		}
 		implicitRWTx = true

--- a/statement_processing_test.go
+++ b/statement_processing_test.go
@@ -288,10 +288,54 @@ func TestBuildStatement(t *testing.T) {
 			},
 		},
 		{
+			desc:  "BEGIN statement with SERIALIZABLE",
+			input: "BEGIN ISOLATION LEVEL SERIALIZABLE",
+			want: &BeginStatement{
+				IsolationLevel: sppb.TransactionOptions_SERIALIZABLE,
+			},
+		},
+		{
+			desc:  "BEGIN statement with REPEATABLE READ",
+			input: "BEGIN ISOLATION LEVEL REPEATABLE READ",
+			want: &BeginStatement{
+				IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ,
+			},
+		},
+		{
+			desc:  "BEGIN statement with REPEATABLE READ and PRIORITY",
+			input: "BEGIN ISOLATION LEVEL REPEATABLE READ PRIORITY MEDIUM",
+			want: &BeginStatement{
+				IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ,
+				Priority:       sppb.RequestOptions_PRIORITY_MEDIUM,
+			},
+		},
+		{
 			desc:  "BEGIN RW PRIORITY statement",
 			input: "BEGIN RW PRIORITY LOW",
 			want: &BeginRwStatement{
 				Priority: sppb.RequestOptions_PRIORITY_LOW,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with SERIALIZABLE",
+			input: "BEGIN RW ISOLATION LEVEL SERIALIZABLE",
+			want: &BeginRwStatement{
+				IsolationLevel: sppb.TransactionOptions_SERIALIZABLE,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with REPEATABLE READ",
+			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ",
+			want: &BeginRwStatement{
+				IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with REPEATABLE READ and PRIORITY",
+			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ PRIORITY MEDIUM",
+			want: &BeginRwStatement{
+				IsolationLevel: sppb.TransactionOptions_REPEATABLE_READ,
+				Priority:       sppb.RequestOptions_PRIORITY_MEDIUM,
 			},
 		},
 		{

--- a/statements_transaction.go
+++ b/statements_transaction.go
@@ -97,7 +97,7 @@ func (s *SetTransactionStatement) Execute(ctx context.Context, session *Session)
 		result.Timestamp = ts
 		return result, nil
 	} else {
-		err := session.BeginReadWriteTransaction(ctx, 0, session.tc.priority)
+		err := session.BeginReadWriteTransaction(ctx, session.tc.isolationLevel, session.tc.priority)
 		if err != nil {
 			return nil, err
 		}

--- a/statements_transaction.go
+++ b/statements_transaction.go
@@ -26,7 +26,8 @@ type BeginRoStatement struct {
 }
 
 type BeginRwStatement struct {
-	Priority sppb.RequestOptions_Priority
+	IsolationLevel sppb.TransactionOptions_IsolationLevel
+	Priority       sppb.RequestOptions_Priority
 }
 
 func (BeginRwStatement) isMutationStatement() {}
@@ -40,7 +41,7 @@ func (s *BeginRwStatement) Execute(ctx context.Context, session *Session) (*Resu
 		return nil, errors.New("you're in read-only transaction. Please finish the transaction by 'CLOSE;'")
 	}
 
-	if err := session.BeginReadWriteTransaction(ctx, s.Priority); err != nil {
+	if err := session.BeginReadWriteTransaction(ctx, s.IsolationLevel, s.Priority); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +49,8 @@ func (s *BeginRwStatement) Execute(ctx context.Context, session *Session) (*Resu
 }
 
 type BeginStatement struct {
-	Priority sppb.RequestOptions_Priority
+	IsolationLevel sppb.TransactionOptions_IsolationLevel
+	Priority       sppb.RequestOptions_Priority
 }
 
 func (s *BeginStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
@@ -68,7 +70,7 @@ func (s *BeginStatement) Execute(ctx context.Context, session *Session) (*Result
 		}, nil
 	}
 
-	err := session.BeginPendingTransaction(ctx, s.Priority)
+	err := session.BeginPendingTransaction(ctx, s.IsolationLevel, s.Priority)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +97,7 @@ func (s *SetTransactionStatement) Execute(ctx context.Context, session *Session)
 		result.Timestamp = ts
 		return result, nil
 	} else {
-		err := session.BeginReadWriteTransaction(ctx, session.tc.priority)
+		err := session.BeginReadWriteTransaction(ctx, 0, session.tc.priority)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR implements `ISOLATION LEVEL` clause for `BEGIN` and `BEGIN RW`.

Note: `REPEATABLE READ` seems not yet to be enabled.

## Reference

- https://github.com/googleapis/java-spanner/pull/3704
  - It is not yet merged so it can be changed. If it is changed, spanner-mycli will do a breaking change. (We don't guarantee stability!)
- https://github.com/cloudspannerecosystem/spanner-cli/pull/206