### PR TITLE
Fix unintended changes in --help output and README.md inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ spanner:
       --enable-partitioned-dml                            Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
       --timeout=                                          Statement timeout (e.g., '10s', '5m', '1h') (default: 10m)
       --mcp                                               Run as MCP server
+
+Help Options:
+  -h, --help                                              Show this help message
 ```
 
 ### Authentication

--- a/main.go
+++ b/main.go
@@ -54,41 +54,49 @@ type globalOptions struct {
 }
 
 // We can't use `default` because spanner-mycli uses multiple flags.NewParser() to process config files and flags.
+// 
+// Config-overridable fields use `default-mask:"-"` to prevent config file values from appearing in help output.
+// This is necessary because:
+// 1. spanner-mycli uses a two-parser approach: config file parser → command line parser
+// 2. go-flags displays struct field values as defaults in help text (not just `default` tags)
+// 3. Config file parsing sets field values before help generation, causing config values to appear as defaults
+// 4. Users would see misleading defaults like "(default: test-value)" when they have values in config files
+// 5. Without default-mask, help output changes based on user's config file contents, creating inconsistent UX
 type spannerOptions struct {
 	ProjectId                 string            `long:"project" short:"p" env:"SPANNER_PROJECT_ID" default-mask:"-" description:"(required) GCP Project ID."`
 	InstanceId                string            `long:"instance" short:"i" env:"SPANNER_INSTANCE_ID" default-mask:"-" description:"(required) Cloud Spanner Instance ID"`
 	DatabaseId                string            `long:"database" short:"d" env:"SPANNER_DATABASE_ID" default-mask:"-" description:"Cloud Spanner Database ID. Optional when --detached is used."`
 	Detached                  bool              `long:"detached" description:"Start in detached mode, ignoring database env var/flag"`
-	Execute                   string            `long:"execute" short:"e" description:"Execute SQL statement and quit. --sql is an alias."`
-	File                      string            `long:"file" short:"f" description:"Execute SQL statement from file and quit."`
+	Execute                   string            `long:"execute" short:"e" description:"Execute SQL statement and quit. --sql is an alias." default-mask:"-"`
+	File                      string            `long:"file" short:"f" description:"Execute SQL statement from file and quit." default-mask:"-"`
 	Table                     bool              `long:"table" short:"t" description:"Display output in table format for batch mode."`
 	Verbose                   bool              `long:"verbose" short:"v" description:"Display verbose output."`
-	Credential                string            `long:"credential" description:"Use the specific credential file"`
+	Credential                string            `long:"credential" description:"Use the specific credential file" default-mask:"-"`
 	Prompt                    *string           `long:"prompt" description:"Set the prompt to the specified format" default-mask:"spanner%t> "`
 	Prompt2                   *string           `long:"prompt2" description:"Set the prompt2 to the specified format" default-mask:"%P%R> "`
 	HistoryFile               *string           `long:"history" description:"Set the history file to the specified path" default-mask:"/tmp/spanner_mycli_readline.tmp"`
-	Priority                  string            `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
-	Role                      string            `long:"role" description:"Use the specific database role. --database-role is an alias."`
-	Endpoint                  string            `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
-	DirectedRead              string            `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
+	Priority                  string            `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)" default-mask:"-"`
+	Role                      string            `long:"role" description:"Use the specific database role. --database-role is an alias." default-mask:"-"`
+	Endpoint                  string            `long:"endpoint" description:"Set the Spanner API endpoint (host:port)" default-mask:"-"`
+	DirectedRead              string            `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE" default-mask:"-"`
 	SQL                       string            `long:"sql" hidden:"true" description:"alias of --execute"`
 	Set                       map[string]string `long:"set" key-value-delimiter:"=" description:"Set system variables e.g. --set=name1=value1 --set=name2=value2" default-mask:"-"`
