### PR TITLE
docs: replace GraphQL sub-issue operations with new gh-helper commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,27 @@ go tool gh-helper reviews wait [PR] --request-review  # Request Gemini review + 
 # Workflow examples  
 gh pr create                                 # Create PR (interactive for title/body)
 go tool gh-helper reviews wait              # Wait for automatic Gemini review (initial PR only)
+go tool gh-helper reviews wait --async      # Check reviews once (non-blocking)
+go tool gh-helper reviews wait --timeout 15m # Wait with custom timeout
+
+# Issue management with gh-helper
+go tool gh-helper issues create --title "Title" --body "Body"  # Create issue
+go tool gh-helper issues create --parent 123 --title "Sub-task"  # Create sub-issue
+go tool gh-helper issues link-parent 456 --parent 123  # Link existing issue as sub-issue
 
 # Review response workflow (for subsequent pushes)
 go tool gh-helper reviews fetch <PR> > tmp/review-data.yaml  # Fetch all review data
+go tool gh-helper reviews fetch <PR> --threads-only          # Only fetch thread data
+go tool gh-helper reviews fetch <PR> --needs-reply-only      # Only threads needing replies
+go tool gh-helper reviews fetch <PR> --exclude-urls          # Exclude URLs from output
 # Create fix plan in tmp/fix-plan.md, make changes, commit & push
 go tool gh-helper reviews wait <PR> --request-review # Request Gemini review
 # Reply to threads with commit hash and --resolve flag
+go tool gh-helper threads reply THREAD_ID --commit-hash abc123 --resolve  # Standard workflow
 # Or use new batch resolve: go tool gh-helper threads resolve THREAD_ID1 THREAD_ID2
+# Show multiple threads at once: go tool gh-helper threads show THREAD_ID1 THREAD_ID2
+# Show thread details (supports multiple threads)
+go tool gh-helper threads show THREAD_ID1 THREAD_ID2 THREAD_ID3
 
 # Output format examples (YAML default, JSON with --json)
 go tool gh-helper reviews fetch 306 | gojq --yaml-input '.threads[] | select(.needsReply)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,9 @@ go tool gh-helper reviews wait --timeout 15m # Wait with custom timeout
 # Issue management with gh-helper
 go tool gh-helper issues create --title "Title" --body "Body"  # Create issue
 go tool gh-helper issues create --parent 123 --title "Sub-task"  # Create sub-issue
-go tool gh-helper issues link-parent 456 --parent 123  # Link existing issue as sub-issue
+go tool gh-helper issues edit 456 --parent 123  # Link existing issue as sub-issue
+go tool gh-helper issues edit 456 --unlink-parent  # Remove parent relationship
+go tool gh-helper issues show 248 --include-sub  # Show issue with sub-issues stats
 
 # Review response workflow (for subsequent pushes)
 go tool gh-helper reviews fetch <PR> > tmp/review-data.yaml  # Fetch all review data
@@ -75,6 +77,15 @@ go tool gh-helper threads reply THREAD_ID --commit-hash abc123 --resolve  # Stan
 # Show multiple threads at once: go tool gh-helper threads show THREAD_ID1 THREAD_ID2
 # Show thread details (supports multiple threads)
 go tool gh-helper threads show THREAD_ID1 THREAD_ID2 THREAD_ID3
