### PR TITLE
feat: Implement tab expansion and CLI_TAB_WIDTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1874,3 +1874,64 @@ Predicates(identified by ID):
 - Column names of `EXPLAIN ANALYZE` are shorter than before.
 
 Note: These changes except column names can be controlled using `SET CLI_SPANNER_CLI_COMPATIBLE_PLAN=TRUE`.
+
+### Tab character handling
+
+spanner-mycli expands tab characters to whitespaces.
+Tab width can be configured using `CLI_TAB_WIDTH` system variable. (default: 4)
+
+```
+spanner> SET CLI_TAB_WIDTH = 2;
+
+Empty set (0.00 sec)
+
+spanner> SELECT "a\tb\tc\td\te\tf\t\n"||
+      ->        "あ\tい\tう\tえ\tお\tか\t\n"||
+      ->        "abc\tdef\tghi\tjkl\tmno\tpqr\t\n"||
+      ->        "あい\tうえ\tおか\tきく\tけこ\tさし\t" AS s;
++--------------------------------------+
+| s                                    |
++--------------------------------------+
+| a b c d e f                          |
+| あ  い  う  え  お  か               |
+| abc def ghi jkl mno pqr              |
+| あい  うえ  おか  きく  けこ  さし   |
++--------------------------------------+
+1 rows in set (2.81 msecs)
+
+spanner> SET CLI_TAB_WIDTH = 4;
+
+Empty set (0.00 sec)
+
+spanner> SELECT "a\tb\tc\td\te\tf\t\n"||
+      ->        "あ\tい\tう\tえ\tお\tか\t\n"||
+      ->        "abc\tdef\tghi\tjkl\tmno\tpqr\t\n"||
+      ->        "あい\tうえ\tおか\tきく\tけこ\tさし\t" AS s;
++--------------------------------------------------+
+| s                                                |
++--------------------------------------------------+
+| a   b   c   d   e   f                            |
+| あ  い  う  え  お  か                           |
+| abc def ghi jkl mno pqr                          |
+| あい    うえ    おか    きく    けこ    さし     |
++--------------------------------------------------+
+1 rows in set (2.31 msecs)
+
+spanner> SET CLI_TAB_WIDTH = 8;
+
+Empty set (0.00 sec)
+
+spanner> SELECT "a\tb\tc\td\te\tf\t\n"||
+      ->        "あ\tい\tう\tえ\tお\tか\t\n"||
+      ->        "abc\tdef\tghi\tjkl\tmno\tpqr\t\n"||
+      ->        "あい\tうえ\tおか\tきく\tけこ\tさし\t" AS s;
++--------------------------------------------------+
+| s                                                |
++--------------------------------------------------+
+| a       b       c       d       e       f        |
+| あ      い      う      え      お      か       |
+| abc     def     ghi     jkl     mno     pqr      |
+| あい    うえ    おか    きく    けこ    さし     |
++--------------------------------------------------+
+1 rows in set (2.76 msecs)
+```

--- a/cli_output.go
+++ b/cli_output.go
@@ -39,13 +39,6 @@ const (
 	DisplayModeTab
 )
 
