### PR TITLE
misc: Refactor tablewriter

### DIFF
--- a/cli_output.go
+++ b/cli_output.go
@@ -83,8 +83,6 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 		wc := &widthCalculator{Condition: rw}
 		adjustedWidths := calculateWidth(result, wc, screenWidth, rows)
 
-		forceTableRender := sysVars.Verbose
-
 		headers := slices.Collect(hiter.Unify(
 			rw.Wrap,
 			hiter.Pairs(
@@ -104,7 +102,9 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 			}
 		}
 
-		if (forceTableRender && len(headers) > 0) || len(rows) > 0 {
+		forceTableRender := sysVars.Verbose && len(headers) > 0
+
+		if forceTableRender || len(rows) > 0 {
 			if err := table.Render(); err != nil {
 				slog.Error("tablewriter.Table.Render() failed", "err", err)
 			}

--- a/cli_output.go
+++ b/cli_output.go
@@ -104,7 +104,7 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 			}
 		}
 
-		if forceTableRender || len(rows) > 0 {
+		if (forceTableRender && len(headers) > 0) || len(rows) > 0 {
 			if err := table.Render(); err != nil {
 				slog.Error("tablewriter.Table.Render() failed", "err", err)
 			}

--- a/cli_output.go
+++ b/cli_output.go
@@ -39,12 +39,13 @@ const (
 	DisplayModeTab
 )
 
+// renderTableHeader renders TableHeader. It is nil safe.
 func renderTableHeader(header TableHeader, verbose bool) []string {
 	if header == nil {
 		return nil
 	}
 
-	return header.Render(verbose)
+	return header.internalRender(verbose)
 }
 
 func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result) {

--- a/cli_output.go
+++ b/cli_output.go
@@ -60,10 +60,10 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 				renderer.NewBlueprint(tw.Rendition{Symbols: tw.NewSymbols(tw.StyleASCII)})),
 			tablewriter.WithHeaderAlignment(tw.AlignLeft),
 			tablewriter.WithTrimSpace(tw.Off),
+			tablewriter.WithHeaderAutoFormat(tw.Off),
 		).Configure(func(config *tablewriter.Config) {
 			config.Row.ColumnAligns = result.ColumnAlign
 			config.Row.Formatting.AutoWrap = tw.WrapNone
-			config.Header.Formatting.AutoFormat = false
 		})
 
 		wc := &widthCalculator{Condition: rw}

--- a/cli_output.go
+++ b/cli_output.go
@@ -56,10 +56,7 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 		screenWidth = math.MaxInt
 	}
 
