### PR TITLE
fix: resolve flag inconsistencies discovered during flag testing

### DIFF
--- a/main.go
+++ b/main.go
@@ -323,32 +323,17 @@ func ValidateSpannerOptions(opts *spannerOptions) error {
 	}
 
 	// Check for mutually exclusive input methods
-	// Note: --execute and --sql are aliases, but we'll handle precedence in determineInputAndMode
-	inputMethods := []struct {
-		value string
-		name  string
-	}{
-		{opts.File, "-f"},
-		{opts.Execute, "--execute"},
-		{opts.SQL, "--sql"},
+	// Note: --execute and --sql are aliases.
+	inputMethodsCount := 0
+	if opts.File != "" {
+		inputMethodsCount++
 	}
-	
-	var nonEmptyMethods []string
-	for _, method := range inputMethods {
-		if method.value != "" {
-			nonEmptyMethods = append(nonEmptyMethods, method.name)
-		}
+	if opts.Execute != "" || opts.SQL != "" {
+		inputMethodsCount++
 	}
-	
-	if len(nonEmptyMethods) > 1 {
-		// Special case: --execute and --sql are aliases, so this is allowed
-		if len(nonEmptyMethods) == 2 && 
-			(nonEmptyMethods[0] == "--execute" && nonEmptyMethods[1] == "--sql" ||
-			 nonEmptyMethods[0] == "--sql" && nonEmptyMethods[1] == "--execute") {
-			// This is OK - will be handled with precedence in determineInputAndMode
-		} else {
-			return fmt.Errorf("invalid combination: -e, -f, --sql are exclusive")
-		}
+
+	if inputMethodsCount > 1 {
+		return fmt.Errorf("invalid combination: -e, -f, --sql are exclusive")
 	}
 
 	if opts.TryPartitionQuery {

--- a/main_test.go
+++ b/main_test.go
@@ -278,18 +278,69 @@ func Test_initializeSystemVariables(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "embedded emulator sets defaults",
+			name: "embedded emulator with user values",
 			opts: &spannerOptions{
 				EmbeddedEmulator: true,
-				ProjectId:        "should-be-overridden",
-				InstanceId:       "should-be-overridden",
-				DatabaseId:       "should-be-overridden",
-				Insecure:         false, // should be overridden
+				ProjectId:        "user-project",
+				InstanceId:       "user-instance",
+				DatabaseId:       "user-database",
+				Insecure:         false, // should be overridden by embedded emulator
 			},
 			want: systemVariables{
-				Project:              "emulator-project",
-				Instance:             "emulator-instance",
-				Database:             "emulator-database",
+				Project:              "user-project",
+				Instance:             "user-instance",
+				Database:             "user-database",
+				Insecure:             true, // embedded emulator always sets this
+				Prompt:               defaultPrompt,
+				Prompt2:              defaultPrompt2,
+				HistoryFile:          defaultHistoryFile,
+				LogLevel:             slog.LevelWarn,
+				VertexAIModel:        defaultVertexAIModel,
+				EnableADCPlus:        true,
+				ReturnCommitStats:    true,
+				AnalyzeColumns:       DefaultAnalyzeColumns,
+				RPCPriority:          defaultPriority,
+				OutputTemplateFile:   "",
+				OutputTemplate:       defaultOutputFormat,
+				ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+			},
+			wantErr: false,
+		},
+		{
+			name: "embedded emulator with no user values",
+			opts: &spannerOptions{
+				EmbeddedEmulator: true,
+			},
+			want: systemVariables{
+				Project:              "emulator-project", // Default value set in initializeSystemVariables
+				Instance:             "emulator-instance", // Default value set in initializeSystemVariables
+				Database:             "emulator-database", // Default value set in initializeSystemVariables
+				Insecure:             true,
+				Prompt:               defaultPrompt,
+				Prompt2:              defaultPrompt2,
+				HistoryFile:          defaultHistoryFile,
+				LogLevel:             slog.LevelWarn,
+				VertexAIModel:        defaultVertexAIModel,
+				EnableADCPlus:        true,
+				ReturnCommitStats:    true,
+				AnalyzeColumns:       DefaultAnalyzeColumns,
+				RPCPriority:          defaultPriority,
+				OutputTemplateFile:   "",
+				OutputTemplate:       defaultOutputFormat,
+				ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+			},
+			wantErr: false,
+		},
+		{
+			name: "embedded emulator with detached mode",
+			opts: &spannerOptions{
+				EmbeddedEmulator: true,
+				Detached:        true,
+			},
+			want: systemVariables{
+				Project:              "emulator-project",  // Default set for emulator
+				Instance:             "emulator-instance", // Default set for emulator
+				Database:             "",                  // Empty - respects detached mode
 				Insecure:             true,
 				Prompt:               defaultPrompt,
 				Prompt2:              defaultPrompt2,

--- a/main_test.go
+++ b/main_test.go
@@ -82,8 +82,8 @@ func Test_initializeSystemVariables(t *testing.T) {
 					"p2": "FLOAT64",
 				},
 				ProtoDescriptorFile:       "testdata/protos/singer.proto",
-				Insecure:                  true,
-				SkipTlsVerify:             false, // Insecure takes precedence
+				Insecure:                  lo.ToPtr(true),
+				SkipTlsVerify:             lo.ToPtr(false), // Insecure takes precedence
 				LogGrpc:                   true,
 				LogLevel:                  "INFO",
 				QueryMode:                 "PLAN",
@@ -217,6 +217,74 @@ func Test_initializeSystemVariables(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "insecure flag precedence - both true",
+			opts: &spannerOptions{
+				Insecure:      lo.ToPtr(true),
+				SkipTlsVerify: lo.ToPtr(true),
+			},
+			want: systemVariables{
+				Insecure:             true, // --insecure takes precedence
+				Prompt:               defaultPrompt,
+				Prompt2:              defaultPrompt2,
+				HistoryFile:          defaultHistoryFile,
+				LogLevel:             slog.LevelWarn,
+				VertexAIModel:        defaultVertexAIModel,
+				EnableADCPlus:        true,
+				ReturnCommitStats:    true,
+				AnalyzeColumns:       DefaultAnalyzeColumns,
+				RPCPriority:          defaultPriority,
+				OutputTemplateFile:   "",
+				OutputTemplate:       defaultOutputFormat,
+				ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+			},
+			wantErr: false,
+		},
+		{
+			name: "insecure flag precedence - insecure false, skip-tls-verify true",
+			opts: &spannerOptions{
+				Insecure:      lo.ToPtr(false),
+				SkipTlsVerify: lo.ToPtr(true),
+			},
+			want: systemVariables{
+				Insecure:             false, // --insecure takes precedence even when false
+				Prompt:               defaultPrompt,
+				Prompt2:              defaultPrompt2,
+				HistoryFile:          defaultHistoryFile,
+				LogLevel:             slog.LevelWarn,
+				VertexAIModel:        defaultVertexAIModel,
+				EnableADCPlus:        true,
+				ReturnCommitStats:    true,
+				AnalyzeColumns:       DefaultAnalyzeColumns,
+				RPCPriority:          defaultPriority,
+				OutputTemplateFile:   "",
+				OutputTemplate:       defaultOutputFormat,
+				ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+			},
+			wantErr: false,
+		},
+		{
+			name: "only skip-tls-verify set",
+			opts: &spannerOptions{
+				SkipTlsVerify: lo.ToPtr(true),
+			},
+			want: systemVariables{
+				Insecure:             true, // Uses skip-tls-verify value
+				Prompt:               defaultPrompt,
+				Prompt2:              defaultPrompt2,
+				HistoryFile:          defaultHistoryFile,
+				LogLevel:             slog.LevelWarn,
+				VertexAIModel:        defaultVertexAIModel,
+				EnableADCPlus:        true,
+				ReturnCommitStats:    true,
+				AnalyzeColumns:       DefaultAnalyzeColumns,
+				RPCPriority:          defaultPriority,
+				OutputTemplateFile:   "",
+				OutputTemplate:       defaultOutputFormat,
+				ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+			},
+			wantErr: false,
+		},
+		{
 			name: "error: invalid timeout format",
 			opts: &spannerOptions{
 				Timeout: "invalid",
@@ -284,7 +352,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				ProjectId:        "user-project",
 				InstanceId:       "user-instance",
 				DatabaseId:       "user-database",
-				Insecure:         false, // should be overridden by embedded emulator
+				Insecure:         lo.ToPtr(false), // should be overridden by embedded emulator
 			},
 			want: systemVariables{
 				Project:              "user-project",


### PR DESCRIPTION
## Summary
- Remove mutual exclusion between alias flags (--insecure/--skip-tls-verify)
- Add origin information to hidden flag descriptions
- Fix --embedded-emulator to respect user-provided values
- Support --embedded-emulator + --detached combination
- Implement proper precedence for boolean alias flags using *bool

## Details

This PR addresses the flag inconsistencies reported in issue #370:

1. **Alias flags are no longer mutually exclusive**
   - --insecure and --skip-tls-verify can be used together
   - --execute and --sql can be used together
   - --role and --database-role can be used together
   - When both are specified, non-hidden flags take precedence with a warning

2. **Flag descriptions now show origins**
   - --sql: "Hidden alias of --execute for gcloud spanner databases execute-sql compatibility"
   - --database-role: "Hidden alias of --role for gcloud spanner databases execute-sql compatibility"
   - --skip-tls-verify: "Hidden alias of --insecure from original spanner-cli"

3. **--embedded-emulator improvements**
   - User-provided project/instance/database values are now respected
   - Defaults are set in initializeSystemVariables() when not specified
   - Logs warnings when custom values are provided
   - Supports --detached mode properly (uses EnableInstanceAutoConfigOnly())

4. **Proper boolean flag precedence**
   - Changed --insecure and --skip-tls-verify from bool to *bool
   - Can now distinguish between unset and explicitly false values
   - --insecure takes precedence even when explicitly set to false
   - Addresses security concern raised by Gemini

5. **Code improvements**
   - Simplified validation logic for mutually exclusive input methods (per Gemini's suggestion)
   - Added comprehensive tests for all flag precedence scenarios

## Documentation
- Added comprehensive comments explaining alias precedence behavior
- Updated spannerOptions struct documentation

Fixes #370

🤖 Generated with [Claude Code](https://claude.ai/code)