### PR TITLE
feat: expose CLI prefix system variables for consistency

### DIFF
--- a/system_variables.go
+++ b/system_variables.go
@@ -1011,6 +1011,29 @@ var systemVariableDefMap = map[string]systemVariableDef{
 			return &variables.AutoConnectAfterCreate
 		}),
 	},
+	"CLI_ENABLE_PROGRESS_BAR": {
+		Description: "A boolean indicating whether to display progress bars during operations. The default is false.",
+		Accessor: boolAccessor(func(variables *systemVariables) *bool {
+			return &variables.EnableProgressBar
+		}),
+	},
+	// Session behavior variables - Getter only to avoid runtime session state changes
+	"CLI_IMPERSONATE_SERVICE_ACCOUNT": {
+		Description: "Service account email for impersonation.",
+		Accessor: accessor{
+			Getter: stringGetter(func(variables *systemVariables) *string {
+				return &variables.ImpersonateServiceAccount
+			}),
+		},
+	},
+	"CLI_ENABLE_ADC_PLUS": {
+		Description: "A boolean indicating whether to enable enhanced Application Default Credentials. The default is false.",
+		Accessor: accessor{
+			Getter: boolGetter(func(variables *systemVariables) *bool {
+				return &variables.EnableADCPlus
+			}),
+		},
+	},
 }
 
 func mergeFDS(left, right *descriptorpb.FileDescriptorSet) *descriptorpb.FileDescriptorSet {

--- a/system_variables_test.go
+++ b/system_variables_test.go
@@ -218,6 +218,19 @@ func TestSystemVariablesSetGet(t *testing.T) {
 			want:  singletonMap("CLI_DATABASE_DIALECT", "GOOGLE_STANDARD_SQL")},
 		{desc: "CLI_QUERY_MODE", name: "CLI_QUERY_MODE", value: "PROFILE",
 			want: singletonMap("CLI_QUERY_MODE", "PROFILE")},
+
+		// New CLI_* variables added for Issue #243
+		{desc: "CLI_ENABLE_PROGRESS_BAR", name: "CLI_ENABLE_PROGRESS_BAR", value: "TRUE",
+			want: singletonMap("CLI_ENABLE_PROGRESS_BAR", "TRUE")},
+		{desc: "CLI_IMPERSONATE_SERVICE_ACCOUNT", name: "CLI_IMPERSONATE_SERVICE_ACCOUNT", unimplementedSet: true,
+			sysVars: &systemVariables{ImpersonateServiceAccount: "test@example.com"},
+			want:    singletonMap("CLI_IMPERSONATE_SERVICE_ACCOUNT", "test@example.com")},
+		{desc: "CLI_ENABLE_ADC_PLUS", name: "CLI_ENABLE_ADC_PLUS", unimplementedSet: true,
+			sysVars: &systemVariables{EnableADCPlus: true},
+			want:    singletonMap("CLI_ENABLE_ADC_PLUS", "TRUE")},
+		{desc: "CLI_MCP", name: "CLI_MCP", unimplementedSet: true,
+			sysVars: &systemVariables{MCP: true},
+			want:    singletonMap("CLI_MCP", "TRUE")},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
- Add `CLI_ENABLE_PROGRESS_BAR` system variable for progress bar display control (read/write)
- Add `CLI_IMPERSONATE_SERVICE_ACCOUNT` system variable for service account impersonation (read-only)
- Add `CLI_ENABLE_ADC_PLUS` system variable for enhanced ADC settings (read-only)

Resolves Issue #243 by exposing the remaining system variables with CLI_ prefix to maintain naming convention consistency. Session behavior variables are read-only to prevent runtime session state changes.

## Test plan
- [x] Add comprehensive test cases in `system_variables_test.go`
- [x] Verify SET/GET operations work correctly for all new variables
- [x] Confirm read-only variables properly reject SET operations
- [x] Run `make test` and `make lint` successfully

🤖 Generated with [Claude Code](https://claude.ai/code)