### PR TITLE
feat: add SHOW OPERATION statement to attach to specific LRO

### DIFF
--- a/client_side_statement_def.go
+++ b/client_side_statement_def.go
@@ -196,6 +196,20 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 			return &ShowSchemaUpdateOperations{}, nil
 		},
 	},
+	{
+		Descriptions: []clientSideStatementDescription{
+			{
+				Usage:  `Show specific operation`,
+				Syntax: `SHOW OPERATION <operation-id-or-name>`,
+				Note:   `Attach to and monitor a specific Long Running Operation by its operation ID or full operation name.`,
+			},
+		},
+		Pattern: regexp.MustCompile(`(?is)^SHOW\s+OPERATION\s+(.+)$`),
+		HandleSubmatch: func(matched []string) (Statement, error) {
+			operationId := unquoteString(matched[1])
+			return &ShowOperationStatement{OperationId: operationId}, nil
+		},
+	},
 	// Split Points
 	{
 		Descriptions: []clientSideStatementDescription{

--- a/client_side_statement_def.go
+++ b/client_side_statement_def.go
@@ -199,15 +199,19 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 	{
 		Descriptions: []clientSideStatementDescription{
 			{
-				Usage:  `Show specific operation`,
-				Syntax: `SHOW OPERATION <operation-id-or-name>`,
-				Note:   `Attach to and monitor a specific Long Running Operation by its operation ID or full operation name.`,
+				Usage:  `Show specific operation (async)`,
+				Syntax: `SHOW OPERATION <operation-id-or-name> [ASYNC|SYNC]`,
+				Note:   `Attach to and monitor a specific Long Running Operation by its operation ID or full operation name. ASYNC (default) returns current status, SYNC provides real-time monitoring (planned).`,
 			},
 		},
-		Pattern: regexp.MustCompile(`(?is)^SHOW\s+OPERATION\s+(.+)$`),
+		Pattern: regexp.MustCompile(`(?is)^SHOW\s+OPERATION\s+(.+?)(?:\s+(SYNC|ASYNC))?$`),
 		HandleSubmatch: func(matched []string) (Statement, error) {
 			operationId := unquoteString(matched[1])
-			return &ShowOperationStatement{OperationId: operationId}, nil
+			mode := strings.ToUpper(matched[2])
+			if mode == "" {
+				mode = "ASYNC" // Default to ASYNC mode
+			}
+			return &ShowOperationStatement{OperationId: operationId, Mode: mode}, nil
 		},
 	},
 	// Split Points

--- a/integration_test.go
+++ b/integration_test.go
@@ -1711,18 +1711,22 @@ func TestShowOperation(t *testing.T) {
 		t.Fatal("Expected at least one schema update operation, but got none")
 	}
 
-	// Extract operation ID from the first row (assuming it's our CREATE TABLE operation)
-	if len(result.Rows) == 0 {
-		t.Fatal("Expected at least one row in SHOW SCHEMA UPDATE OPERATIONS result")
+	// Extract operation ID by matching the DDL statement
+	var operationID string
+	var foundOp bool
+	for _, row := range result.Rows {
+		// Assuming DDL statement is in the second column (index 1) and operation ID in the first (index 0)
+		if len(row) > 1 && strings.Contains(row[1], "CREATE TABLE TestShowOperationTable") {
+			if len(row[0]) > 0 {
+				operationID = row[0]
+				foundOp = true
+				break
+			}
+		}
 	}
 
-	operationID := ""
-	if len(result.Rows[0]) > 0 {
-		operationID = result.Rows[0][0]
-	}
-	
-	if operationID == "" {
-		t.Fatal("Failed to extract operation ID from SHOW SCHEMA UPDATE OPERATIONS result")
+	if !foundOp {
+		t.Fatalf("Failed to find operation ID for DDL: %s in SHOW SCHEMA UPDATE OPERATIONS result", ddlStatement)
 	}
 
 	// Test SHOW OPERATION with the extracted operation ID

--- a/integration_test.go
+++ b/integration_test.go
@@ -1809,5 +1809,36 @@ func TestShowOperation(t *testing.T) {
 		t.Error("Expected error for non-existent operation ID, but got none")
 	}
 
+	// Test SYNC mode error (not yet implemented)
+	syncStmt, err := BuildStatement("SHOW OPERATION 'auto_op_123456789' SYNC")
+	if err != nil {
+		t.Fatalf("invalid SHOW OPERATION SYNC statement: %v", err)
+	}
+
+	_, err = syncStmt.Execute(ctx, session)
+	if err == nil {
+		t.Error("Expected error for SYNC mode (not implemented), but got none")
+	}
+	if !strings.Contains(err.Error(), "SYNC mode is not yet implemented") {
+		t.Errorf("Expected SYNC mode error message, got: %v", err)
+	}
+
+	// Test explicit ASYNC mode (should work same as default)
+	asyncStmt, err := BuildStatement(fmt.Sprintf("SHOW OPERATION '%s' ASYNC", operationID))
+	if err != nil {
+		t.Fatalf("invalid SHOW OPERATION ASYNC statement: %v", err)
+	}
+
+	asyncResult, err := asyncStmt.Execute(ctx, session)
+	if err != nil {
+		t.Fatalf("SHOW OPERATION ASYNC execution failed: %v", err)
+	}
+
+	// Results should be identical for default and explicit ASYNC mode
+	if len(asyncResult.Rows) != len(opResult.Rows) {
+		t.Errorf("Expected same number of rows for default (%d) and ASYNC mode (%d)", 
+			len(opResult.Rows), len(asyncResult.Rows))
+	}
+
 	_ = emulator // Ensure emulator is used to avoid unused variable
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1678,3 +1678,136 @@ func TestPartitionedDML(t *testing.T) {
 		t.Errorf("PARTITIONED UPDATE was executed, but rows were not updated")
 	}
 }
+
+func TestShowOperation(t *testing.T) {
+	ctx := context.Background()
+	emulator, session, teardown := initialize(t, nil, nil)
+	defer teardown()
+
+	// Execute a DDL operation to create an LRO
+	ddlStatement := "CREATE TABLE TestShowOperationTable (id INT64, name STRING(100)) PRIMARY KEY (id)"
+	stmt, err := BuildStatement(ddlStatement)
+	if err != nil {
+		t.Fatalf("invalid DDL statement: %v", err)
+	}
+
+	if _, err := stmt.Execute(ctx, session); err != nil {
+		t.Fatalf("DDL execution failed: %v", err)
+	}
+
+	// Get schema update operations to find our operation ID
+	showOpsStmt, err := BuildStatement("SHOW SCHEMA UPDATE OPERATIONS")
+	if err != nil {
+		t.Fatalf("invalid SHOW SCHEMA UPDATE OPERATIONS statement: %v", err)
+	}
+
+	result, err := showOpsStmt.Execute(ctx, session)
+	if err != nil {
+		t.Fatalf("SHOW SCHEMA UPDATE OPERATIONS execution failed: %v", err)
+	}
+
+	// Verify we have at least one operation
+	if result.AffectedRows == 0 {
+		t.Fatal("Expected at least one schema update operation, but got none")
+	}
+
+	// Extract operation ID from the first row (assuming it's our CREATE TABLE operation)
+	if len(result.Rows) == 0 {
+		t.Fatal("Expected at least one row in SHOW SCHEMA UPDATE OPERATIONS result")
+	}
+
+	operationID := ""
+	if len(result.Rows[0]) > 0 {
+		operationID = result.Rows[0][0]
+	}
+	
+	if operationID == "" {
+		t.Fatal("Failed to extract operation ID from SHOW SCHEMA UPDATE OPERATIONS result")
+	}
+
+	// Test SHOW OPERATION with the extracted operation ID
+	showOpStmt, err := BuildStatement(fmt.Sprintf("SHOW OPERATION '%s'", operationID))
+	if err != nil {
+		t.Fatalf("invalid SHOW OPERATION statement: %v", err)
+	}
+
+	opResult, err := showOpStmt.Execute(ctx, session)
+	if err != nil {
+		t.Fatalf("SHOW OPERATION execution failed: %v", err)
+	}
+
+	// Verify the result has the expected structure
+	expectedHeaders := []string{"OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"}
+	actualHeaders := renderTableHeader(opResult.TableHeader, false)
+	if len(actualHeaders) != len(expectedHeaders) {
+		t.Fatalf("Expected %d table headers, got %d", len(expectedHeaders), len(actualHeaders))
+	}
+
+	for i, expected := range expectedHeaders {
+		if actualHeaders[i] != expected {
+			t.Errorf("Expected header[%d] to be %s, got %s", i, expected, actualHeaders[i])
+		}
+	}
+
+	// Verify we have at least one row (our CREATE TABLE statement)
+	if len(opResult.Rows) == 0 {
+		t.Fatal("Expected at least one row in SHOW OPERATION result")
+	}
+
+	// Verify the operation ID matches what we requested
+	if len(opResult.Rows[0]) > 0 && opResult.Rows[0][0] != operationID {
+		t.Errorf("Expected operation ID %s, got %s", operationID, opResult.Rows[0][0])
+	}
+
+	// Verify the statement contains our DDL
+	if len(opResult.Rows[0]) > 1 {
+		statement := opResult.Rows[0][1]
+		if !strings.Contains(statement, "CREATE TABLE TestShowOperationTable") {
+			t.Errorf("Expected statement to contain CREATE TABLE TestShowOperationTable, got: %s", statement)
+		}
+	}
+
+	// Verify the operation is done (DDL should complete quickly in emulator)
+	if len(opResult.Rows[0]) > 2 {
+		done := opResult.Rows[0][2]
+		if done != "true" {
+			t.Logf("Note: Operation is not done yet: %s (this may be expected for slow operations)", done)
+		}
+	}
+
+	// Test SHOW OPERATION with full operation name format
+	fullOpName := fmt.Sprintf("projects/%s/instances/%s/databases/%s/operations/%s", 
+		session.systemVariables.Project, 
+		session.systemVariables.Instance, 
+		session.systemVariables.Database, 
+		operationID)
+	
+	showOpFullStmt, err := BuildStatement(fmt.Sprintf("SHOW OPERATION '%s'", fullOpName))
+	if err != nil {
+		t.Fatalf("invalid SHOW OPERATION statement with full name: %v", err)
+	}
+
+	fullOpResult, err := showOpFullStmt.Execute(ctx, session)
+	if err != nil {
+		t.Fatalf("SHOW OPERATION execution with full name failed: %v", err)
+	}
+
+	// Results should be identical whether using short ID or full name
+	if len(fullOpResult.Rows) != len(opResult.Rows) {
+		t.Errorf("Expected same number of rows for short ID (%d) and full name (%d)", 
+			len(opResult.Rows), len(fullOpResult.Rows))
+	}
+
+	// Test error case: non-existent operation
+	nonExistentStmt, err := BuildStatement("SHOW OPERATION 'non_existent_operation_id'")
+	if err != nil {
+		t.Fatalf("invalid SHOW OPERATION statement for non-existent ID: %v", err)
+	}
+
+	_, err = nonExistentStmt.Execute(ctx, session)
+	if err == nil {
+		t.Error("Expected error for non-existent operation ID, but got none")
+	}
+
+	_ = emulator // Ensure emulator is used to avoid unused variable
+}

--- a/statement_processing_test.go
+++ b/statement_processing_test.go
@@ -541,19 +541,34 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowSchemaUpdateOperations{},
 		},
 		{
-			desc:  "SHOW OPERATION statement with operation ID",
+			desc:  "SHOW OPERATION statement with operation ID (default ASYNC)",
 			input: "SHOW OPERATION auto_op_123456789",
-			want:  &ShowOperationStatement{OperationId: "auto_op_123456789"},
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789", Mode: "ASYNC"},
 		},
 		{
 			desc:  "SHOW OPERATION statement with quoted operation ID",
 			input: "SHOW OPERATION 'auto_op_123456789'",
-			want:  &ShowOperationStatement{OperationId: "auto_op_123456789"},
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789", Mode: "ASYNC"},
 		},
 		{
 			desc:  "SHOW OPERATION statement with full operation name",
 			input: "SHOW OPERATION 'projects/my-project/instances/my-instance/databases/my-db/operations/auto_op_123456789'",
-			want:  &ShowOperationStatement{OperationId: "projects/my-project/instances/my-instance/databases/my-db/operations/auto_op_123456789"},
+			want:  &ShowOperationStatement{OperationId: "projects/my-project/instances/my-instance/databases/my-db/operations/auto_op_123456789", Mode: "ASYNC"},
+		},
+		{
+			desc:  "SHOW OPERATION statement with explicit ASYNC mode",
+			input: "SHOW OPERATION 'auto_op_123456789' ASYNC",
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789", Mode: "ASYNC"},
+		},
+		{
+			desc:  "SHOW OPERATION statement with SYNC mode",
+			input: "SHOW OPERATION 'auto_op_123456789' SYNC",
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789", Mode: "SYNC"},
+		},
+		{
+			desc:  "SHOW OPERATION statement with case insensitive mode",
+			input: "SHOW OPERATION 'auto_op_123456789' sync",
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789", Mode: "SYNC"},
 		},
 		{
 			desc:  "EXPLAIN SELECT statement",

--- a/statement_processing_test.go
+++ b/statement_processing_test.go
@@ -541,6 +541,21 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowSchemaUpdateOperations{},
 		},
 		{
+			desc:  "SHOW OPERATION statement with operation ID",
+			input: "SHOW OPERATION auto_op_123456789",
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789"},
+		},
+		{
+			desc:  "SHOW OPERATION statement with quoted operation ID",
+			input: "SHOW OPERATION 'auto_op_123456789'",
+			want:  &ShowOperationStatement{OperationId: "auto_op_123456789"},
+		},
+		{
+			desc:  "SHOW OPERATION statement with full operation name",
+			input: "SHOW OPERATION 'projects/my-project/instances/my-instance/databases/my-db/operations/auto_op_123456789'",
+			want:  &ShowOperationStatement{OperationId: "projects/my-project/instances/my-instance/databases/my-db/operations/auto_op_123456789"},
+		},
+		{
 			desc:  "EXPLAIN SELECT statement",
 			input: "EXPLAIN SELECT * FROM t1",
 			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},

--- a/statements.go
+++ b/statements.go
@@ -255,6 +255,76 @@ func (s *ShowSchemaUpdateOperations) Execute(ctx context.Context, session *Sessi
 	}, nil
 }
 
+type ShowOperationStatement struct {
+	OperationId string
+}
+
+func (s *ShowOperationStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	operationName := s.OperationId
+	
+	// If the operation ID doesn't contain a full path, construct the full operation name
+	if !strings.Contains(operationName, "/") {
+		operationName = session.DatabasePath() + "/operations/" + operationName
+	}
+	
+	// Get the specific operation
+	op, err := session.adminClient.GetOperation(ctx, &longrunningpb.GetOperationRequest{
+		Name: operationName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operation %q: %w", operationName, err)
+	}
+	
+	var rows []Row
+	
+	// Handle different operation types
+	switch op.GetMetadata().GetTypeUrl() {
+	case "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata":
+		var md databasepb.UpdateDatabaseDdlMetadata
+		if err := op.GetMetadata().UnmarshalTo(&md); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal UpdateDatabaseDdlMetadata: %w", err)
+		}
+		
+		operationId := lo.LastOrEmpty(strings.Split(op.GetName(), "/"))
+		
+		for i := range md.GetStatements() {
+			rows = append(rows, toRow(
+				lo.Ternary(i == 0, operationId, ""),
+				md.GetStatements()[i]+";",
+				lox.IfOrEmpty(i == 0, strconv.FormatBool(op.GetDone())),
+				lox.IfOrEmptyF(len(md.GetProgress()) > i, func() string {
+					return fmt.Sprint(md.GetProgress()[i].GetProgressPercent())
+				}),
+				lox.IfOrEmptyF(len(md.GetCommitTimestamps()) > i, func() string {
+					return md.GetCommitTimestamps()[i].AsTime().Format(time.RFC3339Nano)
+				}),
+				op.GetError().GetMessage(),
+			))
+		}
+	default:
+		// For other operation types, show basic information
+		operationId := lo.LastOrEmpty(strings.Split(op.GetName(), "/"))
+		rows = append(rows, toRow(
+			operationId,
+			"N/A (Non-DDL Operation)",
+			strconv.FormatBool(op.GetDone()),
+			"N/A",
+			"N/A",
+			op.GetError().GetMessage(),
+		))
+	}
+	
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("operation %q not found or has no statements", operationName)
+	}
+	
+	return &Result{
+		TableHeader:  toTableHeader("OPERATION_ID", "STATEMENTS", "DONE", "PROGRESS", "COMMIT_TIMESTAMP", "ERROR"),
+		Rows:         rows,
+		AffectedRows: 1, // We're showing one operation
+	}, nil
+}
+
 // Protocol Buffers related statements are defined in statements_proto.go
 
 // TRUNCATE TABLE