-func mapAllCells(f func(string) string, rows []Row) []Row {
-	return slices.Collect(
-		xiter.Map(func(r Row) Row { return slices.Collect(xiter.Map(f, slices.Values(r))) },
-			slices.Values(rows)),
-	)
-}
-
 func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result) {
 	mode := sysVars.CLIFormat
 
@@ -57,9 +50,7 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 	switch mode {
 	case DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment:
 		rw := runewidthex.NewCondition()
-		if sysVars.TabWidth != 0 {
-			rw.TabWidth = int(sysVars.TabWidth)
-		}
+		rw.TabWidth = cmp.Or(int(sysVars.TabWidth), 4)
 
 		rows := result.Rows
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c
 	github.com/apstndb/genaischema v0.1.1
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe
+	github.com/apstndb/go-runewidthex v0.1.0
 	github.com/apstndb/gsqlutils v0.0.0-20241220021154-62754cd04acc
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -2467,6 +2467,8 @@ github.com/apstndb/genaischema v0.1.1 h1:oDOp+lEWtYdNkGus0DypWGq14qqUOiBUTIfPwwh
 github.com/apstndb/genaischema v0.1.1/go.mod h1:jiBoJQJxqslpn2qSEbcBcSYgfQMy+n1Aw3dhBoHm3ls=
 github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe h1:77G66thy9/0ySW34B9GCIPrv/tc29NBGwarlpbNWm/g=
 github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe/go.mod h1:f/6/38gdf0Vz+uYGVDtVaHzL4ho6JduiF/v/ngQVWos=
+github.com/apstndb/go-runewidthex v0.1.0 h1:BTROSb06XZLb4hz5PC5i+3o/BBNhXS5QW6a6S/f1NTU=
+github.com/apstndb/go-runewidthex v0.1.0/go.mod h1:i5+ICpKj4bQDXUypcMP2oHkoXjj59jC5Cshcb9Bb6fE=
 github.com/apstndb/gsqlutils v0.0.0-20241220021154-62754cd04acc h1:djtqIk9U2GWAbL2WgpBM/RffNyilUar+War1YWjqI4U=
 github.com/apstndb/gsqlutils v0.0.0-20241220021154-62754cd04acc/go.mod h1:T2x/xf7GA3AOfm8245sTteb27qYAgbXIMlysbxJzpXk=
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82 h1:l54uIOgcH4r0lTg8xKRhehV71v8m4J+76zpjTGcRqsY=

--- a/system_variables.go
+++ b/system_variables.go
@@ -97,6 +97,7 @@ type systemVariables struct {
 	EchoInput          bool                       // CLI_ECHO_INPUT
 	Endpoint           string                     // CLI_ENDPOINT
 	OutputTemplateFile string                     // CLI_OUTPUT_TEMPLATE_FILE
+	TabWidth           int64                      // CLI_TAB_WIDTH
 
 	AnalyzeColumns string // CLI_ANALYZE_COLUMNS
 
@@ -673,6 +674,12 @@ var systemVariableDefMap = map[string]systemVariableDef{
 				return singletonMap(name, this.Database), nil
 			},
 		},
+	},
+	"CLI_TAB_WIDTH": {
+		Description: "",
+		Accessor: int64Accessor(func(variables *systemVariables) *int64 {
+			return &variables.TabWidth
+		}),
 	},
 	"CLI_PROTO_DESCRIPTOR_FILE": {
 		Description: "",

--- a/system_variables.go
+++ b/system_variables.go
@@ -676,7 +676,7 @@ var systemVariableDefMap = map[string]systemVariableDef{
 		},
 	},
 	"CLI_TAB_WIDTH": {
-		Description: "",
+		Description: "Tab width. It is used for expanding tabs.",
 		Accessor: int64Accessor(func(variables *systemVariables) *int64 {
 			return &variables.TabWidth
 		}),


### PR DESCRIPTION
This PR implements tab expansion feature and `CLI_TAB_WIDTH`.

<img width="495" alt="スクリーンショット 2025-05-15 15 37 12" src="https://github.com/user-attachments/assets/00f420af-14e9-40ad-abc3-fe87ea5c9be1" />

Note: You may see unaligned table above, but it is because of unmatched font for Japanese characters.

```
spanner> SET CLI_TAB_WIDTH = 2;

Empty set (0.00 sec)

spanner> SELECT "a\tb\tc\td\te\tf\t\n"||
      ->        "あ\tい\tう\tえ\tお\tか\t\n"||
      ->        "abc\tdef\tghi\tjkl\tmno\tpqr\t\n"||
      ->        "あい\tうえ\tおか\tきく\tけこ\tさし\t" AS s;
+--------------------------------------+
| s                                    |
+--------------------------------------+
| a b c d e f                          |
| あ  い  う  え  お  か               |
| abc def ghi jkl mno pqr              |
| あい  うえ  おか  きく  けこ  さし   |
+--------------------------------------+
1 rows in set (2.81 msecs)

spanner> SET CLI_TAB_WIDTH = 4;

Empty set (0.00 sec)

spanner> SELECT "a\tb\tc\td\te\tf\t\n"||
      ->        "あ\tい\tう\tえ\tお\tか\t\n"||
      ->        "abc\tdef\tghi\tjkl\tmno\tpqr\t\n"||
      ->        "あい\tうえ\tおか\tきく\tけこ\tさし\t" AS s;
+--------------------------------------------------+
| s                                                |
+--------------------------------------------------+
| a   b   c   d   e   f                            |
| あ  い  う  え  お  か                           |
| abc def ghi jkl mno pqr                          |
| あい    うえ    おか    きく    けこ    さし     |
+--------------------------------------------------+
1 rows in set (2.31 msecs)

spanner> SET CLI_TAB_WIDTH = 8;

Empty set (0.00 sec)

spanner> SELECT "a\tb\tc\td\te\tf\t\n"||
      ->        "あ\tい\tう\tえ\tお\tか\t\n"||
      ->        "abc\tdef\tghi\tjkl\tmno\tpqr\t\n"||
      ->        "あい\tうえ\tおか\tきく\tけこ\tさし\t" AS s;
+--------------------------------------------------+
| s                                                |
+--------------------------------------------------+
| a       b       c       d       e       f        |
| あ      い      う      え      お      か       |
| abc     def     ghi     jkl     mno     pqr      |
| あい    うえ    おか    きく    けこ    さし     |
+--------------------------------------------------+
1 rows in set (2.76 msecs)
```