### PR TITLE
docs: update gh-helper documentation with new issue management features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,27 @@ go tool gh-helper reviews wait [PR] --request-review  # Request Gemini review + 
 # Workflow examples  
 gh pr create                                 # Create PR (interactive for title/body)
 go tool gh-helper reviews wait              # Wait for automatic Gemini review (initial PR only)
+go tool gh-helper reviews wait --async      # Check reviews once (non-blocking)
+go tool gh-helper reviews wait --timeout 15m # Wait with custom timeout
+
+# Issue management with gh-helper
+go tool gh-helper issues create --title "Title" --body "Body"  # Create issue
+go tool gh-helper issues create --parent 123 --title "Sub-task"  # Create sub-issue
+go tool gh-helper issues link-parent 456 --parent 123  # Link existing issue as sub-issue
 
 # Review response workflow (for subsequent pushes)
 go tool gh-helper reviews fetch <PR> > tmp/review-data.yaml  # Fetch all review data
+go tool gh-helper reviews fetch <PR> --threads-only          # Only fetch thread data
+go tool gh-helper reviews fetch <PR> --needs-reply-only      # Only threads needing replies
+go tool gh-helper reviews fetch <PR> --exclude-urls          # Exclude URLs from output
 # Create fix plan in tmp/fix-plan.md, make changes, commit & push
 go tool gh-helper reviews wait <PR> --request-review # Request Gemini review
 # Reply to threads with commit hash and --resolve flag
+go tool gh-helper threads reply THREAD_ID --commit-hash abc123 --resolve  # Standard workflow
 # Or use new batch resolve: go tool gh-helper threads resolve THREAD_ID1 THREAD_ID2
+# Show multiple threads at once: go tool gh-helper threads show THREAD_ID1 THREAD_ID2
+# Show thread details (supports multiple threads)
+go tool gh-helper threads show THREAD_ID1 THREAD_ID2 THREAD_ID3
 
 # Output format examples (YAML default, JSON with --json)
 go tool gh-helper reviews fetch 306 | gojq --yaml-input '.threads[] | select(.needsReply)'


### PR DESCRIPTION
## Summary

Updates documentation to reflect the latest gh-helper features, particularly the new issue management capabilities.

## Changes

### CLAUDE.md
- Added examples for new `gh-helper issues` commands
- Added `--async` flag example for `reviews wait`
- Added multi-thread support examples for `threads show`
- Added new `reviews fetch` flags: `--threads-only`, `--needs-reply-only`, `--exclude-urls`

### dev-docs/issue-management.md
- Fixed incorrect timeout format from `--timeout 15` to `--timeout 15m` (2 occurrences)
- Prioritized gh-helper commands as the primary method for sub-issue creation
- Moved complex GraphQL examples to alternative/manual approach sections
- Simplified batch creation script to use gh-helper
- Added comprehensive documentation for new review fetch flags
- Added documentation for reviews wait variations (`--async`, `--exclude-checks`, `--exclude-reviews`)
- Documented multi-thread support for `threads show` and `threads resolve`
- Added note about `--commit-hash` behavior and shorthand usage
- Clarified sub-issue visibility across different tools (Web UI, CLI, GraphQL)

## New gh-helper Features Documented

1. **Issue Management**:
   - `gh-helper issues create` - Create issues with optional parent relationship
   - `gh-helper issues link-parent` - Link existing issues as sub-issues

2. **Enhanced Review Operations**:
   - `reviews fetch --threads-only` - Lightweight thread-only fetch
   - `reviews fetch --needs-reply-only` - Filter threads needing replies
   - `reviews wait --async` - Non-blocking review check
   - `reviews wait --exclude-checks/--exclude-reviews` - Selective waiting

3. **Multi-thread Support**:
   - `threads show` now accepts multiple thread IDs
   - `threads resolve` batch resolution confirmed

## Development Insights

### gh-helper Evolution
The addition of `gh-helper issues` commands represents a significant improvement in workflow efficiency. Previously, creating sub-issues required complex GraphQL queries with node ID lookups. Now it's as simple as:
```bash
go tool gh-helper issues create --parent 123 --title "Sub-task"
```

### Workflow Simplification
The new commands reduce a 20+ line GraphQL workflow to a single command, making sub-issue management accessible to all contributors without GraphQL knowledge.

### AI Assistant Integration
These gh-helper improvements are particularly beneficial for AI assistants:
- Direct issue creation without complex GraphQL mutations
- Simplified sub-issue linking reduces error-prone node ID handling
- The `--async` flag enables non-blocking workflows suitable for automated processes

### Documentation Philosophy
This update follows the principle of presenting the simplest solution first (gh-helper), while preserving advanced options (GraphQL) for special cases. This approach reduces cognitive load while maintaining flexibility.

### Future Considerations
The `gh issue` CLI still lacks native sub-issue support. Until this gap is filled, gh-helper serves as an essential bridge, providing a clean CLI interface over GitHub's GraphQL API.

These updates ensure the documentation accurately reflects gh-helper's current capabilities and provides clearer workflows for common development tasks.