### PR TITLE
feat: implement --try-partition-query flag for standard GoogleSQL partition testing

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -778,6 +778,46 @@ func TestStatements(t *testing.T) {
 			},
 		},
 		{
+			desc: "CLI_TRY_PARTITION_QUERY system variable",
+			stmt: sliceOf(
+				"SET CLI_TRY_PARTITION_QUERY = TRUE",
+				"SELECT 1",
+			),
+			wantResults: []*Result{
+				{
+					KeepVariables: true,
+				},
+				{
+					ForceWrap:    true,
+					AffectedRows: 1,
+					TableHeader:  toTableHeader("Root_Partitionable"),
+					Rows:         sliceOf(toRow("TRUE")),
+				},
+			},
+		},
+		{
+			desc: "CLI_TRY_PARTITION_QUERY with parameters",
+			stmt: sliceOf(
+				"SET CLI_TRY_PARTITION_QUERY = TRUE",
+				"SET PARAM n = 1",
+				"SELECT @n",
+			),
+			wantResults: []*Result{
+				{
+					KeepVariables: true,
+				},
+				{
+					KeepVariables: true,
+				},
+				{
+					ForceWrap:    true,
+					AffectedRows: 1,
+					TableHeader:  toTableHeader("Root_Partitionable"),
+					Rows:         sliceOf(toRow("TRUE")),
+				},
+			},
+		},
+		{
 			desc: "mutation, pdml, partitioned query",
 			ddls: sliceOf("CREATE TABLE TestTable(id INT64, active BOOL) PRIMARY KEY(id)"),
 			stmt: sliceOf(

--- a/system_variables.go
+++ b/system_variables.go
@@ -105,6 +105,7 @@ type systemVariables struct {
 	MarkdownCodeblock   bool      // CLI_MARKDOWN_CODEBLOCK
 
 	QueryMode *sppb.ExecuteSqlRequest_QueryMode // CLI_QUERY_MODE
+	TryPartitionQuery bool                       // CLI_TRY_PARTITION_QUERY
 
 	VertexAIProject    string                     // CLI_VERTEXAI_PROJECT
 	VertexAIModel      string                     // CLI_VERTEXAI_MODEL
@@ -1040,6 +1041,12 @@ var systemVariableDefMap = map[string]systemVariableDef{
 				return nil
 			},
 		},
+	},
+	"CLI_TRY_PARTITION_QUERY": {
+		Description: "A boolean indicating whether to test query for partition compatibility instead of executing it.",
+		Accessor: boolAccessor(func(variables *systemVariables) *bool {
+			return &variables.TryPartitionQuery
+		}),
 	},
 	"CLI_VERSION": {
 		Description: "",


### PR DESCRIPTION
# Add --try-partition-query flag for standard GoogleSQL partition testing

Fixes #281

## Summary

This PR implements the `--try-partition-query` CLI flag to test whether standard Spanner GoogleSQL queries can be executed as partitioned queries, providing execspansql compatibility without requiring spanner-mycli-specific syntax.

## Key Features

- **Standard GoogleSQL Compatibility**: Test existing GoogleSQL queries for partition compatibility without modifying the SQL syntax
- **CLI Flag Support**: `--try-partition-query` for batch mode execution
- **Interactive Mode Support**: `CLI_TRY_PARTITION_QUERY` system variable for interactive sessions
- **Parameter Support**: Compatible with `--param` flag and `SET PARAM` statements
- **Complete Implementation Reuse**: Uses existing `TryPartitionedQueryStatement` implementation for consistent behavior

## Implementation Approach

Following the established pattern of `--query-mode`, this implementation:

1. **CLI Flag Definition**: Added `TryPartitionQuery` to `spannerOptions` struct
2. **System Variable**: Implemented `CLI_TRY_PARTITION_QUERY` as read/write boolean variable
3. **Query Processing Integration**: Modified `SelectStatement` and `DmlStatement` execution to branch to `TryPartitionedQueryStatement` when the flag is enabled
4. **Validation**: Ensures SQL input is provided via `--execute`, `--file`, or `--sql`

## Usage Examples

### Batch Mode with CLI Flag

```bash
# Test a simple query
$ ./spanner-mycli --embedded-emulator -v -t --try-partition-query --execute "SELECT 1"
+--------------------+
| Root_Partitionable |
+--------------------+
| TRUE               |
+--------------------+
1 rows in set (0.01 sec)
timestamp:            2025-06-21T16:47:44.454652+09:00

# Test with parameters
$ ./spanner-mycli --embedded-emulator -v -t --try-partition-query --param "id=123" --execute "SELECT @id AS user_id"
+--------------------+
| Root_Partitionable |
+--------------------+
| TRUE               |
+--------------------+
1 rows in set (0.01 sec)
timestamp:            2025-06-21T16:47:52.178164+09:00

# Test non-partitionable query (shows meaningful error)
$ ./spanner-mycli --embedded-emulator -v -t --try-partition-query --execute "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES"
ERROR: query can't be a partition query: spanner: code="InvalidArgument", desc: The emulator is not able to determine whether this query is partitionable. Please test this query against Cloud Spanner and obtain a query execution plan to confirm it is partitionable. A query is partitionable only if the first operator in the query execution plan is a Distributed Union. If you confirm it is partitionable, set the hint @{spanner_emulator.disable_query_partitionability_check=true} on the query statement to bypass this check in the emulator. This hint will be ignored by the production Cloud Spanner service and the emulator will accept the query and return a valid result when it is run with the check disabled. Possible reason why the query may not be partitionable: Query is not a simple table scan.
```

### Interactive Mode with System Variable

```bash
$ ./spanner-mycli --embedded-emulator -v -t --execute "SET CLI_TRY_PARTITION_QUERY = TRUE; SELECT 1"
Empty set (0.00 sec)
+--------------------+
| Root_Partitionable |
+--------------------+
| TRUE               |
+--------------------+
1 rows in set (0.01 sec)
timestamp:            2025-06-21T16:47:59.068281+09:00
```

## Benefits Over Existing TRY PARTITIONED QUERY

1. **Standard SQL**: No spanner-mycli-specific syntax required
2. **Tool Compatibility**: Same SQL works in gcloud, other clients
3. **Migration Friendly**: Test existing queries without modification
4. **execspansql Compatibility**: Matches expected behavior pattern
5. **Automation Friendly**: Script-based testing with standard SQL

## Relationship to Existing Features

- **Complements `TRY PARTITIONED QUERY`**: Both features serve different purposes
  - `TRY PARTITIONED QUERY` - Interactive exploration with spanner-mycli syntax
  - `--try-partition-query` - Standard SQL testing for automation/migration
- **Consistent Output**: Both use identical output format ("Root_Partitionable", "TRUE")
- **Shared Implementation**: Complete reuse of `TryPartitionedQueryStatement` and `session.RunPartitionQuery()`

## Technical Implementation Details

### Core Changes

1. **main.go**: 
   - Added `TryPartitionQuery` flag to `spannerOptions`
   - Added validation requiring SQL input
   - Added system variable initialization

2. **system_variables.go**:
   - Added `TryPartitionQuery bool` field to `systemVariables` struct
   - Implemented `CLI_TRY_PARTITION_QUERY` with `boolAccessor`

3. **statements.go**:
   - Modified `SelectStatement.Execute()` to check `TryPartitionQuery` flag
   - Modified `DmlStatement.Execute()` to check `TryPartitionQuery` flag
   - Both delegate to existing `TryPartitionedQueryStatement` when enabled

### Implementation Pattern

This follows the exact same pattern as `CLI_QUERY_MODE`:
- CLI flag → system variable conversion in `initializeSystemVariables()`
- Early branching in statement execution based on system variable
- Complete reuse of existing backend implementation

### Testing

Added comprehensive integration tests in `TestStatements`:
- Basic functionality test with `SET CLI_TRY_PARTITION_QUERY = TRUE`
- Parameter compatibility test with `SET PARAM` 
- Both tests verify identical output to existing `TRY PARTITIONED QUERY`

## Development Insights

### Key Design Decisions

1. **System Variable Approach**: Following the `--query-mode` pattern allowed for both CLI and interactive usage with minimal code changes
2. **Complete Implementation Reuse**: By delegating to `TryPartitionedQueryStatement`, we gained:
   - Identical behavior and output format
   - All existing error handling and resource management
   - Parameter processing compatibility
   - Zero code duplication

3. **Early Branching**: Checking `TryPartitionQuery` as the first condition in statement execution ensures:
   - No interference with other query modes
   - Clean separation of concerns
   - Consistent behavior across SELECT and DML statements

### Integration Challenges and Solutions

1. **Test Integration**: Initially struggled with test expectations for SET statement results
   - **Solution**: Studied existing test patterns and used `KeepVariables: true` for SET operations
   - **Learning**: SET statements don't return visible results in spanner-mycli tests

2. **Parameter Handling**: Initially used incorrect parameter syntax in tests
   - **Solution**: Found correct `SET PARAM key = value` syntax by examining existing tests
   - **Learning**: spanner-mycli uses individual `SET PARAM` statements, not map syntax

3. **Error Message Consistency**: Ensured validation errors match spanner-mycli conventions
   - **Implementation**: Used existing error message patterns for missing input validation

### Code Patterns Learned

1. **CLI Flag → System Variable Pattern**:
   ```go
   if opts.TryPartitionQuery {
       if err := sysVars.Set("CLI_TRY_PARTITION_QUERY", "TRUE"); err != nil {
           return systemVariables{}, fmt.Errorf("failed to set CLI_TRY_PARTITION_QUERY: %w", err)
       }
   }
   ```

2. **Statement Execution Branching Pattern**:
   ```go
   switch {
   case session.systemVariables.TryPartitionQuery:
       return (&TryPartitionedQueryStatement{SQL: s.Query}).Execute(ctx, session)
   case qm != nil && *qm == sppb.ExecuteSqlRequest_PLAN:
       // Other modes...
   }
   ```

3. **System Variable Definition Pattern**:
   ```go
   "CLI_TRY_PARTITION_QUERY": {
       Description: "A boolean indicating whether to test query for partition compatibility instead of executing it.",
       Accessor: boolAccessor(func(variables *systemVariables) *bool {
           return &variables.TryPartitionQuery
       }),
   },
   ```

### Testing Strategy Insights

1. **Integration Test Structure**: spanner-mycli uses comprehensive integration tests that verify exact output format
2. **Error Testing**: The framework captures both success and error cases naturally through emulator behavior
3. **Parameter Testing**: Separate test cases for different usage patterns (basic vs. parameterized) provide good coverage

### Future Considerations

1. **Output Format Flexibility**: While current implementation matches existing `TRY PARTITIONED QUERY` output, future versions could make output format configurable
2. **Performance**: Since this delegates to existing implementation, performance characteristics are identical to `TRY PARTITIONED QUERY`
3. **Error Handling**: Spanner API error messages are passed through directly, providing accurate feedback

This implementation demonstrates how following established code patterns and leveraging existing functionality can deliver robust features with minimal risk and maximum consistency.