--- a/statements.go
+++ b/statements.go
@@ -257,9 +257,15 @@ func (s *ShowSchemaUpdateOperations) Execute(ctx context.Context, session *Sessi
 
 type ShowOperationStatement struct {
 	OperationId string
+	Mode        string // "ASYNC" or "SYNC"
 }
 
 func (s *ShowOperationStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	// Check mode support
+	if s.Mode == "SYNC" {
+		return nil, fmt.Errorf("SYNC mode is not yet implemented. Use ASYNC mode (default) for current status check")
+	}
+	
 	operationName := s.OperationId
 	
 	// If the operation ID doesn't contain a full path, construct the full operation name


### PR DESCRIPTION
## Summary

Implements `SHOW OPERATION` command that allows users to attach to and monitor a specific Long Running Operation by its operation ID or full operation name.

Fixes #51

## Features

### ASYNC Mode (Implemented)
- **Default behavior**: `SHOW OPERATION <operation-id>`
- **Explicit mode**: `SHOW OPERATION <operation-id> ASYNC`
- **One-time status check**: Returns current operation status immediately
- **Consistent behavior**: Non-blocking, same as all existing commands

### SYNC Mode (Command parsing ready)
- **Explicit mode**: `SHOW OPERATION <operation-id> SYNC`
- **Command parsing**: Fully implemented and tested
- **Execution**: Returns "not yet implemented" error (Issue #297)
- **Future enhancement**: Real-time monitoring with progress bar

### Flexible Input Formats
- **Operation ID**: `SHOW OPERATION 'auto_op_123456789'`
- **Full operation name**: `SHOW OPERATION 'projects/my-project/instances/my-instance/databases/my-db/operations/auto_op_123456789'`
- **Case insensitive**: `SHOW OPERATION 'id' sync` works

### Comprehensive Operation Support
- **DDL operations**: Detailed progress information (statements, progress %, commit timestamps)
- **Non-DDL operations**: Basic information display
- **Consistent output**: Same format as existing `SHOW SCHEMA UPDATE OPERATIONS`

## Implementation Details

### Core Components
- **client_side_statement_def.go**: Pattern matching with optional SYNC/ASYNC keywords
- **statements.go**: `ShowOperationStatement` with mode support and execution logic
- **Comprehensive error handling**: Proper messages for non-existent operations and unimplemented modes

### Design Benefits
1. **Clear semantics**: ASYNC/SYNC clearly indicates blocking vs non-blocking behavior
2. **Backward compatibility**: Default ASYNC behavior maintains consistency
3. **Future ready**: Foundation for Issue #297 SYNC mode implementation
4. **User choice**: Explicit control over monitoring behavior

## Example Usage

### Basic Usage (ASYNC mode)
```sql
-- Default: check current status and return immediately
spanner> SHOW OPERATION 'auto_op_123456789';
OPERATION_ID    | STATEMENTS                           | DONE | PROGRESS | COMMIT_TIMESTAMP         | ERROR
auto_op_123     | CREATE INDEX idx_name ON table...;  | false| 60       | 2025-06-17T16:30:45...  |

-- Explicit ASYNC mode (same behavior)
spanner> SHOW OPERATION 'auto_op_123456789' ASYNC;
```

### Future SYNC Mode
```sql
-- Will provide real-time monitoring (Issue #297)
spanner> SHOW OPERATION 'auto_op_123456789' SYNC;
Error: SYNC mode is not yet implemented. Use ASYNC mode (default) for current status check
```

## Test Coverage

### ✅ Unit Tests
- Statement parsing for all input formats (ID, quoted ID, full name)
- SYNC/ASYNC mode recognition and case insensitivity
- Error handling for parsing edge cases

### ✅ Integration Tests
- Complete workflow: DDL execution → operation discovery → specific monitoring
- Both short ID and full operation name formats
- Error handling for non-existent operations
- SYNC mode error validation
- ASYNC mode explicit vs default behavior comparison

### ✅ Quality Checks
- **Lint**: `make lint` passes with 0 issues
- **Fast tests**: `make fasttest` passes
- **Full test suite**: `make test` passes (including integration tests)
- **Build verification**: Successful compilation

## Related Issues

- **Fixes #51**: Attach existing LRO (Phase 1: ASYNC mode)
- **Prepares for #297**: SYNC mode with progress bar
- **Part of broader strategy**: Enhanced DDL operation management

## Migration Path

This is a **non-breaking addition**:
- No existing functionality is modified
- New commands are additive only
- Default behavior (ASYNC) is consistent with existing patterns
- Users can adopt new functionality incrementally

🤖 Generated with [Claude Code](https://claude.ai/code)