### PR TITLE
Fix staticcheck linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 version: "2"
 
 linters:
-  disable:
-    - staticcheck
   settings:
     errcheck:
       exclude-functions:

--- a/cli_output.go
+++ b/cli_output.go
@@ -221,9 +221,8 @@ func resultLine(outputTemplate *template.Template, result *Result, verbose bool)
 	elapsedTimePart := lox.IfOrEmpty(result.Stats.ElapsedTime != "", fmt.Sprintf(" (%s)", result.Stats.ElapsedTime))
 
 	var batchInfo string
-	switch {
-	case result.BatchInfo == nil:
-		break
+	switch result.BatchInfo {
+	case nil:
 	default:
 		batchInfo = fmt.Sprintf(" (%d %s%s in batch)", result.BatchInfo.Size,
 			lo.Ternary(result.BatchInfo.Mode == batchModeDDL, "DDL", "DML"),

--- a/client_side_statement_def.go
+++ b/client_side_statement_def.go
@@ -377,7 +377,7 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 				return &ExplainLastQueryStatement{Analyze: isAnalyze, Format: format, Width: width}, nil
 			}
 
-			if strings.TrimSpace(query) == "" && !(hasLastOption && hasQueryOption) {
+			if strings.TrimSpace(query) == "" && (!hasLastOption || !hasQueryOption) {
 				return nil, fmt.Errorf("missing SQL query or 'LAST QUERY' for EXPLAIN%s statement", lo.Ternary(isAnalyze, " ANALYZE", ""))
 			}
 

--- a/session.go
+++ b/session.go
@@ -126,14 +126,14 @@ func (h *SessionHandler) ExecuteStatement(ctx context.Context, stmt Statement) (
 func (h *SessionHandler) createSessionWithOpts(ctx context.Context, sysVars *systemVariables) (*Session, error) {
 	// Create admin-only session if no database is specified
 	if sysVars.Database == "" {
-		return NewAdminSession(ctx, sysVars, h.Session.clientOpts...)
+		return NewAdminSession(ctx, sysVars, h.clientOpts...)
 	}
 	
-	return NewSession(ctx, sysVars, h.Session.clientOpts...)
+	return NewSession(ctx, sysVars, h.clientOpts...)
 }
 
 func (h *SessionHandler) handleUse(ctx context.Context, s *UseStatement) (*Result, error) {
-	newSystemVariables := *h.Session.systemVariables
+	newSystemVariables := *h.systemVariables
 	newSystemVariables.Database = s.Database
 	newSystemVariables.Role = s.Role
 
@@ -162,7 +162,7 @@ func (h *SessionHandler) handleUse(ctx context.Context, s *UseStatement) (*Resul
 }
 
 func (h *SessionHandler) handleDetach(ctx context.Context, s *DetachStatement) (*Result, error) {
-	newSystemVariables := *h.Session.systemVariables
+	newSystemVariables := *h.systemVariables
 	
 	// Clear database and role to switch to detached mode
 	newSystemVariables.Database = ""

--- a/statements.go
+++ b/statements.go
@@ -297,11 +297,11 @@ func (PartitionedDmlStatement) isMutationStatement() {}
 func (s *PartitionedDmlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	if session.InReadWriteTransaction() {
 		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
-		return nil, errors.New(`Partitioned DML statement can not be run in a read-write transaction`)
+		return nil, errors.New(`partitioned DML statement can not be run in a read-write transaction`)
 	}
 	if session.InReadOnlyTransaction() {
 		// Just for user-friendly.
-		return nil, errors.New(`Partitioned DML statement can not be run in a read-only transaction`)
+		return nil, errors.New(`partitioned DML statement can not be run in a read-only transaction`)
 	}
 
 	return executePDML(ctx, session, s.Dml)

--- a/statements_explain_describe.go
+++ b/statements_explain_describe.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
-	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spannerplan"
@@ -175,7 +174,7 @@ func getStructOpts() []yaml.EncodeOption {
 func getGlobalOpts() []yaml.EncodeOption {
 	return slices.Concat(
 		[]yaml.EncodeOption{
-			yaml.CustomMarshaler[*spannerpb.PlanNode_ChildLink](func(link *spannerpb.PlanNode_ChildLink) ([]byte, error) {
+			yaml.CustomMarshaler[*sppb.PlanNode_ChildLink](func(link *sppb.PlanNode_ChildLink) ([]byte, error) {
 				return yaml.MarshalWithOptions(link, yaml.UseJSONMarshaler(), yaml.Flow(true))
 			}),
 		},
@@ -227,7 +226,7 @@ func executeExplain(ctx context.Context, session *Session, sql string, isDML boo
 	}
 
 	if queryPlan == nil {
-		return nil, errors.New("EXPLAIN statement is not supported for Cloud Spanner Emulator.")
+		return nil, errors.New("EXPLAIN statement is not supported for Cloud Spanner Emulator")
 	}
 
 	result, err := generateExplainResult(session.systemVariables, queryPlan, format, width)
@@ -275,7 +274,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 	// Cloud Spanner Emulator doesn't set query plan nodes to the result.
 	// See: https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/77188b228e7757cd56ecffb5bc3ee85dce5d6ae1/frontend/handlers/queries.cc#L224-L230
 	if plan == nil {
-		return nil, errors.New("query plan is not available. EXPLAIN ANALYZE statement is not supported for Cloud Spanner Emulator.")
+		return nil, errors.New("query plan is not available. EXPLAIN ANALYZE statement is not supported for Cloud Spanner Emulator")
 	}
 
 	result, err := generateExplainAnalyzeResult(session.systemVariables, plan, stats, format, width)

--- a/statements_split_points.go
+++ b/statements_split_points.go
@@ -81,11 +81,7 @@ func parseAddSplitPointsBody(body string) ([]*databasepb.SplitPoints, error) {
 
 func parseSplitPoints(p *memefish.Parser, expireTime *timestamppb.Timestamp) ([]*databasepb.SplitPoints, error) {
 	var result []*databasepb.SplitPoints
-	for {
-		if p.Token.Kind == token.TokenEOF {
-			break
-		}
-
+	for p.Token.Kind != token.TokenEOF {
 		sp, err := parseSplitPointsEntry(p, expireTime)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
Resolves all staticcheck linter warnings to improve code quality and enable staticcheck in CI.

## Changes Made

### Code Quality Improvements
- **QF1002**: Optimized tagged switch on `result.BatchInfo` in cli_output.go:225
- **QF1001**: Applied De Morgan's law to simplify boolean logic in client_side_statement_def.go:367  
- **QF1006**: Lifted loop condition optimization in statements_split_points.go:85
- **QF1008**: Removed redundant embedded field selectors in session.go (3 instances)

### Go Convention Compliance
- **ST1005**: Fixed error string capitalization in statements.go (2 instances)
- **ST1005**: Removed punctuation from error strings in statements_explain_describe.go (2 instances)
- **ST1019**: Eliminated duplicate spannerpb imports in statements_explain_describe.go

### Configuration
- **Re-enabled staticcheck** in .golangci.yml after resolving all warnings

## Test Plan
- [x] `make test` - All tests pass ✅
- [x] `make lint` - 0 linter issues ✅  
- [x] All staticcheck warnings resolved ✅

## Verification
```bash
make test && make lint
# ✅ All checks pass
```

Fixes #261

🤖 Generated with [Claude Code](https://claude.ai/code)