### PR TITLE
Fix a bug that DROP DATABASE drops the current database

### DIFF
--- a/statements.go
+++ b/statements.go
@@ -136,7 +136,7 @@ func (DropDatabaseStatement) isMutationStatement() {}
 
 func (s *DropDatabaseStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	if err := session.adminClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
-		Database: databasePath(session.systemVariables.Project, session.systemVariables.Instance, session.systemVariables.Database),
+		Database: databasePath(session.systemVariables.Project, session.systemVariables.Instance, s.DatabaseId),
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes the bug that `DROP DATABASE` drops the current database.