### PR TITLE
feat: add --source as an alias for --file flag

### DIFF
--- a/main_flags_test.go
+++ b/main_flags_test.go
@@ -72,7 +72,7 @@ func TestParseFlagsCombinations(t *testing.T) {
 			name:        "execute and file are mutually exclusive",
 			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--execute", "SELECT 1", "--file", "query.sql"},
 			wantErr:     true,
-			errContains: "-e, -f, --sql are exclusive",
+			errContains: "--execute(-e), --file(-f), --sql, --source are exclusive",
 		},
 		{
 			name:        "strong and read-timestamp are mutually exclusive",
@@ -84,7 +84,7 @@ func TestParseFlagsCombinations(t *testing.T) {
 			name:        "all three input methods (execute, file, sql) are mutually exclusive",
 			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--execute", "SELECT 1", "--file", "query.sql", "--sql", "SELECT 2"},
 			wantErr:     true,
-			errContains: "-e, -f, --sql are exclusive",
+			errContains: "--execute(-e), --file(-f), --sql, --source are exclusive",
 		},
 
 		// Invalid combinations
@@ -92,7 +92,7 @@ func TestParseFlagsCombinations(t *testing.T) {
 			name:        "try-partition-query requires SQL input",
 			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--try-partition-query"},
 			wantErr:     true,
-			errContains: "--try-partition-query requires SQL input",
+			errContains: "--try-partition-query requires SQL input via --execute(-e), --file(-f), --source, or --sql",
 		},
 		{
 			name:        "table flag without SQL input in batch mode",
@@ -114,6 +114,23 @@ func TestParseFlagsCombinations(t *testing.T) {
 			name: "try-partition-query with file is valid",
 			args: []string{"--project", "p", "--instance", "i", "--database", "d", "--try-partition-query", "--file", "query.sql"},
 			wantErr: false,
+		},
+		{
+			name: "try-partition-query with source is valid",
+			args: []string{"--project", "p", "--instance", "i", "--database", "d", "--try-partition-query", "--source", "query.sql"},
+			wantErr: false,
+		},
+		{
+			name:        "execute and source are mutually exclusive",
+			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--execute", "SELECT 1", "--source", "query.sql"},
+			wantErr:     true,
+			errContains: "--execute(-e), --file(-f), --sql, --source are exclusive",
+		},
+		{
+			name:        "all four input methods are mutually exclusive",
+			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--execute", "SELECT 1", "--file", "query.sql", "--sql", "SELECT 2", "--source", "query3.sql"},
+			wantErr:     true,
+			errContains: "--execute(-e), --file(-f), --sql, --source are exclusive",
 		},
 
 		// Embedded emulator tests
@@ -930,7 +947,7 @@ func TestFlagErrorMessages(t *testing.T) {
 		{
 			name:           "conflicting input flags shows which flags conflict",
 			args:           []string{"--project", "p", "--instance", "i", "--database", "d", "--execute", "SELECT 1", "--file", "query.sql"},
-			wantErrKeyword: "-e, -f, --sql are exclusive",
+			wantErrKeyword: "--execute(-e), --file(-f), --sql, --source are exclusive",
 		},
 		{
 			name:           "invalid enum shows valid options",
@@ -950,7 +967,7 @@ func TestFlagErrorMessages(t *testing.T) {
 		{
 			name:           "try-partition-query without input shows requirement",
 			args:           []string{"--project", "p", "--instance", "i", "--database", "d", "--try-partition-query"},
-			wantErrKeyword: "--try-partition-query requires SQL input via --execute, --file, or --sql",
+			wantErrKeyword: "--try-partition-query requires SQL input via --execute(-e), --file(-f), --source, or --sql",
 		},
 		{
 			name:           "invalid timeout shows it's a timeout error",
@@ -1042,13 +1059,13 @@ func TestFileFlagBehavior(t *testing.T) {
 			name:        "file flag with execute is mutually exclusive",
 			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--file", testFile, "--execute", "SELECT 1"},
 			wantErr:     true,
-			errContains: "-e, -f, --sql are exclusive",
+			errContains: "--execute(-e), --file(-f), --sql, --source are exclusive",
 		},
 		{
 			name:        "file flag with sql is mutually exclusive",
 			args:        []string{"--project", "p", "--instance", "i", "--database", "d", "--file", testFile, "--sql", "SELECT 1"},
 			wantErr:     true,
-			errContains: "-e, -f, --sql are exclusive",
+			errContains: "--execute(-e), --file(-f), --sql, --source are exclusive",
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -787,6 +787,27 @@ func TestDetermineInputAndMode(t *testing.T) {
 			wantInput:       "SELECT 3;",
 			wantInteractive: false,
 		},
+		{
+			name:            "Source option from stdin (alias of File)",
+			opts:            &spannerOptions{Source: "-"},
+			stdinProvider:   nonPTYStdin("SELECT 3;"),
+			wantInput:       "SELECT 3;",
+			wantInteractive: false,
+		},
+		{
+			name:            "Both File and Source - File takes precedence",
+			opts:            &spannerOptions{File: "-", Source: "ignored.sql"},
+			stdinProvider:   nonPTYStdin("SELECT FROM FILE;"),
+			wantInput:       "SELECT FROM FILE;",
+			wantInteractive: false,
+		},
+		{
+			name:            "Both Execute and SQL - Execute takes precedence",
+			opts:            &spannerOptions{Execute: "SELECT 1", SQL: "SELECT 2"},
+			stdinProvider:   nonPTYStdin(""),
+			wantInput:       "SELECT 1",
+			wantInteractive: false,
+		},
 		// Piped input tests (non-PTY)
 		{
 			name:            "No options with piped input",


### PR DESCRIPTION
## Summary
- Add `--source` flag as an alias for `--file` to match Google Cloud Spanner CLI behavior
- Implement proper alias precedence handling where primary flags take precedence over aliases
- Update error messages to use a clearer format: `--option(-o)` for better user experience

## Implementation Details

### Alias Handling
The implementation follows a consistent pattern for all alias flags in the codebase:
- `--sql` is an alias of `--execute`
- `--database-role` is an alias of `--role`
- `--skip-tls-verify` is an alias of `--insecure`
- `--source` is an alias of `--file` (new)

When both a primary flag and its alias are specified:
1. A warning is logged: "Both --file and --source are specified. Using --file (alias has lower precedence)"
2. The primary (non-alias) flag value takes precedence

### Flag Validation
All input method flags (`--execute(-e)`, `--file(-f)`, `--sql`, `--source`) are mutually exclusive. This includes aliases - even though `--file` and `--source` are aliases, they cannot be used with other input methods.

### Error Message Improvements
Updated error messages to use a more readable format:
- Before: `-e, -f, --sql are exclusive`
- After: `--execute(-e), --file(-f), --sql, --source are exclusive`

This format clearly shows both long and short options, making it easier for users to understand which flags they can use.

## Test Coverage
- Added tests for `--source` flag functionality in `TestDetermineInputAndMode`
- Added validation tests in `TestParseFlagsCombinations`
- Updated existing error message tests to match new format
- All tests pass with `make test-quick` and `make lint`

## Compatibility
This change maintains full backward compatibility while adding Google Cloud Spanner CLI compatibility for users migrating from the official tool.

Fixes #358
EOF < /dev/null