### PR TITLE
misc: Remove deprecated --log-memefish

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ spanner:
       --credential=                                       Use the specific credential file
       --prompt=                                           Set the prompt to the specified format (default: spanner%t> )
       --prompt2=                                          Set the prompt2 to the specified format (default: %P%R> )
-      --log-memefish                                      Emit SQL parse log using memefish
       --history=                                          Set the history file to the specified path (default: /tmp/spanner_mycli_readline.tmp)
       --priority=                                         Set default request priority (HIGH|MEDIUM|LOW)
       --role=                                             Use the specific database role. --database-role is an alias.

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -98,8 +98,6 @@ var replacerForProgress = strings.NewReplacer(
 )
 
 func executeDdlStatements(ctx context.Context, session *Session, ddls []string) (*Result, error) {
-	logParseStatements(ddls)
-
 	if len(ddls) == 0 {
 		return &Result{
 			IsMutation:  true,

--- a/main.go
+++ b/main.go
@@ -65,7 +65,6 @@ type spannerOptions struct {
 	Credential                string            `long:"credential" description:"Use the specific credential file"`
 	Prompt                    *string           `long:"prompt" description:"Set the prompt to the specified format" default-mask:"spanner%t> "`
 	Prompt2                   *string           `long:"prompt2" description:"Set the prompt2 to the specified format" default-mask:"%P%R> "`
-	LogMemefish               bool              `long:"log-memefish" description:"Emit SQL parse log using memefish"`
 	HistoryFile               *string           `long:"history" description:"Set the history file to the specified path" default-mask:"/tmp/spanner_mycli_readline.tmp"`
 	Priority                  string            `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
 	Role                      string            `long:"role" description:"Use the specific database role. --database-role is an alias."`
@@ -106,8 +105,6 @@ const (
 	defaultHistoryFile   = "/tmp/spanner_mycli_readline.tmp"
 	defaultVertexAIModel = "gemini-2.0-flash"
 )
-
-var logMemefish bool
 
 var (
 	// https://rhysd.hatenablog.com/entry/2021/06/27/222254
@@ -175,8 +172,6 @@ func main() {
 // It returns an error that may contain an exit code.
 // Use GetExitCode(err) to determine the appropriate exit code.
 func run(ctx context.Context, opts *spannerOptions) error {
-	logMemefish = opts.LogMemefish
-
 	if opts.StatementHelp {
 		fmt.Print(renderClientStatementHelp(clientSideStatementDefs))
 		return nil

--- a/session.go
+++ b/session.go
@@ -468,7 +468,6 @@ func (s *Session) RunAnalyzeQuery(ctx context.Context, stmt spanner.Statement) (
 }
 
 func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statement, opts spanner.QueryOptions) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
-	logParseStatement(stmt.SQL)
 
 	if opts.Options == nil {
 		opts.Options = &sppb.ExecuteSqlRequest_QueryOptions{}
@@ -507,8 +506,6 @@ func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, implici
 	if err != nil {
 		return nil, nil, nil, 0, nil, err
 	}
-
-	logParseStatement(stmt.SQL)
 
 	if !s.InReadWriteTransaction() {
 		return nil, nil, nil, 0, nil, errors.New("read-write transaction is not running")

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -257,24 +257,6 @@ func unquoteIdentifier(input string) string {
 	return strings.Trim(strings.TrimSpace(input), "`")
 }
 
-func logParseStatement(stmt string) {
-	if !logMemefish {
-		return
-	}
-	n, err := memefish.ParseStatement("", stmt)
-	if err != nil {
-		log.Printf("SQL can't parsed as a statement, err: %v", err)
-	} else {
-		log.Printf("parsed: %v", n.SQL())
-	}
-}
-
-func logParseStatements(stmts []string) {
-	for _, stmt := range stmts {
-		logParseStatement(stmt)
-	}
-}
-
 // buildCommands parses the input and builds a list of commands for batch execution.
 // It can compose BulkDdlStatement from consecutive DDL statements.
 func buildCommands(input string, mode parseMode) ([]Statement, error) {


### PR DESCRIPTION
This PR removes `--log-memefish`. It is already superceded by `CLI_PARSE_MODE`.

## Breaking Change

- Now, `--log-memefish` is invalid option.