### PR TITLE
Change go-spanner-cassandra log level to warn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1
 	github.com/gocql/gocql v1.7.0
 	github.com/google/go-cmp v0.7.0
-	github.com/googleapis/go-spanner-cassandra v0.1.0
+	github.com/googleapis/go-spanner-cassandra v0.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/hymkor/go-multiline-ny v0.20.2
 	github.com/jessevdk/go-flags v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -2797,8 +2797,8 @@ github.com/googleapis/gax-go/v2 v2.13.0/go.mod h1:Z/fvTZXF8/uw7Xu5GuslPw+bplx6SS
 github.com/googleapis/gax-go/v2 v2.14.0/go.mod h1:lhBCnjdLrWRaPvLWhmc8IS24m9mr07qSYnHncrgo+zk=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
-github.com/googleapis/go-spanner-cassandra v0.1.0 h1:3XaBqCa5CLP56hzjw4wo8rcZYO6wnIqyHZRQhfOFdHY=
-github.com/googleapis/go-spanner-cassandra v0.1.0/go.mod h1:vgKNTC+/4pcNXBAJa3eSzK4BjEVUvl6F9/psq7HOAOk=
+github.com/googleapis/go-spanner-cassandra v0.2.0 h1:nnm9mjQnqmcPabGVoNYimJxse/JkVRn46o8mTfvhP3Q=
+github.com/googleapis/go-spanner-cassandra v0.2.0/go.mod h1:vgKNTC+/4pcNXBAJa3eSzK4BjEVUvl6F9/psq7HOAOk=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/statements.go
+++ b/statements.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gocql/gocql"
 	spancql "github.com/googleapis/go-spanner-cassandra/cassandra/gocql"
 	"github.com/samber/lo"
+	"go.uber.org/zap/zapcore"
 )
 
 var transactionRe = regexp.MustCompile(`(?is)^(?:(READ\s+ONLY)|(READ\s+WRITE))$`)
@@ -312,6 +313,7 @@ func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (*Result,
 	// lazy initialize gocql.ClusterConfig
 	if session.cqlCluster == nil {
 		cluster := spancql.NewCluster(&spancql.Options{
+			LogLevel:    zapcore.WarnLevel.String(),
 			DatabaseUri: session.DatabasePath(),
 		})
 		if cluster == nil {


### PR DESCRIPTION
This PR bumps go-spanner-cassandra to [v0.2.0](https://github.com/googleapis/go-spanner-cassandra/releases/tag/v0.2.0) and change log level to warn.

## Reference

- https://github.com/googleapis/go-spanner-cassandra/pull/30