### PR TITLE
Fix incorrect error check in rollback handling

### DIFF
--- a/execute_sql.go
+++ b/execute_sql.go
@@ -51,7 +51,7 @@ func executeSQL(ctx context.Context, session *Session, sql string) (*Result, err
 		if session.InReadWriteTransaction() && spanner.ErrCode(err) == codes.Aborted {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
 			rollback := &RollbackStatement{}
-			if _, rollbackErr := rollback.Execute(ctx, session); err != nil {
+			if _, rollbackErr := rollback.Execute(ctx, session); rollbackErr != nil {
 				return nil, errors.Join(err, fmt.Errorf("error on rollback: %w", rollbackErr))
 			}
 		}


### PR DESCRIPTION
## Summary
- Fixed incorrect error variable check in rollback handling (execute_sql.go:54)
- Changed from checking `err` to checking `rollbackErr` as intended

## Test plan
- [x] Tests pass locally
- [x] Code change is minimal and focused

Fixes #238

🤖 Generated with [Claude Code](https://claude.ai/code)