-	Param                     map[string]string `long:"param" key-value-delimiter:"=" description:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64"`
-	ProtoDescriptorFile       string            `long:"proto-descriptor-file" description:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message."`
+	Param                     map[string]string `long:"param" key-value-delimiter:"=" description:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64" default-mask:"-"`
+	ProtoDescriptorFile       string            `long:"proto-descriptor-file" description:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message." default-mask:"-"`
 	Insecure                  bool              `long:"insecure" description:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias."`
 	SkipTlsVerify             bool              `long:"skip-tls-verify" description:"An alias of --insecure" hidden:"true"`
 	EmbeddedEmulator          bool              `long:"embedded-emulator" description:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
 	EmulatorImage             string            `long:"emulator-image" description:"container image for --embedded-emulator"`
 	OutputTemplate            string            `long:"output-template" description:"Filepath of output template. (EXPERIMENTAL)"`
-	LogLevel                  string            `long:"log-level"`
+	LogLevel                  string            `long:"log-level" default-mask:"-"`
 	LogGrpc                   bool              `long:"log-grpc" description:"Show gRPC logs"`
-	QueryMode                 string            `long:"query-mode" description:"Mode in which the query must be processed." choice:"NORMAL" choice:"PLAN" choice:"PROFILE"`
+	QueryMode                 string            `long:"query-mode" description:"Mode in which the query must be processed." choice:"NORMAL" choice:"PLAN" choice:"PROFILE" default-mask:"-"`
 	Strong                    bool              `long:"strong" description:"Perform a strong query."`
-	ReadTimestamp             string            `long:"read-timestamp" description:"Perform a query at the given timestamp."`
-	VertexAIProject           string            `long:"vertexai-project" description:"Vertex AI project" ini-name:"vertexai_project"`
+	ReadTimestamp             string            `long:"read-timestamp" description:"Perform a query at the given timestamp." default-mask:"-"`
+	VertexAIProject           string            `long:"vertexai-project" description:"Vertex AI project" ini-name:"vertexai_project" default-mask:"-"`
 	VertexAIModel             *string           `long:"vertexai-model" description:"Vertex AI model" ini-name:"vertexai_model" default-mask:"gemini-2.0-flash"`
-	DatabaseDialect           string            `long:"database-dialect" description:"The SQL dialect of the Cloud Spanner Database." choice:"POSTGRESQL" choice:"GOOGLE_STANDARD_SQL"`
-	ImpersonateServiceAccount string            `long:"impersonate-service-account" description:"Impersonate service account email"`
+	DatabaseDialect           string            `long:"database-dialect" description:"The SQL dialect of the Cloud Spanner Database." choice:"POSTGRESQL" choice:"GOOGLE_STANDARD_SQL" default-mask:"-"`
+	ImpersonateServiceAccount string            `long:"impersonate-service-account" description:"Impersonate service account email" default-mask:"-"`
 	Version                   bool              `long:"version" description:"Show version string."`
 	StatementHelp             bool              `long:"statement-help" description:"Show statement help." hidden:"true"`
 	DatabaseRole              string            `long:"database-role" description:"alias of --role" hidden:"true"`

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ type spannerOptions struct {
 	Endpoint                  string            `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
 	DirectedRead              string            `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
 	SQL                       string            `long:"sql" hidden:"true" description:"alias of --execute"`
-	Set                       map[string]string `long:"set" key-value-delimiter:"=" description:"Set system variables e.g. --set=name1=value1 --set=name2=value2"`
+	Set                       map[string]string `long:"set" key-value-delimiter:"=" description:"Set system variables e.g. --set=name1=value1 --set=name2=value2" default-mask:"-"`
 	Param                     map[string]string `long:"param" key-value-delimiter:"=" description:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64"`
 	ProtoDescriptorFile       string            `long:"proto-descriptor-file" description:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message."`
 	Insecure                  bool              `long:"insecure" description:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias."`
