### PR TITLE
misc: Add octocov push on main

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -20,3 +20,5 @@ report:
   if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}
+push:
+  if: is_default_branch


### PR DESCRIPTION
This PR adds Octocov `push` on default branch.