### PR TITLE
Improve EXPLAIN notation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.3.0
 	github.com/apstndb/spanemuboost v0.2.8
-	github.com/apstndb/spannerplanviz v0.5.0
+	github.com/apstndb/spannerplanviz v0.5.1
 	github.com/apstndb/spantype v0.3.8
 	github.com/apstndb/spanvalue v0.1.5
 	github.com/bufbuild/protocompile v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.3.0
 	github.com/apstndb/spanemuboost v0.2.8
-	github.com/apstndb/spannerplanviz v0.4.0
+	github.com/apstndb/spannerplanviz v0.5.0
 	github.com/apstndb/spantype v0.3.8
 	github.com/apstndb/spanvalue v0.1.5
 	github.com/bufbuild/protocompile v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -2473,8 +2473,8 @@ github.com/apstndb/memebridge v0.3.0 h1:Rewbs9vmHKDFNdyLSP7j9202X6uHhomzy+Cw62rs
 github.com/apstndb/memebridge v0.3.0/go.mod h1:QmcdoK2Cp6Dg4vdFD2k7BF1bUlHuzvUkLNNxrAtEqIc=
 github.com/apstndb/spanemuboost v0.2.8 h1:v4VA3CooN8EAFwGIaxu440C83pviUOqdWZyyDiN4IT8=
 github.com/apstndb/spanemuboost v0.2.8/go.mod h1:wJhll023cMlmIDBqOyyVIUyRpIXTCW3jWp/qalZe4Ok=
-github.com/apstndb/spannerplanviz v0.5.0 h1:WzenyRPHyFBqI2dPKo7UM8RS5p5vJOJ3aU/SfCKKgR4=
-github.com/apstndb/spannerplanviz v0.5.0/go.mod h1:qZ4AieTYzQqV2wDzcwBKm954HzdMpdMk3i3dyCboE/0=
+github.com/apstndb/spannerplanviz v0.5.1 h1:huPd4Ej7Z5ANRy8A+JAjcP40KwuGfE8ZLHMIptk7amg=
+github.com/apstndb/spannerplanviz v0.5.1/go.mod h1:ApXFLrjjBQWaY94HDIOPCVXK18AuExzHYwEJbXgMYA0=
 github.com/apstndb/spantype v0.3.8 h1:xy43Cclc2Hz6SL+3tZYuozOqJv6AML4Mv8cASgYo1O0=
 github.com/apstndb/spantype v0.3.8/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spanvalue v0.1.5 h1:vjGniZPTLVgrCHKhqAdj9cImG2j8hN6VxeM/8KHeGpQ=

--- a/go.sum
+++ b/go.sum
@@ -2473,8 +2473,8 @@ github.com/apstndb/memebridge v0.3.0 h1:Rewbs9vmHKDFNdyLSP7j9202X6uHhomzy+Cw62rs
 github.com/apstndb/memebridge v0.3.0/go.mod h1:QmcdoK2Cp6Dg4vdFD2k7BF1bUlHuzvUkLNNxrAtEqIc=
 github.com/apstndb/spanemuboost v0.2.8 h1:v4VA3CooN8EAFwGIaxu440C83pviUOqdWZyyDiN4IT8=
 github.com/apstndb/spanemuboost v0.2.8/go.mod h1:wJhll023cMlmIDBqOyyVIUyRpIXTCW3jWp/qalZe4Ok=