-	var columnNames []string
-	if result.TableHeader != nil {
-		columnNames = renderTableHeader(result.TableHeader, false)
-	}
+	columnNames := renderTableHeader(result.TableHeader, false)
 
 	switch mode {
 	case DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment:

--- a/cli_test.go
+++ b/cli_test.go
@@ -145,7 +145,7 @@ func TestPrintResult(t *testing.T) {
 					CLIFormat: DisplayModeTable,
 				},
 				result: &Result{
-					ColumnNames: []string{"foo", "bar"},
+					TableHeader: toTableHeader("foo", "bar"),
 					Rows: []Row{
 						{"1", "2"},
 						{"3", "4"},
@@ -167,7 +167,7 @@ func TestPrintResult(t *testing.T) {
 					CLIFormat: DisplayModeTableComment,
 				},
 				result: &Result{
-					ColumnNames: []string{"foo", "bar"},
+					TableHeader: toTableHeader("foo", "bar"),
 					Rows: []Row{
 						{"1", "2"},
 						{"3", "4"},
@@ -193,7 +193,7 @@ func TestPrintResult(t *testing.T) {
 				},
 				input: "SELECT foo, bar\nFROM input",
 				result: &Result{
-					ColumnNames: []string{"foo", "bar"},
+					TableHeader: toTableHeader("foo", "bar"),
 					Rows: []Row{
 						{"1", "2"},
 						{"3", "4"},
@@ -221,10 +221,10 @@ Empty set
 				},
 				screenWidth: 20,
 				result: &Result{
-					ColumnTypes: typector.MustNameCodeSlicesToStructTypeFields(
+					TableHeader: toTableHeader(typector.MustNameCodeSlicesToStructTypeFields(
 						sliceOf("NAME", "LONG_NAME"),
 						sliceOf(sppb.TypeCode_STRING, sppb.TypeCode_STRING),
-					),
+					)),
 					Rows: sliceOf(
 						toRow("1", "2"),
 						toRow("3", "4"),
@@ -251,10 +251,10 @@ Empty set
 				},
 				screenWidth: 19,
 				result: &Result{
-					ColumnTypes: typector.MustNameCodeSlicesToStructTypeFields(
+					TableHeader: toTableHeader(typector.MustNameCodeSlicesToStructTypeFields(
 						sliceOf("NAME", "LONG_NAME"),
 						sliceOf(sppb.TypeCode_STRING, sppb.TypeCode_STRING),
-					),
+					)),
 					Rows: sliceOf(
 						toRow("1", "2"),
 						toRow("3", "4"),
@@ -281,10 +281,10 @@ Empty set
 				},
 				screenWidth: 25,
 				result: &Result{
-					ColumnTypes: typector.MustNameCodeSlicesToStructTypeFields(
+					TableHeader: toTableHeader(typector.MustNameCodeSlicesToStructTypeFields(
 						sliceOf("English", "Japanese"),
 						sliceOf(sppb.TypeCode_STRING, sppb.TypeCode_STRING),
-					),
+					)),
 					Rows: sliceOf(
 						toRow("Hello World", "こんにちは"),
 						toRow("Bye", "さようなら"),
@@ -320,7 +320,7 @@ Empty set
 	t.Run("DisplayModeVertical", func(t *testing.T) {
 		out := &bytes.Buffer{}
 		result := &Result{
-			ColumnNames: sliceOf("foo", "bar"),
+			TableHeader: toTableHeader("foo", "bar"),
 			Rows: sliceOf(
 				toRow("1", "2"),
 				toRow("3", "4"),
@@ -347,7 +347,7 @@ bar: 4
 	t.Run("DisplayModeTab", func(t *testing.T) {
 		out := &bytes.Buffer{}
 		result := &Result{
-			ColumnNames: sliceOf("foo", "bar"),
+			TableHeader: toTableHeader("foo", "bar"),
 			Rows: sliceOf(
 				toRow("1", "2"),
 				toRow("3", "4"),

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -282,7 +282,7 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 	var rows []Row
 	var queryStats map[string]any
 	affected, commitResp, _, metadata, err := session.RunInNewOrExistRwTx(ctx, func(implicit bool) (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error) {
-		rs, stats, _, num, meta, err := session.RunUpdate(ctx, stmt, implicit)
+		rs, stats, num, meta, err := session.RunUpdate(ctx, stmt, implicit)
 		rows = rs
 		queryStats = stats
 		return num, nil, meta, err

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -262,7 +262,6 @@ func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.State
 		IsMutation:  true,
 		Timestamp:   commitResp.CommitTs,
 		CommitStats: commitResp.CommitStats,
-		// ColumnTypes: metadata.GetRowType().GetFields(),
 		Rows: slices.Collect(hiter.Unify(
 			func(s spanner.Statement, n int64) Row {
 				return toRow(s.SQL, strconv.FormatInt(n, 10))

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -64,9 +64,8 @@ func executeSQL(ctx context.Context, session *Session, sql string) (*Result, err
 	}
 
 	result := &Result{
-		ColumnNames:  extractColumnNames(metadata.GetRowType().GetFields()),
 		Rows:         rows,
-		ColumnTypes:  metadata.GetRowType().GetFields(),
+		TableHeader:  toTableHeader(metadata.GetRowType().GetFields()),
 		AffectedRows: len(rows),
 		Stats:        queryStats,
 	}
@@ -101,7 +100,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	if len(ddls) == 0 {
 		return &Result{
 			IsMutation:  true,
-			ColumnNames: lox.IfOrEmpty(session.systemVariables.EchoExecutedDDL, sliceOf("Executed", "Commit Timestamp")),
+			TableHeader: toTableHeader(lox.IfOrEmpty(session.systemVariables.EchoExecutedDDL, sliceOf("Executed", "Commit Timestamp"))),
 		}, nil
 	}
 
@@ -195,7 +194,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	lastCommitTS := lo.LastOrEmpty(metadata.CommitTimestamps).AsTime()
 	result := &Result{IsMutation: true, Timestamp: lastCommitTS}
 	if session.systemVariables.EchoExecutedDDL {
-		result.ColumnNames = sliceOf("Executed", "Commit Timestamp")
+		result.TableHeader = toTableHeader("Executed", "Commit Timestamp")
 		result.Rows = slices.Collect(hiter.Unify(
 			func(ddl string, v *timestamppb.Timestamp) Row {
 				return toRow(ddl+";", v.AsTime().Format(time.RFC3339Nano))
@@ -251,7 +250,7 @@ func bufferOrExecuteDML(ctx context.Context, session *Session, sql string) (*Res
 
 func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.Statement) (*Result, error) {
 	var affectedRowSlice []int64
-	affected, commitResp, _, metadata, err := session.RunInNewOrExistRwTx(ctx, func(implicit bool) (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error) {
+	affected, commitResp, _, _, err := session.RunInNewOrExistRwTx(ctx, func(implicit bool) (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error) {
 		affectedRowSlice, err = session.tc.RWTxn().BatchUpdateWithOptions(ctx, dmls, spanner.QueryOptions{LastStatement: implicit})
 		return lo.Sum(affectedRowSlice), nil, nil, err
 	})
@@ -263,13 +262,13 @@ func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.State
 		IsMutation:  true,
 		Timestamp:   commitResp.CommitTs,
 		CommitStats: commitResp.CommitStats,
-		ColumnTypes: metadata.GetRowType().GetFields(),
+		// ColumnTypes: metadata.GetRowType().GetFields(),
 		Rows: slices.Collect(hiter.Unify(
 			func(s spanner.Statement, n int64) Row {
 				return toRow(s.SQL, strconv.FormatInt(n, 10))
 			},
 			hiter.Pairs(slices.Values(dmls), slices.Values(affectedRowSlice)))),
-		ColumnNames:      sliceOf("DML", "Rows"),
+		TableHeader:      toTableHeader("DML", "Rows"),
 		AffectedRows:     int(affected),
 		AffectedRowsType: lo.Ternary(len(dmls) > 1, rowCountTypeUpperBound, rowCountTypeExact),
 	}, nil
@@ -282,12 +281,10 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 	}
 
 	var rows []Row
-	var columnNames []string
 	var queryStats map[string]any
 	affected, commitResp, _, metadata, err := session.RunInNewOrExistRwTx(ctx, func(implicit bool) (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error) {
-		rs, stats, columns, num, meta, err := session.RunUpdate(ctx, stmt, implicit)
+		rs, stats, _, num, meta, err := session.RunUpdate(ctx, stmt, implicit)
 		rows = rs
-		columnNames = columns
 		queryStats = stats
 		return num, nil, meta, err
 	})
@@ -305,9 +302,8 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 		Timestamp:    commitResp.CommitTs,
 		CommitStats:  commitResp.CommitStats,
 		Stats:        stats,
-		ColumnTypes:  metadata.GetRowType().GetFields(),
+		TableHeader:  toTableHeader(metadata.GetRowType().GetFields()),
 		Rows:         rows,
-		ColumnNames:  columnNames,
 		AffectedRows: int(affected),
 	}, nil
 }
@@ -430,9 +426,8 @@ func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Re
 	}
 
 	result := &Result{
-		ColumnNames:    extractColumnNames(rowType.GetFields()),
 		Rows:           allRows,
-		ColumnTypes:    rowType.GetFields(),
+		TableHeader:    toTableHeader(rowType.GetFields()),
 		AffectedRows:   len(allRows),
 		PartitionCount: len(partitions),
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/ngicks/go-iterator-helper v0.0.18
 	github.com/nyaosorg/go-readline-ny v1.9.0
-	github.com/olekukonko/tablewriter v1.0.1
+	github.com/olekukonko/tablewriter v1.0.6
 	github.com/samber/lo v1.49.1
 	github.com/sourcegraph/conc v0.3.0
 	github.com/testcontainers/testcontainers-go/modules/gcloud v0.36.0
@@ -111,7 +111,7 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
-	github.com/olekukonko/ll v0.0.6-0.20250511102614-9564773e9d27 // indirect
+	github.com/olekukonko/ll v0.0.8-0.20250516010636-22ea57d81985 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2930,10 +2930,10 @@ github.com/nyaosorg/go-readline-ny v1.9.0 h1:5jXBhg5qeOyJK/2R3lo6+VLx30HdjPh2dw7
 github.com/nyaosorg/go-readline-ny v1.9.0/go.mod h1:54AzdC//M5EzTWRdvUHv2ChuYgp58mRrStTlpxiCmT0=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 h1:r3FaAI0NZK3hSmtTDrBVREhKULp8oUeqLT5Eyl2mSPo=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
-github.com/olekukonko/ll v0.0.6-0.20250511102614-9564773e9d27 h1:LgDwLQDELPB6wMOx1x4DSXnH2pjQNDKFgqv2inJuiAU=
-github.com/olekukonko/ll v0.0.6-0.20250511102614-9564773e9d27/go.mod h1:En+sEW0JNETl26+K8eZ6/W4UQ7CYSrrgg/EdIYT2H8g=
-github.com/olekukonko/tablewriter v1.0.1 h1:8Q9cO/98GpqZDPjmOmxFBIvgn4u935JOw2GG2KH0L88=
-github.com/olekukonko/tablewriter v1.0.1/go.mod h1:eUa4ArVhHJYomS27xrJB/GyLtnzKKVkZeLM6/MNO+pA=
+github.com/olekukonko/ll v0.0.8-0.20250516010636-22ea57d81985 h1:V2wKiwjwAfRJRtUP6pC7wt4opeF14enO0du2dRV6Llo=
+github.com/olekukonko/ll v0.0.8-0.20250516010636-22ea57d81985/go.mod h1:En+sEW0JNETl26+K8eZ6/W4UQ7CYSrrgg/EdIYT2H8g=
+github.com/olekukonko/tablewriter v1.0.6 h1:/T45mIHc5hcEvibgzBzvMy7ruT+RjgoQRvkHbnl6OWA=
+github.com/olekukonko/tablewriter v1.0.6/go.mod h1:SJ0MV1aHb/89fLcsBMXMp30Xg3g5eGoOUu0RptEk4AU=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/integration_test.go
+++ b/integration_test.go
@@ -299,7 +299,7 @@ func TestSystemVariables(t *testing.T) {
 			t.Run(tt.varname, func(t *testing.T) {
 				_ = buildAndExecute(t, ctx, session, fmt.Sprintf(`SET %v = "%v"`, tt.varname, tt.value))
 				result := buildAndExecute(t, ctx, session, fmt.Sprintf(`SHOW VARIABLE %v`, tt.varname))
-				if diff := cmp.Diff(sliceOf(tt.varname), result.TableHeader.Render(false)); diff != "" {
+				if diff := cmp.Diff(sliceOf(tt.varname), renderTableHeader(result.TableHeader, false)); diff != "" {
 					t.Errorf("SHOW column names differ: %v", diff)
 				}
 				if diff := cmp.Diff(sliceOf(toRow(tt.value)), result.Rows); diff != "" {

--- a/integration_test.go
+++ b/integration_test.go
@@ -389,7 +389,7 @@ func TestStatements(t *testing.T) {
 			wantResults: []*Result{
 				{
 					KeepVariables: true,
-					ColumnNames:   sliceOf("CLI_VERSION"),
+					TableHeader:   toTableHeader("CLI_VERSION"),
 					Rows:          sliceOf(toRow(getVersion()))},
 			},
 		},
@@ -583,12 +583,12 @@ func TestStatements(t *testing.T) {
 				{KeepVariables: true},
 				{
 					KeepVariables: true,
-					ColumnNames:   sliceOf("Param_Name", "Param_Kind", "Param_Value"),
+					TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),
 					Rows:          sliceOf(toRow("i", "TYPE", "INT64")),
 				},
 				{
 					AffectedRows: 1,
-					ColumnNames:  sliceOf("Column_Name", "Column_Type"),
+					TableHeader:  toTableHeader("Column_Name", "Column_Type"),
 					Rows:         sliceOf(toRow("i", "INT64")),
 				},
 			},
@@ -607,7 +607,7 @@ func TestStatements(t *testing.T) {
 			ddls: sliceOf("CREATE TABLE TestTable (id INT64, active BOOL) PRIMARY KEY (id)"),
 			wantResults: []*Result{
 				{
-					ColumnNames:   sliceOf(""),
+					TableHeader:   toTableHeader(""),
 					KeepVariables: true,
 					Rows: sliceOf(
 						toRow(heredoc.Doc(`
@@ -638,7 +638,7 @@ func TestStatements(t *testing.T) {
 				"SYNC PROTO BUNDLE DELETE (`examples.shipping.Order`)",
 			),
 			wantResults: []*Result{
-				{KeepVariables: true, ColumnNames: sliceOf("full_name", "kind", "package")},
+				{KeepVariables: true, TableHeader: toTableHeader("full_name", "kind", "package")},
 				{KeepVariables: true},
 				{IsMutation: true},
 				{IsMutation: true},
@@ -660,13 +660,13 @@ func TestStatements(t *testing.T) {
 				"SHOW DATABASES",
 			),
 			wantResults: []*Result{
-				{ColumnNames: sliceOf("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
+				{TableHeader: toTableHeader("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
 				{IsMutation: true},
-				{ColumnNames: sliceOf("Database"), Rows: sliceOf(toRow("new-database"), toRow("test-database")), AffectedRows: 2},
+				{TableHeader: toTableHeader("Database"), Rows: sliceOf(toRow("new-database"), toRow("test-database")), AffectedRows: 2},
 				{},
 				{},
 				{IsMutation: true},
-				{ColumnNames: sliceOf("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
+				{TableHeader: toTableHeader("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
 			},
 		},
 		{
@@ -674,10 +674,10 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf("SHOW TABLES"),
 			ddls: sliceOf("CREATE TABLE TestTable (id INT64, active BOOL) PRIMARY KEY (id)"),
 			wantResults: []*Result{
-				{ColumnNames: sliceOf(""), Rows: sliceOf(toRow("TestTable")), AffectedRows: 1},
+				{TableHeader: toTableHeader(""), Rows: sliceOf(toRow("TestTable")), AffectedRows: 1},
 			},
 			cmpOpts: sliceOf(cmp.FilterPath(func(path cmp.Path) bool {
-				return regexp.MustCompile(`\.ColumnNames`).MatchString(path.GoString())
+				return regexp.MustCompile(`\.TableHeader`).MatchString(path.GoString())
 			}, cmp.Ignore())),
 		},
 		{
@@ -687,7 +687,7 @@ func TestStatements(t *testing.T) {
 				{
 					ForceWrap:    true,
 					AffectedRows: 1,
-					ColumnNames:  sliceOf("Root_Partitionable"),
+					TableHeader:  toTableHeader("Root_Partitionable"),
 					Rows:         sliceOf(toRow("TRUE")),
 				},
 			},
@@ -706,8 +706,7 @@ func TestStatements(t *testing.T) {
 				{
 					AffectedRows:   1,
 					PartitionCount: 2,
-					ColumnNames:    sliceOf("id", "active"),
-					ColumnTypes:    testTableRowType,
+					TableHeader:    toTableHeader(testTableRowType),
 					Rows:           sliceOf(toRow("1", "false")),
 				},
 			},
@@ -828,7 +827,7 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf("SHOW VARIABLES"),
 			wantResults: []*Result{
 				{
-					ColumnNames:   sliceOf("name", "value"),
+					TableHeader:   toTableHeader("name", "value"),
 					KeepVariables: true,
 					// Rows and AffectedRows are dynamic, so we don't check them here.
 				},
@@ -861,14 +860,13 @@ func TestStatements(t *testing.T) {
 				{IsMutation: true, BatchInfo: &BatchInfo{Mode: batchModeDML, Size: 1}}, // INSERT (batched)
 				{KeepVariables: true}, // ABORT BATCH
 				{ // SELECT COUNT(*)
-					ColumnNames:  sliceOf(""),
-					ColumnTypes:  sliceOf(typector.NameTypeToStructTypeField("", typector.CodeToSimpleType(sppb.TypeCode_INT64))),
+					TableHeader:  toTableHeader(typector.NameTypeToStructTypeField("", typector.CodeToSimpleType(sppb.TypeCode_INT64))),
 					Rows:         sliceOf(toRow("0")),
 					AffectedRows: 1,
 				},
 			},
 			cmpOpts: sliceOf(cmp.FilterPath(func(path cmp.Path) bool {
-				return regexp.MustCompile(`\.ColumnNames`).MatchString(path.String()) &&
+				return regexp.MustCompile(`\.TableHeader`).MatchString(path.String()) &&
 					!strings.Contains(path.String(), "wantResults[3]")
 			}, cmp.Ignore())),
 		},
@@ -888,13 +886,13 @@ func TestStatements(t *testing.T) {
 				{KeepVariables: true}, // SET +=
 				{ // SHOW VARIABLE
 					KeepVariables: true,
-					ColumnNames:   sliceOf("CLI_PROTO_DESCRIPTOR_FILE"),
+					TableHeader:   toTableHeader("CLI_PROTO_DESCRIPTOR_FILE"),
 					Rows:          sliceOf(toRow(`testdata/protos/order_descriptors.pb`)),
 				},
 				{KeepVariables: true}, // SET +=
 				{ // SHOW VARIABLE
 					KeepVariables: true,
-					ColumnNames:   sliceOf("CLI_PROTO_DESCRIPTOR_FILE"),
+					TableHeader:   toTableHeader("CLI_PROTO_DESCRIPTOR_FILE"),
 					Rows:          sliceOf(toRow(`testdata/protos/order_descriptors.pb,testdata/protos/singer.proto`)),
 				},
 			},
@@ -908,7 +906,7 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf("SHOW CREATE INDEX TestShowCreateIndexIdx"),
 			wantResults: []*Result{
 				{
-					ColumnNames:  sliceOf("Name", "DDL"),
+					TableHeader:  toTableHeader("Name", "DDL"),
 					Rows:         sliceOf(toRow("TestShowCreateIndexIdx", "CREATE INDEX TestShowCreateIndexIdx ON TestShowCreateIndexTbl(val)")),
 					AffectedRows: 1,
 				},
@@ -921,7 +919,7 @@ func TestStatements(t *testing.T) {
 			wantResults: []*Result{
 				{
 					// For DML without THEN RETURN, result is empty.
-					ColumnNames:  sliceOf("Column_Name", "Column_Type"),
+					TableHeader:  toTableHeader("Column_Name", "Column_Type"),
 					Rows:         nil, // No parameters in this DML
 					AffectedRows: 0,   // 0 parameters
 				},
@@ -933,7 +931,7 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf("PARTITION SELECT id FROM TestPartitionQueryTbl"),
 			wantResults: []*Result{
 				{
-					ColumnNames:  sliceOf("Partition_Token"),
+					TableHeader:  toTableHeader("Partition_Token"),
 					AffectedRows: 2, // Emulator usually creates a couple of partitions for simple queries
 					ForceWrap:    true,
 				},
@@ -949,7 +947,7 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf("SHOW SCHEMA UPDATE OPERATIONS"),
 			wantResults: []*Result{
 				{
-					ColumnNames:  sliceOf("OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"),
+					TableHeader:  toTableHeader("OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"),
 					Rows:         nil, // Expect no operations on a fresh emulator DB
 					AffectedRows: 0,
 				},
@@ -967,15 +965,14 @@ func TestStatements(t *testing.T) {
 				{IsMutation: true, AffectedRows: 1}, // Result of INSERT
 				{IsMutation: true},                  // Result of MUTATE (AffectedRows not set by MutateStatement)
 				{ // SELECT COUNT(*)
-					ColumnNames:  sliceOf(""),
-					ColumnTypes:  sliceOf(typector.NameTypeToStructTypeField("", typector.CodeToSimpleType(sppb.TypeCode_INT64))),
+					TableHeader:  toTableHeader(typector.NameTypeToStructTypeField("", typector.CodeToSimpleType(sppb.TypeCode_INT64))),
 					Rows:         sliceOf(toRow("0")),
 					AffectedRows: 1,
 				},
 			},
 			cmpOpts: sliceOf(cmp.FilterPath(func(path cmp.Path) bool {
-				return regexp.MustCompile(`\.ColumnNames`).MatchString(path.String()) &&
-					!strings.Contains(path.String(), "wantResults[2]") // Allow ColumnNames for SELECT
+				return regexp.MustCompile(`\.TableHeader`).MatchString(path.String()) &&
+					!strings.Contains(path.String(), "wantResults[2]") // Allow TableHeader for SELECT
 			}, cmp.Ignore())),
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -411,9 +411,9 @@ func renderClientStatementHelp(stmts []*clientSideStatementDef) string {
 
 	table := tablewriter.NewTable(&sb,
 		tablewriter.WithRenderer(renderer.NewMarkdown()),
+		tablewriter.WithHeaderAutoFormat(tw.Off),
 		tablewriter.WithHeaderAlignment(tw.AlignLeft)).
 		Configure(func(config *tablewriter.Config) {
-			config.Header.Formatting.AutoFormat = false
 		})
 
 	table.Header([]string{"Usage", "Syntax", "Note"})

--- a/main.go
+++ b/main.go
@@ -428,7 +428,7 @@ func renderClientStatementHelp(stmts []*clientSideStatementDef) string {
 	}
 
 	if err := table.Render(); err != nil {
-		slog.Error("tablewriter.Table.Render() failed", "err", err)
+		slog.Error("tablewriter.Table.internalRender() failed", "err", err)
 	}
 
 	return sb.String()

--- a/main.go
+++ b/main.go
@@ -428,7 +428,7 @@ func renderClientStatementHelp(stmts []*clientSideStatementDef) string {
 	}
 
 	if err := table.Render(); err != nil {
-		slog.Error("tablewriter.Table.internalRender() failed", "err", err)
+		slog.Error("tablewriter.Table.Render() failed", "err", err)
 	}
 
 	return sb.String()

--- a/session.go
+++ b/session.go
@@ -501,14 +501,14 @@ func (s *Session) runQueryWithOptions(ctx context.Context, stmt spanner.Statemen
 
 // RunUpdate executes a DML statement on the running read-write transaction.
 // It returns error if there is no running read-write transaction.
-func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, implicit bool) ([]Row, map[string]any, []string, int64, *sppb.ResultSetMetadata, error) {
+func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, implicit bool) ([]Row, map[string]any, int64, *sppb.ResultSetMetadata, error) {
 	fc, err := formatConfigWithProto(s.systemVariables.ProtoDescriptor, s.systemVariables.MultilineProtoText)
 	if err != nil {
-		return nil, nil, nil, 0, nil, err
+		return nil, nil, 0, nil, err
 	}
 
 	if !s.InReadWriteTransaction() {
-		return nil, nil, nil, 0, nil, errors.New("read-write transaction is not running")
+		return nil, nil, 0, nil, errors.New("read-write transaction is not running")
 	}
 
 	opts := s.queryOptions(sppb.ExecuteSqlRequest_PROFILE.Enum())
@@ -519,7 +519,7 @@ func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, implici
 
 	rows, stats, count, metadata, _, err := consumeRowIterCollect(s.tc.RWTxn().QueryWithOptions(ctx, stmt, opts), spannerRowToRow(fc))
 	s.tc.sendHeartbeat = true
-	return rows, stats, extractColumnNames(metadata.GetRowType().GetFields()), count, metadata, err
+	return rows, stats, count, metadata, err
 }
 
 func (s *Session) queryOptions(mode *sppb.ExecuteSqlRequest_QueryMode) spanner.QueryOptions {

--- a/session_slow_test.go
+++ b/session_slow_test.go
@@ -105,7 +105,7 @@ func TestRequestPriority(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("failed to run query: %v", err)
 			}
-			if _, _, _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), true); err != nil {
+			if _, _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), true); err != nil {
 				t.Fatalf("failed to run update: %v", err)
 			}
 			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -122,7 +122,8 @@ func toTableHeader[T interface {
 
 		return result
 	default:
-		panic(fmt.Sprintf("unknown type: %T", ss))
+		// It is unreachable because of type constraints
+		panic(fmt.Sprintf("unreachable code: unknown type: %T", ss))
 	}
 }
 

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -64,8 +64,82 @@ type BatchInfo struct {
 	Size int
 }
 
+type TableHeader interface {
+	Render(verbose bool) []string
+}
+
+type simpleTableHeader []string
+
+func (th simpleTableHeader) Render(verbose bool) []string {
+	return th
+}
+
+// toTableHeader convert slice or variable arguments to TableHeader.
+// nil or empty slice will return untyped nil.
+func toTableHeader[T interface {
+	string | []string | *sppb.StructType_Field | []*sppb.StructType_Field
+}](ss ...T) TableHeader {
+	if len(ss) == 0 {
+		return nil
+	}
+
+	switch any(ss[0]).(type) {
+	case *sppb.StructType_Field:
+		var result typesTableHeader
+		for _, s := range ss {
+			result = append(result, any(s).(*sppb.StructType_Field))
+		}
+
+		return result
+	case string:
+		var result simpleTableHeader
+		for _, s := range ss {
+			result = append(result, any(s).(string))
+		}
+
+		return result
+	case []*sppb.StructType_Field:
+		var result typesTableHeader
+		for _, s := range ss {
+			result = append(result, any(s).([]*sppb.StructType_Field)...)
+		}
+
+		if len(result) == 0 {
+			return nil
+		}
+
+		return result
+	case []string:
+		var result simpleTableHeader
+		for _, s := range ss {
+			result = append(result, any(s).([]string)...)
+		}
+
+		if len(result) == 0 {
+			return nil
+		}
+
+		return result
+	default:
+		panic(fmt.Sprintf("unknown type: %T", ss))
+	}
+}
+
+type typesTableHeader []*sppb.StructType_Field
+
+func (th typesTableHeader) Render(verbose bool) []string {
+	var result []string
+	for _, f := range th {
+		if verbose {
+			result = append(result, formatTypedHeaderColumn(f))
+		} else {
+			result = append(result, f.Name)
+		}
+	}
+	return result
+}
+
 type Result struct {
-	ColumnNames      []string
 	ColumnAlign      []tw.Align // optional
 	Rows             []Row
 	Predicates       []string
@@ -81,8 +155,8 @@ type Result struct {
 	CommitStats   *sppb.CommitResponse_CommitStats
 	KeepVariables bool
 
-	// ColumnTypes will be printed in `--verbose` mode if it is not empty
-	ColumnTypes []*sppb.StructType_Field
+	TableHeader TableHeader
+
 	ForceWrap   bool
 	LintResults []string
 	PreInput    string

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -65,12 +65,13 @@ type BatchInfo struct {
 }
 
 type TableHeader interface {
-	Render(verbose bool) []string
+	// internalRender shouldn't be called directly. Use renderTableHeader().
+	internalRender(verbose bool) []string
 }
 
 type simpleTableHeader []string
 
-func (th simpleTableHeader) Render(verbose bool) []string {
+func (th simpleTableHeader) internalRender(verbose bool) []string {
 	return th
 }
 
@@ -127,7 +128,7 @@ func toTableHeader[T interface {
 
 type typesTableHeader []*sppb.StructType_Field
 
-func (th typesTableHeader) Render(verbose bool) []string {
+func (th typesTableHeader) internalRender(verbose bool) []string {
 	var result []string
 	for _, f := range th {
 		if verbose {

--- a/statements.go
+++ b/statements.go
@@ -165,7 +165,7 @@ func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) 
 		rows = append(rows, toRow(matched[1]))
 	}
 
-	return &Result{ColumnNames: []string{"Database"},
+	return &Result{TableHeader: simpleTableHeader{"Database"},
 		Rows:         rows,
 		AffectedRows: len(rows),
 	}, nil
@@ -223,7 +223,7 @@ func (s *ShowSchemaUpdateOperations) Execute(ctx context.Context, session *Sessi
 		}
 	}
 	return &Result{
-		ColumnNames:  []string{"OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"},
+		TableHeader:  simpleTableHeader{"OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"},
 		Rows:         rows,
 		AffectedRows: num,
 	}, nil
@@ -437,7 +437,7 @@ func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (*Result,
 		rows = append(rows, row)
 	}
 
-	return &Result{ColumnNames: headers, Rows: rows, AffectedRows: len(rows)}, nil
+	return &Result{TableHeader: toTableHeader(headers), Rows: rows, AffectedRows: len(rows)}, nil
 }
 
 func formatCassandraTypeName(typeInfo gocql.TypeInfo) string {
@@ -463,7 +463,7 @@ func (s *HelpStatement) Execute(ctx context.Context, session *Session) (*Result,
 		}
 	}
 	return &Result{
-		ColumnNames:   sliceOf("Usage", "Syntax"),
+		TableHeader:   toTableHeader("Usage", "Syntax"),
 		Rows:          rows,
 		AffectedRows:  len(rows),
 		KeepVariables: true,

--- a/statements.go
+++ b/statements.go
@@ -165,7 +165,7 @@ func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) 
 		rows = append(rows, toRow(matched[1]))
 	}
 
-	return &Result{TableHeader: simpleTableHeader{"Database"},
+	return &Result{TableHeader: toTableHeader("Database"),
 		Rows:         rows,
 		AffectedRows: len(rows),
 	}, nil
@@ -223,7 +223,7 @@ func (s *ShowSchemaUpdateOperations) Execute(ctx context.Context, session *Sessi
 		}
 	}
 	return &Result{
-		TableHeader:  simpleTableHeader{"OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"},
+		TableHeader:  toTableHeader("OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"),
 		Rows:         rows,
 		AffectedRows: num,
 	}, nil

--- a/statements_explain_describe.go
+++ b/statements_explain_describe.go
@@ -85,7 +85,7 @@ func (s *DescribeStatement) Execute(ctx context.Context, session *Session) (*Res
 
 	result := &Result{
 		AffectedRows: len(rows),
-		ColumnNames:  describeColumnNames,
+		TableHeader:  toTableHeader(describeColumnNames),
 		Timestamp:    timestamp,
 		Rows:         rows,
 	}
@@ -113,7 +113,7 @@ func executeExplain(ctx context.Context, session *Session, sql string, isDML boo
 	}
 
 	result := &Result{
-		ColumnNames:  explainColumnNames,
+		TableHeader:  toTableHeader(explainColumnNames),
 		ColumnAlign:  explainColumnAlign,
 		AffectedRows: len(rows),
 		Rows:         rows,
@@ -175,7 +175,7 @@ func generateExplainAnalyzeResult(sysVars *systemVariables, plan *sppb.QueryPlan
 
 	// ReadOnlyTransaction.Timestamp() is invalid until read.
 	result := &Result{
-		ColumnNames:  columnNames,
+		TableHeader:  toTableHeader(columnNames),
 		ColumnAlign:  columnAlign,
 		ForceVerbose: true,
 		AffectedRows: len(rows),

--- a/statements_llm.go
+++ b/statements_llm.go
@@ -64,7 +64,7 @@ func (s *GeminiStatement) Execute(ctx context.Context, session *Session) (*Resul
 				toRow("text", composed.Statement.Text),
 				toRow("semanticDescription", composed.Statement.SemanticDescription),
 				toRow("syntaxDescription", composed.Statement.SyntaxDescription))),
-		ColumnNames: sliceOf("Column", "Value")}, nil
+		TableHeader: toTableHeader("Column", "Value")}, nil
 }
 
 func readFiles(fsys fs.FS, root string, pred func(string, fs.DirEntry) bool) ([][]byte, error) {

--- a/statements_params.go
+++ b/statements_params.go
@@ -27,7 +27,7 @@ func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*R
 		ToSortFunc(func(r Row) string { return r[0] /* parameter name */ }))
 
 	return &Result{
-		ColumnNames:   []string{"Param_Name", "Param_Kind", "Param_Value"},
+		TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),
 		Rows:          rows,
 		KeepVariables: true,
 	}, nil

--- a/statements_partitioned_query.go
+++ b/statements_partitioned_query.go
@@ -35,7 +35,7 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 	}
 
 	return &Result{
-		ColumnNames:  sliceOf("Partition_Token"),
+		TableHeader:  toTableHeader("Partition_Token"),
 		Rows:         rows,
 		AffectedRows: len(rows),
 		Timestamp:    ts,
@@ -67,7 +67,7 @@ func (s *TryPartitionedQueryStatement) Execute(ctx context.Context, session *Ses
 	}
 
 	return &Result{
-		ColumnNames:  sliceOf("Root_Partitionable"),
+		TableHeader:  toTableHeader("Root_Partitionable"),
 		Rows:         sliceOf(toRow("TRUE")),
 		AffectedRows: 1,
 		Timestamp:    ts,

--- a/statements_proto.go
+++ b/statements_proto.go
@@ -95,7 +95,7 @@ func (s *ShowLocalProtoStatement) Execute(ctx context.Context, session *Session)
 	)
 
 	return &Result{
-		ColumnNames:   []string{"full_name", "kind", "package", "file"},
+		TableHeader:   toTableHeader("full_name", "kind", "package", "file"),
 		Rows:          rows,
 		AffectedRows:  len(rows),
 		KeepVariables: true,
@@ -127,7 +127,7 @@ func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session
 	)
 
 	return &Result{
-		ColumnNames:   []string{"full_name", "kind", "package"},
+		TableHeader:   toTableHeader("full_name", "kind", "package"),
 		Rows:          rows,
 		AffectedRows:  len(rows),
 		KeepVariables: true,

--- a/statements_query_profile.go
+++ b/statements_query_profile.go
@@ -98,7 +98,7 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 	}
 
 	return &Result{
-		ColumnNames:  sliceOf("Plan"),
+		TableHeader:  toTableHeader("Plan"),
 		Rows:         resultRows,
 		AffectedRows: len(resultRows),
 	}, nil

--- a/statements_schema.go
+++ b/statements_schema.go
@@ -173,7 +173,7 @@ func executeInformationSchemaBasedStatementImpl(ctx context.Context, session *Se
 	}
 	tableHeader := typesTableHeader(metadata.GetRowType().GetFields())
 	return &Result{
-		// Pre-render only column names when enforceVerbose is false
+		// Pre-render only column names when forceVerbose is false
 		TableHeader:  lo.Ternary[TableHeader](forceVerbose, tableHeader, toTableHeader(renderTableHeader(tableHeader, false))),
 		ForceVerbose: forceVerbose,
 		Rows:         rows,

--- a/statements_schema.go
+++ b/statements_schema.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apstndb/lox"
 	"github.com/ngicks/go-iterator-helper/hiter/stringsiter"
 	"github.com/ngicks/go-iterator-helper/x/exp/xiter"
+	"github.com/samber/lo"
 )
 
 type ShowCreateStatement struct {
@@ -42,7 +43,7 @@ func (s *ShowCreateStatement) Execute(ctx context.Context, session *Session) (*R
 	}
 
 	result := &Result{
-		ColumnNames:  []string{"Name", "DDL"},
+		TableHeader:  toTableHeader("Name", "DDL"),
 		Rows:         rows,
 		AffectedRows: len(rows),
 	}
@@ -135,7 +136,7 @@ func (s *ShowDdlsStatement) Execute(ctx context.Context, session *Session) (*Res
 	return &Result{
 		KeepVariables: true,
 		// intentionally empty column name to make TAB format valid DDL
-		ColumnNames: sliceOf(""),
+		TableHeader: toTableHeader(""),
 		Rows: sliceOf(toRow(stringsiter.Collect(xiter.Map(
 			func(s string) string { return s + ";\n" },
 			slices.Values(resp.GetStatements()))))),
@@ -170,10 +171,10 @@ func executeInformationSchemaBasedStatementImpl(ctx context.Context, session *Se
 	if len(rows) == 0 && emptyErrorF != nil {
 		return nil, emptyErrorF()
 	}
-
+	tableHeader := typesTableHeader(metadata.GetRowType().GetFields())
 	return &Result{
-		ColumnNames:  extractColumnNames(metadata.GetRowType().GetFields()),
-		ColumnTypes:  lox.IfOrEmpty(forceVerbose, metadata.GetRowType().GetFields()),
+		// Pre-render only column names when enforceVerbose is false
+		TableHeader:  lo.Ternary[TableHeader](forceVerbose, tableHeader, toTableHeader(renderTableHeader(tableHeader, false))),
 		ForceVerbose: forceVerbose,
 		Rows:         rows,
 		AffectedRows: len(rows),

--- a/statements_schema.go
+++ b/statements_schema.go
@@ -171,7 +171,8 @@ func executeInformationSchemaBasedStatementImpl(ctx context.Context, session *Se
 	if len(rows) == 0 && emptyErrorF != nil {
 		return nil, emptyErrorF()
 	}
-	tableHeader := typesTableHeader(metadata.GetRowType().GetFields())
+
+	tableHeader := toTableHeader(metadata.GetRowType().GetFields())
 	return &Result{
 		// Pre-render only column names when forceVerbose is false
 		TableHeader:  lo.Ternary[TableHeader](forceVerbose, tableHeader, toTableHeader(renderTableHeader(tableHeader, false))),

--- a/statements_system_variable.go
+++ b/statements_system_variable.go
@@ -27,7 +27,7 @@ func (s *ShowVariableStatement) Execute(ctx context.Context, session *Session) (
 		row = append(row, value[n])
 	}
 	return &Result{
-		ColumnNames:   columnNames,
+		TableHeader:   toTableHeader(columnNames),
 		Rows:          sliceOf(toRow(row...)),
 		KeepVariables: true,
 	}, nil
@@ -59,7 +59,7 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 		ToSortFunc(func(r Row) string { return r[0] /* name */ }))
 
 	return &Result{
-		ColumnNames:   []string{"name", "value"},
+		TableHeader:   toTableHeader("name", "value"),
 		Rows:          rows,
 		KeepVariables: true,
 	}, nil
@@ -124,7 +124,7 @@ func (s *HelpVariablesStatement) Execute(ctx context.Context, session *Session) 
 	})
 
 	return &Result{
-		ColumnNames:   []string{"name", "operations", "desc"},
+		TableHeader:   toTableHeader("name", "operations", "desc"),
 		Rows:          rows,
 		AffectedRows:  len(rows),
 		KeepVariables: true,


### PR DESCRIPTION
This PR refactors table header logic.
- `ColumnNames []string` and `ColumnTypes []*sppb.StructType_Field` are unified into `TableHeader TableHeader`.
- Some cleanup related column names.
- Also, `tablewriter` module is bumped to v1.0.6.