### PR TITLE
Introduce CLI_EXECUTION_METHOD_FORMAT and change default format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.3.0
 	github.com/apstndb/spanemuboost v0.2.6
-	github.com/apstndb/spannerplanviz v0.3.3
+	github.com/apstndb/spannerplanviz v0.4.0
 	github.com/apstndb/spantype v0.3.8
 	github.com/apstndb/spanvalue v0.1.4
 	github.com/bufbuild/protocompile v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -2473,8 +2473,8 @@ github.com/apstndb/memebridge v0.3.0 h1:Rewbs9vmHKDFNdyLSP7j9202X6uHhomzy+Cw62rs
 github.com/apstndb/memebridge v0.3.0/go.mod h1:QmcdoK2Cp6Dg4vdFD2k7BF1bUlHuzvUkLNNxrAtEqIc=
 github.com/apstndb/spanemuboost v0.2.6 h1:Cw9U2FqoKrRBhVu/E3JqBN5UEDEMe4rVpkLZFlRCWu4=
 github.com/apstndb/spanemuboost v0.2.6/go.mod h1:ztuvIiI5a6p2dfNyKwnpuqwg7K0dwez2E4BU/NKFXHU=
-github.com/apstndb/spannerplanviz v0.3.3 h1:ZJBbHTGusUMxqhHCtjgOnfuBopYjxDlrSOazU+1duQo=
-github.com/apstndb/spannerplanviz v0.3.3/go.mod h1:nog9R8IUexhSz0NDncp+g8XT/r1Ere9dv8i37EvnMS0=
+github.com/apstndb/spannerplanviz v0.4.0 h1:wviUiJFTPzBDKObFqIcpfSj+h48WjNcNIyzYp5oVa5A=
+github.com/apstndb/spannerplanviz v0.4.0/go.mod h1:408f4dcRyB7b5u65At+4bXOF/oaQ+Ymtx4KR252AVNs=
 github.com/apstndb/spantype v0.3.8 h1:xy43Cclc2Hz6SL+3tZYuozOqJv6AML4Mv8cASgYo1O0=
 github.com/apstndb/spantype v0.3.8/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spanvalue v0.1.4 h1:K+x5x2brDCCAIiyaPWRDD9/WJ3+y33NdBLJr9dco3s8=

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/apstndb/spanemuboost"
+	"github.com/apstndb/spannerplanviz/queryplan"
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/cloudspannerecosystem/memefish"
@@ -203,6 +204,7 @@ func run(ctx context.Context, opts *spannerOptions) (exitCode int) {
 		VertexAIProject:           opts.VertexAIProject,
 		VertexAIModel:             lo.FromPtrOr(opts.VertexAIModel, defaultVertexAIModel),
 		EnableADCPlus:             true,
+		ExecutionMethodFormat:     queryplan.ExecutionMethodFormatAngle,
 	}
 
 	if opts.Strong {

--- a/statements_explain_describe_test.go
+++ b/statements_explain_describe_test.go
@@ -378,7 +378,7 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := plantree.ProcessPlan(queryplan.New(plan.GetPlanNodes()))
+			got, err := processPlanNodes(plan.GetPlanNodes(), queryplan.ExecutionMethodFormatAngle)
 			if err != nil {
 				t.Errorf("error should be nil, but got = %v", err)
 			}

--- a/statements_query_profile.go
+++ b/statements_query_profile.go
@@ -76,7 +76,7 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 
 	var resultRows []Row
 	for _, row := range rows {
-		rows, predicates, err := processPlanWithStats(row.QueryProfile.QueryPlan)
+		rows, predicates, err := processPlanWithStats(row.QueryProfile.QueryPlan, session.systemVariables.ExecutionMethodFormat)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ ORDER BY INTERVAL_END DESC`,
 		return nil, errors.New("empty result")
 	}
 
-	rows, predicates, err := processPlanWithStats(qpr.QueryProfile.QueryPlan)
+	rows, predicates, err := processPlanWithStats(qpr.QueryProfile.QueryPlan, session.systemVariables.ExecutionMethodFormat)
 	if err != nil {
 		return nil, err
 	}

--- a/system_variables.go
+++ b/system_variables.go
@@ -699,7 +699,7 @@ var systemVariableDefMap = map[string]systemVariableDef{
 					this.ExecutionMethodFormat = queryplan.ExecutionMethodFormatAngle
 					return nil
 				default:
-					return fmt.Errorf("invalid value: %v", s)
+					return fmt.Errorf("invalid value: %v. Valid values are 'RAW' and 'ANGLE'", s)
 				}
 			},
 		},


### PR DESCRIPTION
This PR introduces `CLI_EXECUTION_METHOD_FORMAT` and change default format.

- New format displays `execution_method` metadata as `<Row>` or `<Batch>` after display name of operator.
- It reduces column width, typically 16 characters(`s/execution_method: /<>/`).
- I believe it improves query plan readability in both of simple and complex cases.

## Simple example

```sql
EXPLAIN
SELECT * FROM Singers;
```

### `CLI_EXECUTION_METHOD_FORMAT=RAW` (original)

```
+----+------------------------------------------------------------------------------------------------------+
| ID | Query_Execution_Plan                                                                                 |
+----+------------------------------------------------------------------------------------------------------+
|  0 | Distributed Union (distribution_table: Singers, execution_method: Row, split_ranges_aligned: false)  |
|  1 | +- Local Distributed Union (execution_method: Row)                                                   |
|  2 |    +- Serialize Result (execution_method: Row)                                                       |
|  3 |       +- Table Scan (Full scan: true, Table: Singers, execution_method: Row, scan_method: Automatic) |
+----+------------------------------------------------------------------------------------------------------+
```

### `CLI_EXECUTION_METHOD_FORMAT=ANGLE` (new default)

```
+----+-------------------------------------------------------------------------------------+
| ID | Query_Execution_Plan                                                                |
+----+-------------------------------------------------------------------------------------+
|  0 | Distributed Union <Row> (distribution_table: Singers, split_ranges_aligned: false)  |
|  1 | +- Local Distributed Union <Row>                                                    |
|  2 |    +- Serialize Result <Row>                                                        |
|  3 |       +- Table Scan <Row> (Full scan: true, Table: Singers, scan_method: Automatic) |
+----+-------------------------------------------------------------------------------------+
```

## Complex example

https://cloud.google.com/spanner/docs/graph/queries-overview#quantified-edge-pattern

```sql
EXPLAIN
GRAPH FinGraph
MATCH (src:Account {id: 7})-[e:Transfers]->{1, 3}(dst:Account)
WHERE src != dst
RETURN src.id AS src_account_id, ARRAY_LENGTH(e) AS path_length, dst.id AS dst_account_id;
```

### `CLI_EXECUTION_METHOD_FORMAT=RAW` (original)


```
+-----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan                                                                                                                                                            |
+-----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|   0 | Serialize Result (execution_method: Row)                                                                                                                                        |
|  *1 | +- Filter (execution_method: Row)                                                                                                                                               |
|   2 |    +- DataBlockToRow                                                                                                                                                            |
|   3 |       +- Recursive Union                                                                                                                                                        |
|   4 |          +- Union Input                                                                                                                                                         |
|   5 |          |  +- RowToDataBlock                                                                                                                                                   |
|   6 |          |     +- Cross Apply (execution_method: Row)                                                                                                                           |
|   7 |          |        +- Stream Aggregate (execution_method: Row, scalar_aggregate: true)                                                                                           |
|   8 |          |        |  +- Compute Struct (execution_method: Row)                                                                                                                  |
|   9 |          |        |     +- Empty Relation (execution_method: Row)                                                                                                               |
|  22 |          |        +- [Map] DataBlockToRow                                                                                                                                       |
| *23 |          |           +- Distributed Union (distribution_table: Account, execution_method: Batch, split_ranges_aligned: false)                                                   |
|  24 |          |              +- RowToDataBlock                                                                                                                                       |
|  25 |          |                 +- Local Distributed Union (execution_method: Row)                                                                                                   |
|  26 |          |                    +- Compute (execution_method: Row)                                                                                                                |
|  27 |          |                       +- Filter Scan (execution_method: Row, seekable_key_size: 0)                                                                                   |
| *28 |          |                          +- Table Scan (Table: Account, execution_method: Row, scan_method: Row)                                                                     |
|  47 |          +- Union Input                                                                                                                                                         |
|  48 |             +- RowToDataBlock                                                                                                                                                   |
|  49 |                +- Compute (execution_method: Row)                                                                                                                               |
| *50 |                   +- Hash Join (execution_method: Row, join_type: INNER)                                                                                                        |
|  51 |                      +- [Build] BloomFilterBuild (execution_method: Row)                                                                                                        |
|  52 |                      |  +- DataBlockToRow                                                                                                                                       |
|  53 |                      |     +- Recursive Spool Scan                                                                                                                              |
|  64 |                      +- [Probe] DataBlockToRow                                                                                                                                  |
|  65 |                         +- Distributed Union (distribution_table: IDX_AccountTransferAccount_to_id_8F1D3A3A173541D1, execution_method: Batch, split_ranges_aligned: false)      |
|  66 |                            +- RowToDataBlock                                                                                                                                    |
|  67 |                               +- Local Distributed Union (execution_method: Row)                                                                                                |
|  68 |                                  +- Compute Struct (execution_method: Row)                                                                                                      |
| *69 |                                     +- Filter Scan (execution_method: Row, seekable_key_size: 0)                                                                                |
|  70 |                                        +- Index Scan (Full scan: true, Index: IDX_AccountTransferAccount_to_id_8F1D3A3A173541D1, execution_method: Row, scan_method: Automatic) |
+-----+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

### `CLI_EXECUTION_METHOD_FORMAT=ANGLE` (new default)



```
+-----+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan                                                                                                                                           |
+-----+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
|   0 | Serialize Result <Row>                                                                                                                                         |
|  *1 | +- Filter <Row>                                                                                                                                                |
|   2 |    +- DataBlockToRow                                                                                                                                           |
|   3 |       +- Recursive Union                                                                                                                                       |
|   4 |          +- Union Input                                                                                                                                        |
|   5 |          |  +- RowToDataBlock                                                                                                                                  |
|   6 |          |     +- Cross Apply <Row>                                                                                                                            |
|   7 |          |        +- Stream Aggregate <Row> (scalar_aggregate: true)                                                                                           |
|   8 |          |        |  +- Compute Struct <Row>                                                                                                                   |
|   9 |          |        |     +- Empty Relation <Row>                                                                                                                |
|  22 |          |        +- [Map] DataBlockToRow                                                                                                                      |
| *23 |          |           +- Distributed Union <Batch> (distribution_table: Account, split_ranges_aligned: false)                                                   |
|  24 |          |              +- RowToDataBlock                                                                                                                      |
|  25 |          |                 +- Local Distributed Union <Row>                                                                                                    |
|  26 |          |                    +- Compute <Row>                                                                                                                 |
|  27 |          |                       +- Filter Scan <Row> (seekable_key_size: 0)                                                                                   |
| *28 |          |                          +- Table Scan <Row> (Table: Account, scan_method: Row)                                                                     |
|  47 |          +- Union Input                                                                                                                                        |
|  48 |             +- RowToDataBlock                                                                                                                                  |
|  49 |                +- Compute <Row>                                                                                                                                |
| *50 |                   +- Hash Join <Row> (join_type: INNER)                                                                                                        |
|  51 |                      +- [Build] BloomFilterBuild <Row>                                                                                                         |
|  52 |                      |  +- DataBlockToRow                                                                                                                      |
|  53 |                      |     +- Recursive Spool Scan                                                                                                             |
|  64 |                      +- [Probe] DataBlockToRow                                                                                                                 |
|  65 |                         +- Distributed Union <Batch> (distribution_table: IDX_AccountTransferAccount_to_id_8F1D3A3A173541D1, split_ranges_aligned: false)      |
|  66 |                            +- RowToDataBlock                                                                                                                   |
|  67 |                               +- Local Distributed Union <Row>                                                                                                 |
|  68 |                                  +- Compute Struct <Row>                                                                                                       |
| *69 |                                     +- Filter Scan <Row> (seekable_key_size: 0)                                                                                |
|  70 |                                        +- Index Scan <Row> (Full scan: true, Index: IDX_AccountTransferAccount_to_id_8F1D3A3A173541D1, scan_method: Automatic) |
+-----+----------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

## Breaking Change

It changes default format of `EXPLAIN` and `EXPLAIN ANALYZE`.
You can show old format by `SET CLI_EXECUTION_METHOD_FORMAT="RAW"`.