### PR TITLE
misc: Refactor exitf

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -143,10 +143,11 @@ func (c *Cli) RunInteractive(ctx context.Context) int {
 
 // readInputLine reads and processes an input line from the editor.
 func (c *Cli) readInputLine(ctx context.Context, ed *multiline.Editor) (*inputStatement, error) {
+	input, err := readInteractiveInput(ctx, ed)
+
 	// reset for next input before continue
 	ed.SetDefault(nil)
 
-	input, err := readInteractiveInput(ctx, ed)
 	if err != nil {
 		return nil, err
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ExitCodeError represents an error that only carries an exit code without a message
+type ExitCodeError struct {
+	exitCode int
+}
+
+// Error implements the error interface
+func (e *ExitCodeError) Error() string {
+	return fmt.Errorf("exit code: %d", e.exitCode).Error()
+}
+
+// NewExitCodeError creates a new ExitCodeError
+func NewExitCodeError(exitCode int) error {
+	if exitCode == exitCodeSuccess {
+		return nil
+	}
+
+	return &ExitCodeError{
+		exitCode: exitCode,
+	}
+}
+
+// GetExitCode returns the appropriate exit code based on the error type.
+// It checks for ExitCodeError first and returns its exit code if found.
+// Otherwise, it returns exitCodeSuccess for nil errors and exitCodeError for all other errors.
+//
+// In the future, this function could be further enhanced to return different
+// exit codes based on other error types, such as:
+//
+//	var validationErr *ValidationError
+//	if errors.As(err, &validationErr) {
+//	    return exitCodeValidationError // e.g., 2
+//	}
+//
+// This would require defining additional exit code constants.
+func GetExitCode(err error) int {
+	if err == nil {
+		return exitCodeSuccess
+	}
+
+	// Check for ExitCodeError
+	var exitCodeErr *ExitCodeError
+	if errors.As(err, &exitCodeErr) {
+		return exitCodeErr.exitCode
+	}
+
+	// Default to generic error
+	return exitCodeError
+}

--- a/errors.go
+++ b/errors.go
@@ -12,7 +12,7 @@ type ExitCodeError struct {
 
 // Error implements the error interface
 func (e *ExitCodeError) Error() string {
-	return fmt.Errorf("exit code: %d", e.exitCode).Error()
+	return fmt.Sprintf("exit code: %d", e.exitCode)
 }
 
 // NewExitCodeError creates a new ExitCodeError

--- a/main.go
+++ b/main.go
@@ -160,7 +160,8 @@ func main() {
 	// the GetExitCode function in errors.go.
 
 	if err := run(context.Background(), &gopts.Spanner); err != nil {
-		if exitCodeErr := (*ExitCodeError)(nil); !errors.As(err, &exitCodeErr) {
+		var exitCodeErr *ExitCodeError
+		if !errors.As(err, &exitCodeErr) {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 		}
 
@@ -382,16 +383,16 @@ func run(ctx context.Context, opts *spannerOptions) error {
 		sysVars.CLIFormat = lo.Ternary(interactive || opts.Table, DisplayModeTable, DisplayModeTab)
 	}
 
-	exitCode := lo.TernaryF(interactive,
-		func() int {
+	err = lo.TernaryF(interactive,
+		func() error {
 			sysVars.EnableProgressBar = true
 			return cli.RunInteractive(ctx)
 		},
-		func() int {
+		func() error {
 			return cli.RunBatch(ctx, input)
 		})
 
-	return NewExitCodeError(exitCode)
+	return err
 }
 
 // renderClientStatementHelp generates a table of client-side statement help.

--- a/main_slow_test.go
+++ b/main_slow_test.go
@@ -8,8 +8,8 @@ import (
 
 // TestRun ensure that --embedded-emulator doesn't need ADC.
 func TestRun(t *testing.T) {
-	exitCode := run(t.Context(), &spannerOptions{Execute: "SELECT 1", EmbeddedEmulator: true})
-	if exitCode != exitCodeSuccess {
-		t.Errorf("exitCode != exitCodeSuccess, exitCode: %v", exitCode)
+	err := run(t.Context(), &spannerOptions{Execute: "SELECT 1", EmbeddedEmulator: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
This PR refactors `main.go` to remove use of `exitf` and `exitCode` in function signature.