### PR TITLE
Handle ignored errors throughout the codebase

### DIFF
--- a/execute_sql.go
+++ b/execute_sql.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime"
 	"slices"
 	"strconv"
@@ -72,7 +73,12 @@ func executeSQL(ctx context.Context, session *Session, sql string) (*Result, err
 
 	// ReadOnlyTransaction.Timestamp() is invalid until read.
 	if roTxn != nil {
-		result.Timestamp, _ = roTxn.Timestamp()
+		ts, err := roTxn.Timestamp()
+		if err != nil {
+			slog.Warn("failed to get read-only transaction timestamp", "err", err)
+		} else {
+			result.Timestamp = ts
+		}
 	}
 
 	session.systemVariables.LastQueryCache = &LastQueryCache{

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -75,7 +75,7 @@ func executeSQL(ctx context.Context, session *Session, sql string) (*Result, err
 	if roTxn != nil {
 		ts, err := roTxn.Timestamp()
 		if err != nil {
-			slog.Warn("failed to get read-only transaction timestamp", "err", err)
+			slog.Warn("failed to get read-only transaction timestamp", "err", err, "sql", sql)
 		} else {
 			result.Timestamp = ts
 		}

--- a/statements_explain_describe.go
+++ b/statements_explain_describe.go
@@ -283,7 +283,14 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		return nil, err
 	}
 
-	result.Timestamp = lox.IfOrEmptyF(roTxn != nil, func() time.Time { return ignoreError(roTxn.Timestamp()) })
+	if roTxn != nil {
+		ts, err := roTxn.Timestamp()
+		if err != nil {
+			slog.Warn("failed to get read-only transaction timestamp", "err", err)
+		} else {
+			result.Timestamp = ts
+		}
+	}
 
 	session.systemVariables.LastQueryCache = &LastQueryCache{
 		QueryPlan:  plan,

--- a/statements_explain_describe.go
+++ b/statements_explain_describe.go
@@ -286,7 +286,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 	if roTxn != nil {
 		ts, err := roTxn.Timestamp()
 		if err != nil {
-			slog.Warn("failed to get read-only transaction timestamp", "err", err)
+			slog.Warn("failed to get read-only transaction timestamp", "err", err, "sql", sql)
 		} else {
 			result.Timestamp = ts
 		}

--- a/util.go
+++ b/util.go
@@ -41,9 +41,6 @@ func toRow(vs ...string) Row {
 	return vs
 }
 
-func ignoreError[T1, T2 any](v1 T1, _ T2) T1 {
-	return v1
-}
 
 func sliceOf[V any](vs ...V) []V {
 	return vs

--- a/zap_logger.go
+++ b/zap_logger.go
@@ -33,7 +33,9 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 			case proto.Message:
 				b, err := protojson.Marshal(v)
 				if err != nil {
-					f = append(f, zap.Error(err))
+					// Associate the error with the original key to avoid collisions
+					// and to make it clear which field failed to marshal.
+					f = append(f, zap.String(key.(string), fmt.Sprintf("ERROR: failed to marshal proto: %v", err)))
 				} else {
 					f = append(f, zap.Any(key.(string), json.RawMessage(b)))
 				}

--- a/zap_logger.go
+++ b/zap_logger.go
@@ -35,7 +35,7 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 				if err != nil {
 					// Associate the error with the original key to avoid collisions
 					// and to make it clear which field failed to marshal.
-					f = append(f, zap.String(key.(string), fmt.Sprintf("ERROR: failed to marshal proto: %v, proto: %v", err, v)))
+					f = append(f, zap.String(key.(string), fmt.Sprintf("ERROR: failed to marshal proto type %s: %v", string(v.ProtoReflect().Descriptor().FullName()), err)))
 				} else {
 					f = append(f, zap.Any(key.(string), json.RawMessage(b)))
 				}

--- a/zap_logger.go
+++ b/zap_logger.go
@@ -35,7 +35,7 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 				if err != nil {
 					// Associate the error with the original key to avoid collisions
 					// and to make it clear which field failed to marshal.
-					f = append(f, zap.String(key.(string), fmt.Sprintf("ERROR: failed to marshal proto: %v", err)))
+					f = append(f, zap.String(key.(string), fmt.Sprintf("ERROR: failed to marshal proto: %v, proto: %v", err, v)))
 				} else {
 					f = append(f, zap.Any(key.(string), json.RawMessage(b)))
 				}

--- a/zap_logger.go
+++ b/zap_logger.go
@@ -31,8 +31,12 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 			case bool:
 				f = append(f, zap.Bool(key.(string), v))
 			case proto.Message:
-				b, _ := protojson.Marshal(v)
-				f = append(f, zap.Any(key.(string), json.RawMessage(b)))
+				b, err := protojson.Marshal(v)
+				if err != nil {
+					f = append(f, zap.Error(err))
+				} else {
+					f = append(f, zap.Any(key.(string), json.RawMessage(b)))
+				}
 			default:
 				f = append(f, zap.Any(key.(string), v))
 			}


### PR DESCRIPTION
## Summary
- Add proper error handling for `roTxn.Timestamp()` calls that were previously ignored
- Add error handling for `protojson.Marshal()` in zap logger
- Remove unused `ignoreError` utility function that encouraged error suppression
- Log warnings when timestamp errors occur instead of silently ignoring them

## Changes Made
### Fixed Ignored Errors:
1. **execute_sql.go:75** - `roTxn.Timestamp()` error now properly handled with warning log
2. **zap_logger.go:34** - `protojson.Marshal()` error now handled with error logging
3. **statements_explain_describe.go:286** - Another `roTxn.Timestamp()` error fixed
4. **session.go** - `adminClient.Close()` error handling was already reasonable (logs but continues cleanup)

### Code Quality Improvements:
- Removed `ignoreError` utility function that was encouraging error suppression
- Added missing `log/slog` import where needed
- Consistent error handling patterns across timestamp operations

## Test Plan
- [x] All tests pass (`make test`)
- [x] Linting passes with 0 issues (`make lint`)
- [x] Fast tests pass (`make fasttest`)
- [x] No functional changes to existing behavior
- [x] Errors are now logged instead of silently ignored

## Impact
- Improves debugging by making previously silent failures visible
- Maintains existing functionality while adding robustness
- Follows Go best practices for error handling
- No breaking changes to public API

Fixes #241

🤖 Generated with [Claude Code](https://claude.ai/code)