### PR TITLE
feat: migrate from mcp-go to official modelcontextprotocol/go-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ credentials.json
 # Cache and temporary files - safe to delete anywhere
 .cache/       # Application cache directory
 tmp/          # Development temporary files (e.g., help output generation)
+.tmp/         # Temporary directory for cloning external repos (hidden from go test)
 
 # Configuration files with secrets - may contain sensitive connection info, check before deleting
 .*.cnf

--- a/cli_mcp.go
+++ b/cli_mcp.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/samber/lo"
 )
 
 // ExecuteStatementArgs represents the arguments for the execute_statement tool
@@ -31,31 +31,11 @@ type ExecuteStatementArgs struct {
 	Statement string `json:"statement" description:"Valid spanner-mycli statement. It can be SQL(Query, DML, DDL), GQL, and spanner-mycli client-side statements"`
 }
 
-// createMCPServer creates a new MCP server with the execute_statement tool
-func createMCPServer(cli *Cli) *server.MCPServer {
-	s := server.NewMCPServer("spanner-mycli", version,
-		server.WithToolCapabilities(false))
-
-	tool := mcp.NewTool("execute_statement",
-		mcp.WithDescription(heredoc.Doc(
-			`Execute any spanner-mycli statement.
-If you want to check valid statements, see "HELP".
-Result is ASCII table rendered, so you need to print as code block`)),
-		mcp.WithString("statement",
-			mcp.Required(),
-			mcp.Description("Valid spanner-mycli statement. It can be SQL(Query, DML, DDL), GQL, and spanner-mycli client-side statements"),
-		),
-		// Add tool annotations to provide hints about the tool's behavior
-		mcp.WithTitleAnnotation("Execute Spanner SQL Statement"),
-		mcp.WithReadOnlyHintAnnotation(false),   // Can modify the database
-		mcp.WithDestructiveHintAnnotation(true), // Can perform destructive operations
-		mcp.WithIdempotentHintAnnotation(false), // Repeated calls can have different effects
-		mcp.WithOpenWorldHintAnnotation(true),   // Interacts with external entities (the database)
-	)
-
-	s.AddTool(tool, mcp.NewTypedToolHandler(func(ctx context.Context, request mcp.CallToolRequest, args ExecuteStatementArgs) (*mcp.CallToolResult, error) {
+// executeStatementHandler handles the execute_statement tool
+func executeStatementHandler(cli *Cli) func(context.Context, *mcp.ServerSession, *mcp.CallToolParamsFor[ExecuteStatementArgs]) (*mcp.CallToolResultFor[struct{}], error) {
+	return func(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[ExecuteStatementArgs]) (*mcp.CallToolResultFor[struct{}], error) {
 		// Parse the statement
-		statement := strings.TrimSuffix(args.Statement, ";")
+		statement := strings.TrimSuffix(params.Arguments.Statement, ";")
 		stmt, err := cli.parseStatement(&inputStatement{statement: statement, statementWithoutComments: statement, delim: ";"})
 		if err != nil {
 			return nil, err
@@ -70,10 +50,43 @@ Result is ASCII table rendered, so you need to print as code block`)),
 			return nil, err
 		}
 
-		return mcp.NewToolResultText(sb.String()), nil
-	}))
+		return &mcp.CallToolResultFor[struct{}]{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: sb.String()},
+			},
+		}, nil
+	}
+}
 
-	return s
+// createMCPServer creates a new MCP server with the execute_statement tool
+func createMCPServer(cli *Cli) *mcp.Server {
+	server := mcp.NewServer("spanner-mycli", version, nil)
+
+	description := heredoc.Doc(
+		`Execute any spanner-mycli statement.
+If you want to check valid statements, see "HELP".
+Result is ASCII table rendered, so you need to print as code block`)
+
+	tool := mcp.NewServerTool("execute_statement", description, executeStatementHandler(cli),
+		mcp.Input(
+			mcp.Property("statement",
+				mcp.Description("Valid spanner-mycli statement. It can be SQL(Query, DML, DDL), GQL, and spanner-mycli client-side statements"),
+			),
+		),
+	)
+
+	// Set tool annotations to provide hints about the tool's behavior
+	tool.Tool.Annotations = &mcp.ToolAnnotations{
+		Title:           "Execute Spanner SQL Statement",
+		ReadOnlyHint:    false,               // Can modify the database
+		DestructiveHint: lo.ToPtr(true),     // Can perform destructive operations
+		IdempotentHint:  false,               // Repeated calls can have different effects
+		OpenWorldHint:   lo.ToPtr(true),      // Interacts with external entities (the database)
+	}
+
+	server.AddTools(tool)
+
+	return server
 }
 
 // RunMCP runs the MCP server
@@ -87,10 +100,13 @@ func (c *Cli) RunMCP(ctx context.Context) error {
 		return NewExitCodeError(c.ExitOnError(fmt.Errorf("unknown database %q", c.SystemVariables.Database)))
 	}
 
-	s := createMCPServer(c)
+	server := createMCPServer(c)
 
-	if err := server.ServeStdio(s); err != nil {
+	transport := mcp.NewStdioTransport()
+	session, err := server.Connect(ctx, transport)
+	if err != nil {
 		return fmt.Errorf("failed to serve mcp: %w", err)
 	}
-	return nil
+	// Wait for the session to complete
+	return session.Wait()
 }

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/k0kubun/pp/v3 v3.4.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/mark3labs/mcp-go v0.31.0
 	github.com/mattn/go-runewidth v0.0.16
+	github.com/modelcontextprotocol/go-sdk v0.0.0-20250625213837-ff0d746521c4
 	github.com/ngicks/go-iterator-helper v0.0.18
 	github.com/nyaosorg/go-readline-ny v1.9.0
 	github.com/olekukonko/tablewriter v1.0.6
@@ -138,7 +138,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.37.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2881,8 +2881,6 @@ github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLO
 github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mark3labs/mcp-go v0.31.0 h1:4UxSV8aM770OPmTvaVe/b1rA2oZAjBMhGBfUgOGut+4=
-github.com/mark3labs/mcp-go v0.31.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -2921,6 +2919,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v0.0.0-20250625213837-ff0d746521c4 h1:FQT63ASJ/Y1MkqrIZiKDz3Ynqb7x1Ck5LU3FRBXgiqM=
+github.com/modelcontextprotocol/go-sdk v0.0.0-20250625213837-ff0d746521c4/go.mod h1:DcXfbr7yl7e35oMpzHfKw2nUYRjhIGS2uou/6tdsTB0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
@@ -3043,8 +3043,6 @@ github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPD
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
 github.com/vbauerster/mpb/v8 v8.9.3 h1:PnMeF+sMvYv9u23l6DO6Q3+Mdj408mjLRXIzmUmU2Z8=
 github.com/vbauerster/mpb/v8 v8.9.3/go.mod h1:hxS8Hz4C6ijnppDSIX6LjG8FYJSoPo9iIOcE53Zik0c=
-github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
-github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
@@ -3668,6 +3666,8 @@ golang.org/x/tools v0.20.0/go.mod h1:WvitBU7JJf6A4jOdg4S1tviW9bhUxkgeCui/0JHctQg
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Summary

This PR migrates the MCP (Model Context Protocol) implementation from the community `mcp-go` library to the official `modelcontextprotocol/go-sdk`.

## Key Changes

- **cli_mcp.go**: 
  - Updated imports from `github.com/mark3labs/mcp-go` to `github.com/modelcontextprotocol/go-sdk/mcp`
  - Adapted to new API patterns: `Server.Connect()`, `ServerSession`, typed handlers
  - Tool annotations are now set manually on the Tool struct (no longer part of tool creation options)

- **integration_mcp_test.go**: 
  - Updated test infrastructure to use `ClientSession` instead of `client.Client`
  - Changed from `NewInProcessTransport()` to `NewInMemoryTransports()`
  - Adapted to new client/server connection patterns

- **go.mod**: 
  - Removed `github.com/mark3labs/mcp-go` dependency
  - Added `github.com/modelcontextprotocol/go-sdk` dependency

- **.gitignore**:
  - Added `.tmp/` directory for cloning external repos (hidden from go test)

## Migration Details

### API Changes
- Server creation: `server.NewMCPServer()` → `mcp.NewServer()`
- Server serving: `server.ServeStdio()` → `server.Connect()` + `session.Wait()`
- Tool creation: `mcp.NewTool()` with options → `mcp.NewServerTool()` with typed handler
- Tool annotations: Previously passed as options, now set directly on `tool.Tool.Annotations`

### Preserved Features
- ✅ All tool annotations (Title, ReadOnlyHint, DestructiveHint, IdempotentHint, OpenWorldHint)
- ✅ Typed tool handlers with `ToolHandlerFor[In, Out]`
- ✅ Schema customization with `Input()` option
- ✅ All existing functionality and tests pass

## Testing

- All existing MCP integration tests pass
- `make check` passes (test + lint)

Fixes #360