### PR TITLE
fix: Support query parameters in bufferOrExecuteDML

### DIFF
--- a/statements.go
+++ b/statements.go
@@ -17,8 +17,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -27,10 +29,12 @@ import (
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/gsqlutils"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/memebridge"
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/cloudspannerecosystem/memefish/token"
 	"github.com/gocql/gocql"
 	spancql "github.com/googleapis/go-spanner-cassandra/cassandra/gocql"
 	"github.com/samber/lo"
@@ -482,7 +486,19 @@ func (s *NopStatement) Execute(ctx context.Context, session *Session) (*Result, 
 // Helper function for statements.go.
 
 func newStatement(sql string, params map[string]ast.Node, includeType bool) (spanner.Statement, error) {
-	genParams, err := generateParams(params, includeType)
+	usedParamNames, err := usedQueryParameterNames(sql)
+	if err != nil {
+		return spanner.Statement{}, err
+	}
+
+	filteredParams := make(map[string]ast.Node)
+	for _, name := range usedParamNames {
+		if _, ok := params[name]; ok {
+			filteredParams[name] = params[name]
+		}
+	}
+
+	genParams, err := generateParams(filteredParams, includeType)
 	if err != nil {
 		return spanner.Statement{}, err
 	}
@@ -490,6 +506,21 @@ func newStatement(sql string, params map[string]ast.Node, includeType bool) (spa
 		SQL:    sql,
 		Params: genParams,
 	}, nil
+}
+
+func usedQueryParameterNames(s string) ([]string, error) {
+	set := make(map[string]struct{})
+	for tok, err := range gsqlutils.NewLexerSeq("", s) {
+		if err != nil {
+			return nil, err
+		}
+
+		if tok.Kind == token.TokenParam {
+			set[tok.AsString] = struct{}{}
+		}
+	}
+
+	return slices.Sorted(maps.Keys(set)), nil
 }
 
 func extractSchemaAndName(s string) (string, string) {

--- a/statements.go
+++ b/statements.go
@@ -301,7 +301,7 @@ func (s *BulkDdlStatement) Execute(ctx context.Context, session *Session) (*Resu
 }
 
 type BatchDMLStatement struct {
-	DMLs []string
+	DMLs []spanner.Statement
 }
 
 func (BatchDMLStatement) IsMutationStatement() {}

--- a/statements_test.go
+++ b/statements_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanvalue/gcvctor"
+	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestNewStatement(t *testing.T) {
+	type args struct {
+		sql         string
+		params      map[string]ast.Node
+		includeType bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    spanner.Statement
+		wantErr bool
+	}{
+		{
+			name: "Statement without params",
+			args: args{
+				sql: "SELECT 1",
+			},
+			want:    spanner.Statement{SQL: "SELECT 1"},
+			wantErr: false,
+		},
+		{
+			name: "Statement with unused params",
+			args: args{
+				sql: "SELECT 1",
+				params: map[string]ast.Node{
+					"unused": &ast.BoolLiteral{Value: true},
+				},
+			},
+			want:    spanner.Statement{SQL: "SELECT 1"},
+			wantErr: false,
+		},
+		{
+			name: "Statement with used params",
+			args: args{
+				sql: "SELECT @n",
+				params: map[string]ast.Node{
+					"n": &ast.IntLiteral{Base: 10, Value: "1"},
+				},
+			},
+			want: spanner.Statement{
+				SQL: "SELECT @n",
+				Params: map[string]interface{}{
+					"n": gcvctor.Int64Value(1),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Statement with used and unused params",
+			args: args{
+				sql: "SELECT @n",
+				params: map[string]ast.Node{
+					"n":      &ast.IntLiteral{Base: 10, Value: "1"},
+					"unused": &ast.BoolLiteral{Value: true},
+				},
+			},
+			want: spanner.Statement{
+				SQL: "SELECT @n",
+				Params: map[string]interface{}{
+					"n": gcvctor.Int64Value(1),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newStatement(tt.args.sql, tt.args.params, tt.args.includeType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newStatement() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want, cmpopts.EquateEmpty(), protocmp.Transform()); diff != "" {
+				t.Errorf("newStatement() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes behavior of query parameters in batch DML.
Additionally, this change ensures that unused parameter won't be sent.

## Related Issues

- close #162 