### PR TITLE
fix: handle non-TTY stdin correctly to avoid permission denied error

### DIFF
--- a/cli_readline.go
+++ b/cli_readline.go
@@ -270,7 +270,7 @@ func readInteractiveInput(ctx context.Context, ed *multiline.Editor) (*inputStat
 	lines, err := ed.Read(ctx)
 	if err != nil {
 		if len(lines) == 0 {
-			return nil, err
+			return nil, fmt.Errorf("failed to read input: %w", err)
 		}
 
 		str := strings.Join(lines, "\n")


### PR DESCRIPTION
## Summary

This PR fixes the "permission denied" error that occurs when running spanner-mycli with non-TTY stdin (e.g., `/dev/null` or `nohup`).

## Problem

When running spanner-mycli in the following scenarios, it would fail with "permission denied" error:
```bash
# With /dev/null
./spanner-mycli -p project -i instance -d database < /dev/null

# With nohup
nohup ./spanner-mycli -p project -i instance -d database &
```

The root cause was that `/dev/null` is a character device but not a terminal. The existing `os.ModeCharDevice` check incorrectly identified it as a terminal, leading to interactive mode initialization failure.

## Solution

1. **Replace `os.ModeCharDevice` with `term.IsTerminal`**: This properly distinguishes between actual terminals and other character devices like `/dev/null`.

2. **Extract `determineInputAndMode` function**: Centralized the logic for determining input source and mode, making it testable.

3. **Improve error handling**: Added context to readline errors for better debugging.

## Changes

- Replace TTY detection logic in `main.go`
- Extract input/mode determination into a testable function
- Add comprehensive tests covering both PTY and non-PTY scenarios
- Improve error message in `cli_readline.go`

## Testing

Added comprehensive tests in `TestDetermineInputAndMode`:
- Command line options (SQL, Execute, File)
- Piped input scenarios
- Empty stdin (like /dev/null)
- Real terminal with PTY
- PTY with command line options

All tests pass successfully.

## Test plan

- [x] Run with `/dev/null`: `./spanner-mycli -p project -i instance -d database < /dev/null`
- [x] Run with nohup: `nohup ./spanner-mycli -p project -i instance -d database --sql 'SELECT 1' &`
- [x] Run with piped input: `echo "SELECT 1;" | ./spanner-mycli -p project -i instance -d database`
- [x] Run interactively (normal terminal usage)
- [x] Run unit tests: `go test -v -short -run TestDetermineInputAndMode`