@@ -80,7 +80,6 @@ type spannerOptions struct {
 	EmbeddedEmulator          bool              `long:"embedded-emulator" description:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
 	EmulatorImage             string            `long:"emulator-image" description:"container image for --embedded-emulator"`
 	OutputTemplate            string            `long:"output-template" description:"Filepath of output template. (EXPERIMENTAL)"`
-	Help                      bool              `long:"help" short:"h" hidden:"true"`
 	LogLevel                  string            `long:"log-level"`
 	LogGrpc                   bool              `long:"log-grpc" description:"Show gRPC logs"`
 	QueryMode                 string            `long:"query-mode" description:"Mode in which the query must be processed." choice:"NORMAL" choice:"PLAN" choice:"PROFILE"`
@@ -177,9 +176,6 @@ func main() {
 		parser.WriteHelp(os.Stderr)
 		fmt.Fprintf(os.Stderr, "Invalid options: %v\n", err)
 		os.Exit(exitCodeError)
-		return
-	} else if gopts.Spanner.Help {
-		parser.WriteHelp(os.Stderr)
 		return
 	} else if gopts.Spanner.Version {
 		fmt.Printf("%v\n%v\n", getVersion(), installFrom)
@@ -515,7 +511,7 @@ func parseFlags() (globalOptions, *flags.Parser, error) {
 
 	// then, process environment variables and command line options
 	// use another parser to process environment variables with higher precedence than configuration files
-	flagParser := flags.NewParser(&gopts, flags.PrintErrors|flags.PassDoubleDash)
+	flagParser := flags.NewParser(&gopts, flags.PrintErrors|flags.PassDoubleDash|flags.HelpFlag)
 
 	_, err := flagParser.Parse()
 	return gopts, flagParser, err

--- a/main.go
+++ b/main.go
@@ -54,23 +54,17 @@ type globalOptions struct {
 }
 
 // We can't use `default` because spanner-mycli uses multiple flags.NewParser() to process config files and flags.
-// 
-// Config-overridable fields use `default-mask:"-"` to prevent config file values from appearing in help output.
-// This is necessary because:
-// 1. spanner-mycli uses a two-parser approach: config file parser → command line parser
-// 2. go-flags displays struct field values as defaults in help text (not just `default` tags)
-// 3. Config file parsing sets field values before help generation, causing config values to appear as defaults
-// 4. Users would see misleading defaults like "(default: test-value)" when they have values in config files
-// 5. Without default-mask, help output changes based on user's config file contents, creating inconsistent UX
+// All fields use `default-mask:"-"` to prevent struct field values from appearing in help output.
+// This is necessary because go-flags displays any non-zero struct field values as defaults in help text.
 type spannerOptions struct {
 	ProjectId                 string            `long:"project" short:"p" env:"SPANNER_PROJECT_ID" default-mask:"-" description:"(required) GCP Project ID."`
 	InstanceId                string            `long:"instance" short:"i" env:"SPANNER_INSTANCE_ID" default-mask:"-" description:"(required) Cloud Spanner Instance ID"`
 	DatabaseId                string            `long:"database" short:"d" env:"SPANNER_DATABASE_ID" default-mask:"-" description:"Cloud Spanner Database ID. Optional when --detached is used."`
-	Detached                  bool              `long:"detached" description:"Start in detached mode, ignoring database env var/flag"`
+	Detached                  bool              `long:"detached" description:"Start in detached mode, ignoring database env var/flag" default-mask:"-"`
 	Execute                   string            `long:"execute" short:"e" description:"Execute SQL statement and quit. --sql is an alias." default-mask:"-"`
 	File                      string            `long:"file" short:"f" description:"Execute SQL statement from file and quit." default-mask:"-"`
-	Table                     bool              `long:"table" short:"t" description:"Display output in table format for batch mode."`
-	Verbose                   bool              `long:"verbose" short:"v" description:"Display verbose output."`
+	Table                     bool              `long:"table" short:"t" description:"Display output in table format for batch mode." default-mask:"-"`
+	Verbose                   bool              `long:"verbose" short:"v" description:"Display verbose output." default-mask:"-"`
 	Credential                string            `long:"credential" description:"Use the specific credential file" default-mask:"-"`
 	Prompt                    *string           `long:"prompt" description:"Set the prompt to the specified format" default-mask:"spanner%t> "`
 	Prompt2                   *string           `long:"prompt2" description:"Set the prompt2 to the specified format" default-mask:"%P%R> "`
@@ -79,30 +73,30 @@ type spannerOptions struct {
 	Role                      string            `long:"role" description:"Use the specific database role. --database-role is an alias." default-mask:"-"`
 	Endpoint                  string            `long:"endpoint" description:"Set the Spanner API endpoint (host:port)" default-mask:"-"`
 	DirectedRead              string            `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE" default-mask:"-"`
-	SQL                       string            `long:"sql" hidden:"true" description:"alias of --execute"`
+	SQL                       string            `long:"sql" hidden:"true" description:"alias of --execute" default-mask:"-"`
 	Set                       map[string]string `long:"set" key-value-delimiter:"=" description:"Set system variables e.g. --set=name1=value1 --set=name2=value2" default-mask:"-"`
 	Param                     map[string]string `long:"param" key-value-delimiter:"=" description:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64" default-mask:"-"`
 	ProtoDescriptorFile       string            `long:"proto-descriptor-file" description:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message." default-mask:"-"`
-	Insecure                  bool              `long:"insecure" description:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias."`
-	SkipTlsVerify             bool              `long:"skip-tls-verify" description:"An alias of --insecure" hidden:"true"`
-	EmbeddedEmulator          bool              `long:"embedded-emulator" description:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
-	EmulatorImage             string            `long:"emulator-image" description:"container image for --embedded-emulator"`
-	OutputTemplate            string            `long:"output-template" description:"Filepath of output template. (EXPERIMENTAL)"`
+	Insecure                  bool              `long:"insecure" description:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias." default-mask:"-"`
+	SkipTlsVerify             bool              `long:"skip-tls-verify" description:"An alias of --insecure" hidden:"true" default-mask:"-"`
+	EmbeddedEmulator          bool              `long:"embedded-emulator" description:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured." default-mask:"-"`
+	EmulatorImage             string            `long:"emulator-image" description:"container image for --embedded-emulator" default-mask:"-"`
+	OutputTemplate            string            `long:"output-template" description:"Filepath of output template. (EXPERIMENTAL)" default-mask:"-"`
 	LogLevel                  string            `long:"log-level" default-mask:"-"`
-	LogGrpc                   bool              `long:"log-grpc" description:"Show gRPC logs"`
+	LogGrpc                   bool              `long:"log-grpc" description:"Show gRPC logs" default-mask:"-"`
 	QueryMode                 string            `long:"query-mode" description:"Mode in which the query must be processed." choice:"NORMAL" choice:"PLAN" choice:"PROFILE" default-mask:"-"`
-	Strong                    bool              `long:"strong" description:"Perform a strong query."`
+	Strong                    bool              `long:"strong" description:"Perform a strong query." default-mask:"-"`
 	ReadTimestamp             string            `long:"read-timestamp" description:"Perform a query at the given timestamp." default-mask:"-"`
 	VertexAIProject           string            `long:"vertexai-project" description:"Vertex AI project" ini-name:"vertexai_project" default-mask:"-"`
 	VertexAIModel             *string           `long:"vertexai-model" description:"Vertex AI model" ini-name:"vertexai_model" default-mask:"gemini-2.0-flash"`
 	DatabaseDialect           string            `long:"database-dialect" description:"The SQL dialect of the Cloud Spanner Database." choice:"POSTGRESQL" choice:"GOOGLE_STANDARD_SQL" default-mask:"-"`
 	ImpersonateServiceAccount string            `long:"impersonate-service-account" description:"Impersonate service account email" default-mask:"-"`
-	Version                   bool              `long:"version" description:"Show version string."`
-	StatementHelp             bool              `long:"statement-help" description:"Show statement help." hidden:"true"`
-	DatabaseRole              string            `long:"database-role" description:"alias of --role" hidden:"true"`
-	EnablePartitionedDML      bool              `long:"enable-partitioned-dml" description:"Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)"`
+	Version                   bool              `long:"version" description:"Show version string." default-mask:"-"`
+	StatementHelp             bool              `long:"statement-help" description:"Show statement help." hidden:"true" default-mask:"-"`
+	DatabaseRole              string            `long:"database-role" description:"alias of --role" hidden:"true" default-mask:"-"`
+	EnablePartitionedDML      bool              `long:"enable-partitioned-dml" description:"Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)" default-mask:"-"`
 	Timeout                   string            `long:"timeout" description:"Statement timeout (e.g., '10s', '5m', '1h')" default:"10m"`
-	MCP                       bool              `long:"mcp" description:"Run as MCP server"`
+	MCP                       bool              `long:"mcp" description:"Run as MCP server" default-mask:"-"`
 }
 
 // determineInitialDatabase determines the initial database based on CLI flags and environment


