### PR TITLE
feat: implement RETURN_COMMIT_STATS setter (SET variable)

### DIFF
--- a/session.go
+++ b/session.go
@@ -561,7 +561,7 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolationLevel 
 	resolvedIsolationLevel := s.resolveIsolationLevel(isolationLevel)
 
 	opts := spanner.TransactionOptions{
-		CommitOptions:               spanner.CommitOptions{ReturnCommitStats: true, MaxCommitDelay: s.systemVariables.MaxCommitDelay},
+		CommitOptions:               spanner.CommitOptions{ReturnCommitStats: s.systemVariables.ReturnCommitStats, MaxCommitDelay: s.systemVariables.MaxCommitDelay},
 		CommitPriority:              resolvedPriority,
 		TransactionTag:              tag,
 		ExcludeTxnFromChangeStreams: s.systemVariables.ExcludeTxnFromChangeStreams,

--- a/system_variables.go
+++ b/system_variables.go
@@ -506,12 +506,9 @@ var systemVariableDefMap = map[string]systemVariableDef{
 		})},
 	"RETURN_COMMIT_STATS": {
 		Description: "A property of type BOOL indicating whether statistics should be returned for transactions on this connection.",
-		Accessor: accessor{
-			Getter: boolGetter(func(variables *systemVariables) *bool {
-				return &variables.ReturnCommitStats
-			}),
-			// Setter will be implemented in issue #310
-		},
+		Accessor: boolAccessor(func(variables *systemVariables) *bool {
+			return &variables.ReturnCommitStats
+		}),
 	},
 	"AUTO_BATCH_DML": {
 		Description: "A property of type BOOL indicating whether the DML is executed immediately or begins a batch DML. The default is false.",

--- a/system_variables_test.go
+++ b/system_variables_test.go
@@ -233,9 +233,10 @@ func TestSystemVariablesSetGet(t *testing.T) {
 		{desc: "CLI_MCP", name: "CLI_MCP", unimplementedSet: true,
 			sysVars: &systemVariables{MCP: true},
 			want:    singletonMap("CLI_MCP", "TRUE")},
-		{desc: "RETURN_COMMIT_STATS", name: "RETURN_COMMIT_STATS", unimplementedSet: true,
-			sysVars: &systemVariables{ReturnCommitStats: true},
-			want:    singletonMap("RETURN_COMMIT_STATS", "TRUE")},
+		{desc: "RETURN_COMMIT_STATS true", name: "RETURN_COMMIT_STATS", value: "TRUE",
+			want: singletonMap("RETURN_COMMIT_STATS", "TRUE")},
+		{desc: "RETURN_COMMIT_STATS false", name: "RETURN_COMMIT_STATS", value: "FALSE",
+			want: singletonMap("RETURN_COMMIT_STATS", "FALSE")},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Implements the setter functionality for `RETURN_COMMIT_STATS` system variable to support `SET RETURN_COMMIT_STATS = {true|false}` command, completing the java-spanner JDBC compatibility for this variable.

## Changes

1. **Changed accessor to boolAccessor** (`system_variables.go:507-511`)
   - Replaced read-only getter with `boolAccessor` helper which provides both getter and setter functionality
   - This follows the established pattern for boolean system variables in the codebase

2. **Updated transaction options** (`session.go:564`)
   - Changed hardcoded `ReturnCommitStats: true` to use the system variable value
   - Now respects the user's preference for commit statistics collection

3. **Updated tests** (`system_variables_test.go:236-239`)
   - Removed `unimplementedSet: true` flag
   - Added test cases for both `TRUE` and `FALSE` values

## Implementation Insights

### Discovery of hardcoded behavior
During investigation, I discovered that `ReturnCommitStats` was hardcoded to `true` in `BeginReadWriteTransaction()`. This meant that even though the variable existed and had a default value of `true`, it wasn't actually being used to control the behavior.

### Integration point with Cloud Spanner client
The `ReturnCommitStats` option is passed to the Cloud Spanner client via `spanner.CommitOptions` within `spanner.TransactionOptions`. When set to `false`, the client will not request commit statistics from the server, which can provide a minor performance benefit by reducing the response payload.

### Design consistency
The implementation follows the established patterns in the codebase:
- Using `boolAccessor` for boolean variables that need both getter and setter
- Maintaining the default value of `true` in `newSystemVariablesWithDefaults()`
- Following the naming convention without CLI_ prefix as this is a java-spanner compatible variable

## Testing

- All existing tests pass with `make check`
- Added specific test cases for setting the variable to both `true` and `false`
- The default value remains `true` for backward compatibility

## Success Criteria Met

- ✅ `SET RETURN_COMMIT_STATS = true/false` works correctly
- ✅ Setting persists for the session
- ✅ When false, commit statistics are not collected (via Cloud Spanner client option)
- ✅ When true, maintains current behavior (statistics collected)
- ✅ Integration with existing commit response handling works correctly

Fixes #310
EOF < /dev/null