+
+# Label management (bulk operations)
+go tool gh-helper labels add bug,enhancement --items 254,267,238,245  # Add to multiple items
+go tool gh-helper labels remove needs-review --items pull/302,issue/301  # Remove from items
+go tool gh-helper labels add-from-issues --pr 254  # Inherit labels from linked issues
+
+# Release notes analysis
+go tool gh-helper releases analyze --milestone v0.19.0  # Analyze by milestone
+go tool gh-helper releases analyze --since 2024-01-01 --until 2024-01-31  # By date range
 
 # Output format examples (YAML default, JSON with --json)
 go tool gh-helper reviews fetch 306 | gojq --yaml-input '.threads[] | select(.needsReply)'

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/apstndb/gh-dev-tools v0.0.0-20250620073509-54ee9d532d98 // indirect
+	github.com/apstndb/gh-dev-tools v0.0.0-20250622011548-7465a4bd3f45 // indirect
 	github.com/apstndb/treeprint v0.0.0-20250529153958-e82576b37da6 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2459,6 +2459,10 @@ github.com/apstndb/gh-dev-tools v0.0.0-20250619064936-7269bb010bab h1:HJOp+4QYc2
 github.com/apstndb/gh-dev-tools v0.0.0-20250619064936-7269bb010bab/go.mod h1:vCY+WO4EZHR2ha+9C++DJX34wH4Dmb7LeBuYmsBGV0c=
 github.com/apstndb/gh-dev-tools v0.0.0-20250620073509-54ee9d532d98 h1:tdgoDfBFculaP1tH6I/8V3IJpm23qHIa/1/w/s4SQ4A=
 github.com/apstndb/gh-dev-tools v0.0.0-20250620073509-54ee9d532d98/go.mod h1:vCY+WO4EZHR2ha+9C++DJX34wH4Dmb7LeBuYmsBGV0c=
+github.com/apstndb/gh-dev-tools v0.0.0-20250621142745-33d360b2fd77 h1:Qib8UKmmQhY2zvBtLUoVGdvsLaPCVZZK//5QVqis54s=
+github.com/apstndb/gh-dev-tools v0.0.0-20250621142745-33d360b2fd77/go.mod h1:vCY+WO4EZHR2ha+9C++DJX34wH4Dmb7LeBuYmsBGV0c=
+github.com/apstndb/gh-dev-tools v0.0.0-20250622011548-7465a4bd3f45 h1:SUOP69Qnre2x3T+EpJFKMPLD9WiLQQl75/DJnLq8a0U=
+github.com/apstndb/gh-dev-tools v0.0.0-20250622011548-7465a4bd3f45/go.mod h1:vCY+WO4EZHR2ha+9C++DJX34wH4Dmb7LeBuYmsBGV0c=
 github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe h1:77G66thy9/0ySW34B9GCIPrv/tc29NBGwarlpbNWm/g=
 github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe/go.mod h1:f/6/38gdf0Vz+uYGVDtVaHzL4ho6JduiF/v/ngQVWos=
 github.com/apstndb/go-runewidthex v0.1.0 h1:BTROSb06XZLb4hz5PC5i+3o/BBNhXS5QW6a6S/f1NTU=


### PR DESCRIPTION
## Summary
- Updated gh-dev-tools to latest version with new sub-issue management features
- Replaced most GraphQL queries in documentation with simpler gh-helper commands
- Significantly simplified sub-issue workflows by eliminating node ID requirements

## Key Changes
- **CLAUDE.md**: Added new gh-helper commands for sub-issue operations
- **dev-docs/issue-management.md**: Replaced GraphQL examples with gh-helper equivalents
- **go.mod/go.sum**: Updated gh-dev-tools dependency

## New gh-helper Features Documented

### issues edit (replaces multiple GraphQL operations)
- `edit --parent`: Link issue as sub-issue (deprecates `link-parent`)
- `edit --unlink-parent`: Remove parent relationship
- `edit --overwrite`: Move sub-issue to different parent

### issues show (replaces GraphQL queries)
- `--include-sub`: Show sub-issues list with completion statistics
- `--detailed`: Include detailed information for each sub-issue

## GraphQL Operations Still Required
- Reordering sub-issues within a parent
- Schema introspection queries
- Custom field selections beyond gh-helper's output

## Development Insights

This update demonstrates the evolution of gh-helper as a GraphQL replacement tool. The new commands eliminate the most painful aspects of sub-issue management:
- No more node ID lookups
- No more complex jq processing
- Simpler error handling
- More intuitive command structure

The pattern of gradually replacing GraphQL with purpose-built commands is working well and should continue for other common operations identified in the feature request documents.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>