### PR DESCRIPTION
## Summary

This PR fixes help output inconsistencies identified in issue #285 by implementing comprehensive default-mask handling and restoring proper help flag behavior.

## Changes Made

### 1. Restore [OPTIONS] in help output
- Enable `flags.HelpFlag` in the parser configuration
- Remove redundant manual help flag handling

### 2. Fix --set default display issue
- Apply `default-mask:"-"` comprehensively to all `spannerOptions` fields
- Prevent config file values from appearing as misleading defaults in help output

### 3. Update README.md
- Add missing "Help Options" section to match actual help output

### 4. Simplify struct documentation
- Streamline comments explaining go-flags behavior with default-mask

## Technical Details

### go-flags Default Value Display Behavior

The core issue was that `go-flags` displays **any non-zero struct field values** as defaults in help text, not just values from `default` tags. This behavior becomes problematic with spanner-mycli's two-parser architecture:

1. **Config file parser** (`flags.Default`) - loads `.spanner_mycli.cnf` and sets struct field values
2. **Command line parser** (`flags.HelpFlag`) - processes CLI args and generates help output

Without `default-mask:"-"`, help output would show config file values as defaults, creating inconsistent and misleading help text that varies based on user's config file contents.

### Comprehensive default-mask Application

Applied `default-mask:"-"` to **all** `spannerOptions` fields for consistency, including:
- Visible config-overridable fields (prevents config value leakage)
- Hidden fields (`hidden:"true"`) - for consistency, even though hidden fields never appear in help output
- Fields with meaningful defaults use `default-mask:"actual-value"` (e.g., `Prompt`, `VertexAIModel`)

## Development Insights

### Key Discovery: go-flags hidden Field Behavior
Through testing, we confirmed that **fields with `hidden:"true"` are completely excluded from help output**, regardless of their values. Even when config file values are loaded into hidden fields, they never appear in help text.

This means:
- `hidden:"true"` alone is sufficient to exclude fields from help
- Adding `default-mask:"-"` to hidden fields is technically unnecessary but improves consistency

### Testing Approach
Created test config file with values for both visible and hidden fields:
```ini
[spanner]
priority = HIGH
sql = "hidden-field-test"  # This never appears in help due to hidden:"true"
```

Confirmed that:
- Hidden fields remain invisible in help output regardless of config values
- Visible fields without `default-mask` would show config values as defaults
- Fields with `default-mask:"-"` properly hide current values from help display

### Architecture Pattern
This establishes a clear pattern for future CLI option additions:
- **All fields**: Use `default-mask:"-"` for consistency
- **Exception**: Fields with meaningful display defaults use `default-mask:"value"`
- **Simple rule**: No need to distinguish between config-overridable vs non-config-overridable fields

## Verification

All changes maintain backward compatibility while fixing the help output inconsistencies described in issue #285.

Fixes #285