### PR TITLE
fix: Ensure to clear spinner

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -331,7 +331,7 @@ func (c *Cli) PrintProgressingMark() func() {
 
 	stop := func() {
 		ticker.Stop()
-		fmt.Fprintf(c.OutStream, "\r") // clear progressing mark
+		fmt.Fprintf(c.OutStream, "\r \r") // ensure to clear progressing mark
 	}
 	return stop
 }


### PR DESCRIPTION
This PR ensures progress spinner is cleared after execution.
Additionally, it avoids to output empty line if rendered table is empty.

before
```
spanner> INSERT OR UPDATE INTO Items (item_no, item_name, price) VALUES('003', 'ボールペン', 100);
/
Query OK, 1 rows affected (46.17 msecs)
timestamp:      2025-05-20T09:08:15.366834+09:00
mutation_count: 3
```

after

```
spanner> INSERT OR UPDATE INTO Items (item_no, item_name, price) VALUES('003', 'ボールペン', 100);
Query OK, 1 rows affected (61.43 msecs)
timestamp:      2025-05-20T09:11:10.510426+09:00
mutation_count: 3

```