### PR TITLE
docs: add Go coding standards and guidelines documentation

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -10,6 +10,7 @@ dev-docs/
 ├── architecture-guide.md        # System architecture and code organization
 ├── development-insights.md      # Development patterns and best practices
 ├── issue-management.md          # GitHub workflow and PR processes
+├── coding-guidelines.md         # Coding standards and style guidelines
 └── patterns/                    # Specific implementation patterns
     └── system-variables.md      # System variable implementation patterns
 ```
@@ -36,6 +37,11 @@ dev-docs/
 - Code review strategies
 - Git best practices
 - Knowledge management through PR comments
+
+### [Coding Guidelines](coding-guidelines.md)
+- Go language standards and conventions
+- Project-specific coding rules
+- Current deviations and future improvements
 
 ### [Patterns](patterns/)
 - [System Variables](patterns/system-variables.md) - Implementation patterns for system variables, timeout management, and testing strategies

--- a/dev-docs/coding-guidelines.md
+++ b/dev-docs/coding-guidelines.md
@@ -1,0 +1,44 @@
+# Coding Guidelines
+
+This document defines the coding guidelines for the spanner-mycli project, based on Go language standards and project-specific conventions.
+
+## Summary of Findings
+
+### 1. Capitalized Error Messages
+- **Issue**: Some error messages start with uppercase letters
+- **Go Convention**: Error strings should not be capitalized unless they begin with proper nouns or acronyms
+- **Example Pattern**: `"EXPLAIN statement is not supported"` should be `"explain statement is not supported"` or better: `"unsupported by emulator: EXPLAIN"`
+
+### 2. Missing Doc Comments on Exported Functions
+- **Issue**: Multiple exported functions lack doc comments
+- **Go Convention**: All exported functions, types, constants, and variables should have doc comments starting with the name of the item
+- **Affected Areas**: Session management, CLI functions, statement processing, utility functions
+- **Note**: Since this project is not used as an external library, some internal-only exports may have minimal documentation by design
+
+### 3. Exported Variables Without Doc Comments
+- **Issue**: Some exported variables lack documentation
+- **Go Convention**: Exported variables should have doc comments explaining their purpose
+
+## Positive Findings ✅
+
+### 1. Error Handling
+- No patterns of silently ignored errors found
+- Errors appear to be properly propagated
+
+### 2. Naming Conventions
+- Function and variable names follow Go conventions (camelCase, exported items start with uppercase)
+- No Hungarian notation or underscore-separated names found
+
+### 3. Package Organization
+- Single package (main) structure is appropriate for a CLI tool
+- No circular dependencies
+
+## Recommendations
+
+1. **Error Messages**: Ensure new error messages follow the lowercase convention
+2. **Documentation**: Add doc comments to exported items in new code
+3. **Future Improvements**: Consider restructuring to minimize unnecessary exports
+
+## Status
+
+As documented in `dev-docs/development-insights.md`, these existing deviations are temporarily permitted but will be addressed in future refactoring. New code should follow standard Go conventions.

--- a/dev-docs/development-insights.md
+++ b/dev-docs/development-insights.md
@@ -141,6 +141,41 @@ make clean                 # Clean artifacts when needed
 scripts/docs/update-help-output.sh    # Generate help output for README.md
 ```
 
+## Go Coding Standards
+
+**Core Principle**: This project follows standard Go conventions. Any exceptions must have documented rationale.
+
+### Essential References
+- **[Effective Go](https://go.dev/doc/effective_go)** - Foundational guide for idiomatic Go
+- **[Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)** - Common review points
+- **[Go Proverbs](https://go-proverbs.github.io/)** - Design philosophy
+
+### Key Standards Applied
+- **Error handling**: Errors are values, handle them gracefully (no silent failures)
+- **Package design**: Clear package boundaries, minimal interfaces
+- **Testing**: Table-driven tests preferred, meaningful test names
+- **Documentation**: All exported items must have doc comments
+
+### Project-Specific Conventions
+- **Linting**: `make lint` enforces staticcheck rules (must pass before push)
+- **Error messages**: 
+  - Should not be capitalized (start with lowercase)
+  - No punctuation at the end
+  - Can contain uppercase words (e.g., SQL keywords)
+  - Good: `"unsupported by emulator: EXPLAIN"`
+  - Bad: `"EXPLAIN statement is not supported"`
+- **Imports**: Standard library → third-party → local packages
+- **Exceptions**: Any deviation from standard Go patterns should include comment explaining rationale
+
+### Known Deviations (Temporary)
+**Note**: These existing deviations are temporarily permitted but will be fixed. New code should follow standard Go conventions.
+
+- **Missing doc comments**: Some exported functions lack proper documentation (e.g., in `session.go`)
+- **Capitalized error messages**: Some errors start with uppercase (e.g., `"EXPLAIN statement is not supported"`)
+  - Should be: `"unsupported by emulator: EXPLAIN"`
+- **Internal-only exports**: Some functions are exported only for Go visibility rules, not for external use
+  - Future fix: Restructure packages to minimize unnecessary exports
+
 ## Related Documentation
 
 - [System Variable Patterns](patterns/system-variables.md) - Implementation patterns for system variables


### PR DESCRIPTION
## Summary
- Add comprehensive Go coding standards documentation to guide development
- Document existing code deviations as temporary, with clear guidance for new code
- Establish project-specific conventions while adhering to standard Go practices

## Changes
1. **Add Go Coding Standards section to `dev-docs/development-insights.md`**
   - Essential references (Effective Go, Code Review Comments, Go Proverbs)
   - Key standards applied in the project
   - Project-specific conventions for error messages and exports
   - Document known temporary deviations

2. **Create `dev-docs/coding-guidelines.md`**
   - Summary of current code review findings
   - Document positive aspects (good error handling, naming conventions)
   - Clear recommendations for future development

3. **Update `dev-docs/README.md`**
   - Add navigation links to coding guidelines

## Key Guidelines Established
- Error messages should not be capitalized (start with lowercase) but can contain uppercase SQL keywords
- Good: `"unsupported by emulator: EXPLAIN"`
- Bad: `"EXPLAIN statement is not supported"`
- Existing deviations are temporary; new code should follow standard Go conventions

🤖 Generated with [Claude Code](https://claude.ai/code)