### PR TITLE
misc: Bump go-genai to v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ spanner:
       --query-mode=[NORMAL|PLAN|PROFILE]                  Mode in which the query must be processed.
       --strong                                            Perform a strong query.
       --read-timestamp=                                   Perform a query at the given timestamp.
-      --vertexai-project=                                 VertexAI project
-      --vertexai-model=                                   VertexAI project (default: gemini-2.0-flash)
+      --vertexai-project=                                 Vertex AI project
+      --vertexai-model=                                   Vertex AI model (default: gemini-2.0-flash)
       --database-dialect=[POSTGRESQL|GOOGLE_STANDARD_SQL] The SQL dialect of the Cloud Spanner Database.
       --impersonate-service-account=                      Impersonate service account email
       --version                                           Show version string.

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/term v0.31.0
 	google.golang.org/api v0.229.0
-	google.golang.org/genai v1.1.0
+	google.golang.org/genai v1.3.0
 	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.6
 	spheric.cloud/xiter v0.0.0-20250113160306-a1a2c1108100

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	cloud.google.com/go v0.120.1
+	cloud.google.com/go/longrunning v0.6.6
 	cloud.google.com/go/spanner v1.79.0
 	github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c
 	github.com/apstndb/genaischema v0.1.1
@@ -51,7 +52,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/iam v1.4.2 // indirect
-	cloud.google.com/go/longrunning v0.6.6 // indirect
 	cloud.google.com/go/monitoring v1.24.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3779,6 +3779,8 @@ google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJ
 google.golang.org/appengine/v2 v2.0.6/go.mod h1:WoEXGoXNfa0mLvaH5sV3ZSGXwVmy8yf7Z1JKf3J3wLI=
 google.golang.org/genai v1.1.0 h1:EXgATzxiPi13tZCmfEKeEq0dybQ2FbKLlLAyWYe2FeA=
 google.golang.org/genai v1.1.0/go.mod h1:TyfOKRz/QyCaj6f/ZDt505x+YreXnY40l2I6k8TvgqY=
+google.golang.org/genai v1.3.0 h1:tXhPJF30skOjnnDY7ZnjK3q7IKy4PuAlEA0fk7uEaEI=
+google.golang.org/genai v1.3.0/go.mod h1:TyfOKRz/QyCaj6f/ZDt505x+YreXnY40l2I6k8TvgqY=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/go.sum
+++ b/go.sum
@@ -3777,8 +3777,6 @@ google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/appengine/v2 v2.0.6/go.mod h1:WoEXGoXNfa0mLvaH5sV3ZSGXwVmy8yf7Z1JKf3J3wLI=
-google.golang.org/genai v1.1.0 h1:EXgATzxiPi13tZCmfEKeEq0dybQ2FbKLlLAyWYe2FeA=
-google.golang.org/genai v1.1.0/go.mod h1:TyfOKRz/QyCaj6f/ZDt505x+YreXnY40l2I6k8TvgqY=
 google.golang.org/genai v1.3.0 h1:tXhPJF30skOjnnDY7ZnjK3q7IKy4PuAlEA0fk7uEaEI=
 google.golang.org/genai v1.3.0/go.mod h1:TyfOKRz/QyCaj6f/ZDt505x+YreXnY40l2I6k8TvgqY=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/main.go
+++ b/main.go
@@ -81,8 +81,8 @@ type spannerOptions struct {
 	QueryMode                 string            `long:"query-mode" description:"Mode in which the query must be processed." choice:"NORMAL" choice:"PLAN" choice:"PROFILE"`
 	Strong                    bool              `long:"strong" description:"Perform a strong query."`
 	ReadTimestamp             string            `long:"read-timestamp" description:"Perform a query at the given timestamp."`
-	VertexAIProject           string            `long:"vertexai-project" description:"VertexAI project" ini-name:"vertexai_project"`
-	VertexAIModel             *string           `long:"vertexai-model" description:"VertexAI project" ini-name:"vertexai_model" default-mask:"gemini-2.0-flash"`
+	VertexAIProject           string            `long:"vertexai-project" description:"Vertex AI project" ini-name:"vertexai_project"`
+	VertexAIModel             *string           `long:"vertexai-model" description:"Vertex AI model" ini-name:"vertexai_model" default-mask:"gemini-2.0-flash"`
 	DatabaseDialect           string            `long:"database-dialect" description:"The SQL dialect of the Cloud Spanner Database." choice:"POSTGRESQL" choice:"GOOGLE_STANDARD_SQL"`
 	ImpersonateServiceAccount string            `long:"impersonate-service-account" description:"Impersonate service account email"`
 	Version                   bool              `long:"version" description:"Show version string."`

--- a/statements_llm.go
+++ b/statements_llm.go
@@ -134,7 +134,7 @@ Here is the prototext of File Proto Descriptors.
 ` + fmt.Sprintf("```\n%v\n```", prototext.Format(&fds))
 
 	return genaischema.GenerateObjectContent[*output](ctx, client, model,
-		[]*genai.Content{{Parts: parts}},
+		[]*genai.Content{{Role: genai.RoleUser, Parts: parts}},
 		&genai.GenerateContentConfig{
 			SystemInstruction: &genai.Content{
 				Parts: sliceOf(genai.NewPartFromText(systemPrompt)),


### PR DESCRIPTION
This PR bumps go-genai to v1.3.0.

Additionally, it includes some fix:
- Explicit user role. It is required after go-genai v0.6.0. https://github.com/googleapis/go-genai/releases/tag/v0.6.0
  - > Remove default role to "user" for GenerateContent and GenerateContentStream.
- Fix description of `--vertexai-model`.