### PR TITLE
fix: replace context.TODO() with t.Context() in integration tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -676,7 +676,7 @@ func TestStatements(t *testing.T) {
 			stmt: sliceOf("HELP"),
 			wantResults: []*Result{
 				// It should be safe because HELP doesn't depend on ctx and session.
-				lo.Must((&HelpStatement{}).Execute(context.TODO(), nil)),
+				lo.Must((&HelpStatement{}).Execute(t.Context(), nil)),
 			},
 		},
 		{
@@ -928,7 +928,7 @@ func TestStatements(t *testing.T) {
 			desc: "HELP VARIABLES",
 			stmt: sliceOf("HELP VARIABLES"),
 			wantResults: []*Result{
-				lo.Must((&HelpVariablesStatement{}).Execute(context.TODO(), nil)),
+				lo.Must((&HelpVariablesStatement{}).Execute(t.Context(), nil)),
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Replace `context.TODO()` with `t.Context()` in integration tests for proper test context usage
- Update HELP and HELP VARIABLES test cases in `TestStatements`

## Changes
- Replace 2 instances of `context.TODO()` with `t.Context()` in `integration_test.go`
  - Line 679: HELP statement test case
  - Line 931: HELP VARIABLES statement test case

## Testing
- All tests pass with `make check` 
- No functional changes, just using proper test contexts

Fixes #249

🤖 Generated with [Claude Code](https://claude.ai/code)