### PR TITLE
fix: Avoid empty line

### DIFF
--- a/cli_output.go
+++ b/cli_output.go
@@ -117,7 +117,9 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 			s = bottomRightRe.ReplaceAllLiteralString(s, "*/")
 		}
 
-		fmt.Fprintln(out, s)
+		if s != "" {
+			fmt.Fprintln(out, s)
+		}
 	case DisplayModeVertical:
 		maxLen := 0
 		for _, columnName := range columnNames {


### PR DESCRIPTION
This PR fixes to avoid empty line when result set is not printed.
It is typically case of DMLs without `THEN RETURN`

before
```
spanner> INSERT OR UPDATE MutationTest(PK, Col) VALUES(0, 1);

Query OK, 1 rows affected (61.87 msecs)
timestamp:      2025-05-20T13:58:22.431434+09:00
mutation_count: 2
```
after
```
spanner> INSERT OR UPDATE MutationTest(PK, Col) VALUES(0, 1);
Query OK, 1 rows affected (61.87 msecs)
timestamp:      2025-05-20T13:58:22.431434+09:00
mutation_count: 2
```