### PR TITLE
Update header of EXPLAIN and EXPLAIN ANALYZE

### DIFF
--- a/statement_processing.go
+++ b/statement_processing.go
@@ -129,10 +129,10 @@ const (
 )
 
 var (
-	explainColumnNames = []string{"ID", "Query_Execution_Plan"}
+	explainColumnNames = []string{"ID", "Query_Execution_Plan <execution_method> (metadata, ...)"}
 	explainColumnAlign = []int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT}
 
-	explainAnalyzeColumnNames = []string{"ID", "Query_Execution_Plan", "Rows_Returned", "Executions", "Total_Latency"}
+	explainAnalyzeColumnNames = []string{"ID", "Query_Execution_Plan <execution_method> (metadata, ...)", "Rows_Returned", "Executions", "Total_Latency"}
 	explainAnalyzeColumnAlign = []int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT}
 
 	describeColumnNames = []string{"Column_Name", "Column_Type"}


### PR DESCRIPTION
This PR updates header of `EXPLAIN` and `EXPLAIN ANALYZE` to improve readability.

```
spanner> EXPLAIN
      -> SELECT * FROM Singers;
+----+-------------------------------------------------------------------------------------+
| ID | Query_Execution_Plan <execution_method> (metadata, ...)                             |
+----+-------------------------------------------------------------------------------------+
|  0 | Distributed Union <Row> (distribution_table: Singers, split_ranges_aligned: false)  |
|  1 | +- Local Distributed Union <Row>                                                    |
|  2 |    +- Serialize Result <Row>                                                        |
|  3 |       +- Table Scan <Row> (Full scan: true, Table: Singers, scan_method: Automatic) |
+----+-------------------------------------------------------------------------------------+
4 rows in set (0.17 sec)

spanner> EXPLAIN ANALYZE
      -> SELECT * FROM Singers;
+----+-------------------------------------------------------------------------------------+---------------+------------+---------------+
| ID | Query_Execution_Plan <execution_method> (metadata, ...)                             | Rows_Returned | Executions | Total_Latency |
+----+-------------------------------------------------------------------------------------+---------------+------------+---------------+
|  0 | Distributed Union <Row> (distribution_table: Singers, split_ranges_aligned: false)  | 5             | 1          | 1.17 msecs    |
|  1 | +- Local Distributed Union <Row>                                                    | 5             | 1          | 1.16 msecs    |
|  2 |    +- Serialize Result <Row>                                                        | 5             | 1          | 1.15 msecs    |
|  3 |       +- Table Scan <Row> (Full scan: true, Table: Singers, scan_method: Automatic) | 5             | 1          | 1.14 msecs    |
+----+-------------------------------------------------------------------------------------+---------------+------------+---------------+

```