### PR TITLE
fix: Replace tabs to avoid broken rendering

### DIFF
--- a/cli_output.go
+++ b/cli_output.go
@@ -36,6 +36,13 @@ const (
 	DisplayModeTab
 )
 
+func mapAllCells(f func(string) string, rows []Row) []Row {
+	return slices.Collect(
+		xiter.Map(func(r Row) Row { return slices.Collect(xiter.Map(f, slices.Values(r))) },
+			slices.Values(rows)),
+	)
+}
+
 func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result, interactive bool, input string) {
 	mode := sysVars.CLIFormat
 
@@ -55,21 +62,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 	switch mode {
 	case DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment:
 		// Replace tabs with two whitespace
-		rows := slices.Collect(
-			xiter.Map(
-				func(r Row) Row {
-					return slices.Collect(
-						xiter.Map(
-							func(s string) string {
-								return strings.ReplaceAll(s, "\t", "  ")
-							},
-							slices.Values(r),
-						),
-					)
-				},
-				slices.Values(result.Rows),
-			),
-		)
+		rows := mapAllCells(strings.NewReplacer("\t", "  ").Replace, result.Rows)
 
 		var tableBuf strings.Builder
 		table := tablewriter.NewWriter(&tableBuf)
@@ -77,9 +70,11 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 		table.SetAlignment(tablewriter.ALIGN_LEFT)
 		table.SetAutoWrapText(false)
+
 		if len(result.ColumnAlign) > 0 {
 			table.SetColumnAlignment(result.ColumnAlign)
 		}
+
 		var adjustedWidths []int
 		if len(result.ColumnTypes) > 0 {
 			names := slices.Collect(xiter.Map(
@@ -91,6 +86,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		} else {
 			adjustedWidths = calculateOptimalWidth(sysVars.Debug, screenWidth, result.ColumnNames, slices.Concat(sliceOf(toRow(result.ColumnNames...)), rows))
 		}
+
 		var forceTableRender bool
 		if sysVars.Verbose && len(result.ColumnTypes) > 0 {
 			forceTableRender = true
@@ -105,6 +101,7 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		} else {
 			table.SetHeader(result.ColumnNames)
 		}
+
 		for _, row := range rows {
 			wrappedColumns := slices.Collect(hiter.Unify(
 				runewidth.Wrap,

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -196,7 +196,9 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	if session.systemVariables.EchoExecutedDDL {
 		result.ColumnNames = sliceOf("Executed", "Commit Timestamp")
 		result.Rows = slices.Collect(hiter.Unify(
-			func(k string, v *timestamppb.Timestamp) Row { return toRow(k+";", v.AsTime().Format(time.RFC3339Nano)) },
+			func(ddl string, v *timestamppb.Timestamp) Row {
+				return toRow(strings.ReplaceAll(ddl, "\t", " ")+";", v.AsTime().Format(time.RFC3339Nano))
+			},
 			hiter.Pairs(slices.Values(ddls), slices.Values(metadata.GetCommitTimestamps())),
 		),
 		)

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -196,7 +196,6 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 		result.ColumnNames = sliceOf("Executed", "Commit Timestamp")
 		result.Rows = slices.Collect(hiter.Unify(
 			func(ddl string, v *timestamppb.Timestamp) Row {
-				// Replace tabs to avoid broken table
 				return toRow(ddl+";", v.AsTime().Format(time.RFC3339Nano))
 			},
 			hiter.Pairs(slices.Values(ddls), slices.Values(metadata.GetCommitTimestamps())),

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -261,7 +261,7 @@ func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.State
 		ColumnTypes: metadata.GetRowType().GetFields(),
 		Rows: slices.Collect(hiter.Unify(
 			func(s spanner.Statement, n int64) Row {
-				return toRow(s.SQL, strconv.FormatInt(n, 10))
+				return toRow(strings.ReplaceAll(s.SQL, "\t", " "), strconv.FormatInt(n, 10))
 			},
 			hiter.Pairs(slices.Values(dmls), slices.Values(affectedRowSlice)))),
 		ColumnNames:      sliceOf("DML", "Rows"),

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -123,7 +123,10 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 			bar := p.AddBar(int64(100),
 				mpb.PrependDecorators(
 					decor.Spinner(nil, decor.WCSyncSpaceR),
-					decor.Name(runewidth.Truncate(strings.ReplaceAll(ddl, "\n", " "), 40, "..."), decor.WCSyncSpaceR),
+					decor.Name(runewidth.Truncate(strings.NewReplacer(
+						"\n", " ",
+						"\t", " ",
+					).Replace(ddl), 40, "..."), decor.WCSyncSpaceR),
 					decor.Percentage(decor.WCSyncSpace),
 					decor.Elapsed(decor.ET_STYLE_MMSS, decor.WCSyncSpace)),
 				mpb.BarRemoveOnComplete(),

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.120.1
 	cloud.google.com/go/longrunning v0.6.6
 	cloud.google.com/go/spanner v1.79.0
+	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c
 	github.com/apstndb/genaischema v0.1.1
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe

--- a/integration_test.go
+++ b/integration_test.go
@@ -584,13 +584,13 @@ func TestStatements(t *testing.T) {
 				{KeepVariables: true, BatchInfo: &BatchInfo{Mode: batchModeDDL}},
 				{IsMutation: true, BatchInfo: &BatchInfo{Mode: batchModeDDL, Size: 1}},
 				{IsMutation: true, BatchInfo: &BatchInfo{Mode: batchModeDDL, Size: 2}},
-				// tab is converted to a single whitespace
+				// tab is pass-through as is in this layer
 				{IsMutation: true, AffectedRows: 0, ColumnNames: sliceOf("Executed", "Commit Timestamp"), Rows: sliceOf(
 					toRow(
 						heredoc.Doc(`
 										CREATE TABLE TestTable (
-										 id  INT64,
-										 active BOOL,
+											id		INT64,
+											active	BOOL,
 										) PRIMARY KEY(id);`), "(ignored)"),
 					toRow(`CREATE TABLE TestTable2 (id INT64, active BOOL) PRIMARY KEY(id);`, "(ignored)"),
 				),
@@ -610,7 +610,7 @@ func TestStatements(t *testing.T) {
 				"SET AUTO_BATCH_DML = TRUE",
 				"INSERT INTO TestTable6 (id, active) VALUES (1,true)",
 				"BEGIN",
-				"INSERT INTO TestTable6 (id, active) VALUES (2,\tfalse)", // includes tab character
+				"INSERT INTO TestTable6 (id, active) VALUES (2,	false)", // includes tab character
 				"COMMIT",
 				"SELECT * FROM TestTable6 ORDER BY id",
 			),
@@ -620,8 +620,8 @@ func TestStatements(t *testing.T) {
 				{IsMutation: true, AffectedRows: 1},
 				{IsMutation: true},
 				{IsMutation: true, AffectedRows: 0, BatchInfo: &BatchInfo{Mode: batchModeDML, Size: 1}},
-				// tab is converted to a single whitespace
-				{IsMutation: true, AffectedRows: 1, ColumnNames: sliceOf("DML", "Rows"), Rows: sliceOf(Row{"INSERT INTO TestTable6 (id, active) VALUES (2, false)", "1"})},
+				// tab is pass-through as is in this layer
+				{IsMutation: true, AffectedRows: 1, ColumnNames: sliceOf("DML", "Rows"), Rows: sliceOf(Row{"INSERT INTO TestTable6 (id, active) VALUES (2,	false)", "1"})},
 				{
 					AffectedRows: 2,
 					ColumnNames:  []string{"id", "active"},

--- a/integration_test.go
+++ b/integration_test.go
@@ -563,9 +563,9 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf(
 				"CREATE TABLE TestTable6(id INT64, active BOOL) PRIMARY KEY(id)",
 				"SET AUTO_BATCH_DML = TRUE",
-				"INSERT INTO TestTable6 (id, active) VALUES (1, true)",
+				"INSERT INTO TestTable6 (id, active) VALUES (1,true)",
 				"BEGIN",
-				"INSERT INTO TestTable6 (id, active) VALUES (2, false)",
+				"INSERT INTO TestTable6 (id, active) VALUES (2,\tfalse)", // includes tab character
 				"COMMIT",
 				"SELECT * FROM TestTable6 ORDER BY id",
 			),
@@ -575,6 +575,7 @@ func TestStatements(t *testing.T) {
 				{IsMutation: true, AffectedRows: 1},
 				{IsMutation: true},
 				{IsMutation: true, AffectedRows: 0, BatchInfo: &BatchInfo{Mode: batchModeDML, Size: 1}},
+				// tab is converted to a single whitespace
 				{IsMutation: true, AffectedRows: 1, ColumnNames: sliceOf("DML", "Rows"), Rows: sliceOf(Row{"INSERT INTO TestTable6 (id, active) VALUES (2, false)", "1"})},
 				{
 					AffectedRows: 2,


### PR DESCRIPTION
This PR fixes some broken rendering when SQL includes tabs.

- Progress bar of DDL execution
- Result table
  - Now, all tabs in result are replaced to two whitespaces when table output.

## Related Issue

- close #201 