-github.com/apstndb/spannerplanviz v0.4.0 h1:wviUiJFTPzBDKObFqIcpfSj+h48WjNcNIyzYp5oVa5A=
-github.com/apstndb/spannerplanviz v0.4.0/go.mod h1:408f4dcRyB7b5u65At+4bXOF/oaQ+Ymtx4KR252AVNs=
+github.com/apstndb/spannerplanviz v0.5.0 h1:WzenyRPHyFBqI2dPKo7UM8RS5p5vJOJ3aU/SfCKKgR4=
+github.com/apstndb/spannerplanviz v0.5.0/go.mod h1:qZ4AieTYzQqV2wDzcwBKm954HzdMpdMk3i3dyCboE/0=
 github.com/apstndb/spantype v0.3.8 h1:xy43Cclc2Hz6SL+3tZYuozOqJv6AML4Mv8cASgYo1O0=
 github.com/apstndb/spantype v0.3.8/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spanvalue v0.1.5 h1:vjGniZPTLVgrCHKhqAdj9cImG2j8hN6VxeM/8KHeGpQ=

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/apstndb/spanemuboost"
-	"github.com/apstndb/spannerplanviz/queryplan"
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/cloudspannerecosystem/memefish"
@@ -204,7 +203,6 @@ func run(ctx context.Context, opts *spannerOptions) (exitCode int) {
 		VertexAIProject:           opts.VertexAIProject,
 		VertexAIModel:             lo.FromPtrOr(opts.VertexAIModel, defaultVertexAIModel),
 		EnableADCPlus:             true,
-		ExecutionMethodFormat:     queryplan.ExecutionMethodFormatAngle,
 	}
 
 	if opts.Strong {

--- a/statements_explain_describe_test.go
+++ b/statements_explain_describe_test.go
@@ -378,7 +378,7 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := processPlanNodes(plan.GetPlanNodes(), queryplan.ExecutionMethodFormatAngle)
+			got, err := processPlanNodes(plan.GetPlanNodes(), true)
 			if err != nil {
 				t.Errorf("error should be nil, but got = %v", err)
 			}

--- a/statements_query_profile.go
+++ b/statements_query_profile.go
@@ -76,7 +76,7 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 
 	var resultRows []Row
 	for _, row := range rows {
-		rows, predicates, err := processPlanWithStats(row.QueryProfile.QueryPlan, session.systemVariables.ExecutionMethodFormat)
+		rows, predicates, err := processPlanWithStats(row.QueryProfile.QueryPlan, session.systemVariables.SpannerCLICompatiblePlan)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ ORDER BY INTERVAL_END DESC`,
 		return nil, errors.New("empty result")
 	}
 
-	rows, predicates, err := processPlanWithStats(qpr.QueryProfile.QueryPlan, session.systemVariables.ExecutionMethodFormat)
+	rows, predicates, err := processPlanWithStats(qpr.QueryProfile.QueryPlan, session.systemVariables.SpannerCLICompatiblePlan)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR introduces new `EXPLAIN` notation via spannerplanviz package.

- https://github.com/apstndb/spannerplanviz/releases/tag/v0.5.0
  - Now, `Full scan: true` is shown as `Full scan`.
  - Now, `scan_target` and `distribution_table` are shown as `on <target>` after operator name.
- https://github.com/apstndb/spannerplanviz/releases/tag/v0.5.1
  - Fix `[Input]` pseudo link type in `* Apply` operators.
- `CLI_SPANNER_CLI_COMPATIBLE_PLAN=true` shows old notation.

## Breaking Change

- `CLI_EXECUTION_METHOD_FORMAT` (introduced at [v0.12.0](https://github.com/apstndb/spanner-mycli/releases/tag/v0.12.0)) is replaced by `CLI_SPANNER_CLI_COMPATIBLE_PLAN`.

## Example

```sql
SELECT *
FROM Singers@{FORCE_INDEX=SingersByFirstLastName}
WHERE FirstName = "Marc";
```
### Before
```
+-----+---------------------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan <execution_method> (metadata, ...)                                           |
+-----+---------------------------------------------------------------------------------------------------+
|  *0 | Distributed Union <Row> (distribution_table: SingersByFirstLastName, split_ranges_aligned: false) |
|  *1 | +- Distributed Cross Apply <Row>                                                                  |
|   2 |    +- Create Batch <Row>                                                                          |
|   3 |    |  +- Local Distributed Union <Row>                                                            |
|   4 |    |     +- Compute Struct <Row>                                                                  |
|   5 |    |        +- Filter Scan <Row> (seekable_key_size: 0)                                           |
|  *6 |    |           +- Index Scan <Row> (Index: SingersByFirstLastName, scan_method: Automatic)        |
|  17 |    +- [Map] Serialize Result <Row>                                                                |
|  18 |       +- Cross Apply <Row>                                                                        |
|  19 |          +- KeyRangeAccumulator <Row>                                                             |
|  20 |          |  +- Batch Scan <Row> (Batch: $v2, scan_method: Row)                                    |
|  23 |          +- [Map] Local Distributed Union <Row>                                                   |
|  24 |             +- Filter Scan <Row> (seekable_key_size: 0)                                           |
| *25 |                +- Table Scan <Row> (Table: Singers, scan_method: Row)                             |
+-----+---------------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  0: Split Range: ($FirstName = 'Marc')
  1: Split Range: ($SingerId' = $SingerId)
  6: Seek Condition: IS_NOT_DISTINCT_FROM($FirstName, 'Marc')
 25: Seek Condition: ($SingerId' = $batched_SingerId)
```

### New Default

```
+-----+---------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan <execution_method> (metadata, ...)                               |
+-----+---------------------------------------------------------------------------------------+
|  *0 | Distributed Union on SingersByFirstLastName <Row> (split_ranges_aligned: false)       |
|  *1 | +- Distributed Cross Apply <Row>                                                      |
|   2 |    +- [Input] Create Batch <Row>                                                      |
|   3 |    |  +- Local Distributed Union <Row>                                                |
|   4 |    |     +- Compute Struct <Row>                                                      |
|   5 |    |        +- Filter Scan <Row> (seekable_key_size: 0)                               |
|  *6 |    |           +- Index Scan on SingersByFirstLastName <Row> (scan_method: Automatic) |
|  17 |    +- [Map] Serialize Result <Row>                                                    |
|  18 |       +- Cross Apply <Row>                                                            |
|  19 |          +- [Input] KeyRangeAccumulator <Row>                                         |
|  20 |          |  +- Batch Scan on $v2 <Row> (scan_method: Row)                             |
|  23 |          +- [Map] Local Distributed Union <Row>                                       |
|  24 |             +- Filter Scan <Row> (seekable_key_size: 0)                               |
| *25 |                +- Table Scan on Singers <Row> (scan_method: Row)                      |
+-----+---------------------------------------------------------------------------------------+
Predicates(identified by ID):
  0: Split Range: ($FirstName = 'Marc')
  1: Split Range: ($SingerId' = $SingerId)
  6: Seek Condition: IS_NOT_DISTINCT_FROM($FirstName, 'Marc')
 25: Seek Condition: ($SingerId' = $batched_SingerId)
```