### PR TITLE
feat: implement \R meta-command for prompt change

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Meta commands are special commands that start with a backslash (`\`) and are pro
 |---------|-------------|---------|
 | `\! <shell_command>` | Execute a system shell command | `\! ls -la` |
 | `\. <filename>` | Execute SQL statements from a file | `\. script.sql` |
+| `\R <prompt_string>` | Change the prompt string | `\R mycli> ` |
 
 For detailed documentation on each meta command, see [docs/meta_commands.md](docs/meta_commands.md).
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -684,6 +684,29 @@ func TestCli_getInterpolatedPrompt(t *testing.T) {
 			},
 			want: "spanner:test-database> ",
 		},
+		{
+			desc:   "invalid percent sequence - single character",
+			prompt: "Invalid: %z",
+			want:   "Invalid: %z",
+		},
+		{
+			desc:   "invalid percent sequence - multiple invalid sequences",
+			prompt: "Test %x %y %z end",
+			want:   "Test %x %y %z end",
+		},
+		{
+			desc:   "mixed valid and invalid percent sequences",
+			prompt: "%p %z %i %q %d",
+			sysVars: &systemVariables{
+				Project:  "proj",
+				Instance: "inst",
+				Database: "db",
+			},
+			session: &Session{
+				mode: DatabaseConnected,
+			},
+			want: "proj %z inst %q db",
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -100,16 +100,17 @@ spanner> \R [%p/%i/%d]>
 
 spanner> \R custom> 
 custom> SHOW VARIABLE CLI_PROMPT;
-+--------------+---------+
-| Variable_name | Value   |
-+--------------+---------+
-| CLI_PROMPT   | custom> |
-+--------------+---------+
++---------------+----------+
+| Variable_name | Value    |
++---------------+----------+
+| CLI_PROMPT    | custom>  |
++---------------+----------+
 ```
 
 ### Notes
 
-- Trailing spaces in the prompt string are trimmed
+- A trailing space is automatically added to the prompt for better separation between prompt and user input
+- The input prompt string has trailing spaces trimmed, but a space is always added when setting the prompt
 - An empty `\R` command (without a prompt string) will show an error
 - The prompt change only affects the current session
-- This is equivalent to `SET CLI_PROMPT = 'prompt>'` but more convenient for interactive use
+- This is similar to `SET CLI_PROMPT = 'prompt> '` but more convenient for interactive use

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -75,3 +75,41 @@ spanner> \. setup.sql
 Query OK, 0 rows affected (1.23 sec)
 Query OK, 2 rows affected (0.45 sec)
 ```
+
+## Prompt Change (`\R`)
+
+The `\R` meta command allows you to change the prompt string during your session:
+
+```
+spanner> \R mycli> 
+mycli> 
+```
+
+### Features
+
+- Changes the prompt immediately for the current session
+- Updates the `CLI_PROMPT` system variable
+- Supports the same percent expansion patterns as the `--prompt` flag (see README.md for details)
+- The change persists for the duration of the session
+
+### Examples
+
+```
+spanner> \R [%p/%i/%d]> 
+[myproject/myinstance/mydatabase]> 
+
+spanner> \R custom> 
+custom> SHOW VARIABLE CLI_PROMPT;
++--------------+---------+
+| Variable_name | Value   |
++--------------+---------+
+| CLI_PROMPT   | custom> |
++--------------+---------+
+```
+
+### Notes
+
+- Trailing spaces in the prompt string are trimmed
+- An empty `\R` command (without a prompt string) will show an error
+- The prompt change only affects the current session
+- This is equivalent to `SET CLI_PROMPT = 'prompt>'` but more convenient for interactive use

--- a/integration_meta_command_test.go
+++ b/integration_meta_command_test.go
@@ -71,9 +71,16 @@ func TestMetaCommandIntegration(t *testing.T) {
 			t.Error("Expected error for meta command in batch mode")
 		}
 		
-		// Check error message
-		if err != nil && err.Error() != "meta commands are not supported in batch mode" {
-			t.Errorf("Expected 'meta commands are not supported in batch mode' error, got: %v", err)
+		// Check error type
+		if err != nil {
+			if _, ok := err.(*ExitCodeError); !ok {
+				t.Errorf("Expected error of type *ExitCodeError, but got %T", err)
+			}
+			// Check that the correct error message was printed to the error stream
+			const expectedErrStr = "meta commands are not supported in batch mode"
+			if !strings.Contains(output.String(), expectedErrStr) {
+				t.Errorf("Expected output to contain %q, but got: %s", expectedErrStr, output.String())
+			}
 		}
 	})
 	
@@ -96,9 +103,16 @@ func TestMetaCommandIntegration(t *testing.T) {
 			t.Error("Expected error for meta command in batch mode")
 		}
 		
-		// Check error message (batch mode check happens before system command check)
-		if err != nil && err.Error() != "meta commands are not supported in batch mode" {
-			t.Errorf("Expected 'meta commands are not supported in batch mode' error, got: %v", err)
+		// Check error type
+		if err != nil {
+			if _, ok := err.(*ExitCodeError); !ok {
+				t.Errorf("Expected error of type *ExitCodeError, but got %T", err)
+			}
+			// Check that the correct error message was printed to the error stream
+			const expectedErrStr = "meta commands are not supported in batch mode"
+			if !strings.Contains(output.String(), expectedErrStr) {
+				t.Errorf("Expected output to contain %q, but got: %s", expectedErrStr, output.String())
+			}
 		}
 	})
 	
@@ -249,9 +263,16 @@ SELECT "foo" AS s;`
 			t.Error("Expected error for meta command in batch mode")
 		}
 		
-		// Check error message
-		if err != nil && err.Error() != "meta commands are not supported in batch mode" {
-			t.Errorf("Expected 'meta commands are not supported in batch mode' error, got: %v", err)
+		// Check error type
+		if err != nil {
+			if _, ok := err.(*ExitCodeError); !ok {
+				t.Errorf("Expected error of type *ExitCodeError, but got %T", err)
+			}
+			// Check that the correct error message was printed to the error stream
+			const expectedErrStr = "meta commands are not supported in batch mode"
+			if !strings.Contains(output.String(), expectedErrStr) {
+				t.Errorf("Expected output to contain %q, but got: %s", expectedErrStr, output.String())
+			}
 		}
 	})
 
@@ -356,9 +377,16 @@ SELECT "foo" AS s;`
 			t.Error("Expected error for meta command in batch mode")
 		}
 		
-		// Check error message
-		if err != nil && err.Error() != "meta commands are not supported in batch mode" {
-			t.Errorf("Expected 'meta commands are not supported in batch mode' error, got: %v", err)
+		// Check error type
+		if err != nil {
+			if _, ok := err.(*ExitCodeError); !ok {
+				t.Errorf("Expected error of type *ExitCodeError, but got %T", err)
+			}
+			// Check that the correct error message was printed to the error stream
+			const expectedErrStr = "meta commands are not supported in batch mode"
+			if !strings.Contains(output.String(), expectedErrStr) {
+				t.Errorf("Expected output to contain %q, but got: %s", expectedErrStr, output.String())
+			}
 		}
 	})
 
@@ -435,9 +463,16 @@ SELECT "foo" AS s;`
 			t.Error("Expected error for meta command in batch mode")
 		}
 		
-		// Check error message
-		if err != nil && err.Error() != "meta commands are not supported in batch mode" {
-			t.Errorf("Expected 'meta commands are not supported in batch mode' error, got: %v", err)
+		// Check error type
+		if err != nil {
+			if _, ok := err.(*ExitCodeError); !ok {
+				t.Errorf("Expected error of type *ExitCodeError, but got %T", err)
+			}
+			// Check that the correct error message was printed to the error stream
+			const expectedErrStr = "meta commands are not supported in batch mode"
+			if !strings.Contains(output.String(), expectedErrStr) {
+				t.Errorf("Expected output to contain %q, but got: %s", expectedErrStr, output.String())
+			}
 		}
 	})
 }

--- a/integration_meta_command_test.go
+++ b/integration_meta_command_test.go
@@ -288,9 +288,9 @@ SELECT "foo" AS s;`
 			}
 		}
 
-		// Verify the prompt was changed
-		if sysVars.Prompt != "custom-prompt>" {
-			t.Errorf("Expected prompt to be 'custom-prompt>', got %q", sysVars.Prompt)
+		// Verify the prompt was changed (with trailing space added)
+		if sysVars.Prompt != "custom-prompt> " {
+			t.Errorf("Expected prompt to be 'custom-prompt> ', got %q", sysVars.Prompt)
 		}
 
 		// Check that SHOW VARIABLE output contains the new prompt
@@ -333,9 +333,9 @@ SELECT "foo" AS s;`
 			}
 		}
 
-		// Verify the prompt was changed (expansion happens during display)
-		if sysVars.Prompt != "[%p/%i/%d]>" {
-			t.Errorf("Expected prompt to be '[%%p/%%i/%%d]>', got %q", sysVars.Prompt)
+		// Verify the prompt was changed (expansion happens during display, with trailing space added)
+		if sysVars.Prompt != "[%p/%i/%d]> " {
+			t.Errorf("Expected prompt to be '[%%p/%%i/%%d]> ', got %q", sysVars.Prompt)
 		}
 	})
 

--- a/integration_meta_command_test.go
+++ b/integration_meta_command_test.go
@@ -314,10 +314,16 @@ SELECT "foo" AS s;`
 			t.Errorf("Expected prompt to be 'custom-prompt> ', got %q", sysVars.Prompt)
 		}
 
-		// Check that SHOW VARIABLE output contains the new prompt
+		// Check that SHOW VARIABLE output contains the expected table format
+		// The output should have a single column "CLI_PROMPT" with value "custom-prompt> "
 		outputStr := output.String()
-		if !strings.Contains(outputStr, "custom-prompt>") {
-			t.Errorf("Expected output to contain 'custom-prompt>', got: %s", outputStr)
+		expectedRow := "| custom-prompt> |"  // Note: includes the trailing space
+		
+		if !strings.Contains(outputStr, "CLI_PROMPT") {
+			t.Errorf("Expected output to contain column header 'CLI_PROMPT', got: %s", outputStr)
+		}
+		if !strings.Contains(outputStr, expectedRow) {
+			t.Errorf("Expected output to contain row %q, got: %s", expectedRow, outputStr)
 		}
 	})
 
@@ -358,6 +364,11 @@ SELECT "foo" AS s;`
 		if sysVars.Prompt != "[%p/%i/%d]> " {
 			t.Errorf("Expected prompt to be '[%%p/%%i/%%d]> ', got %q", sysVars.Prompt)
 		}
+		
+		// Note: This test verifies that the prompt is stored with percent patterns intact.
+		// The actual expansion of %p, %i, %d happens during prompt display in getInterpolatedPrompt.
+		// Since this integration test doesn't have a real Spanner connection, we can't verify
+		// the expanded output. Unit tests in cli_test.go cover the expansion logic.
 	})
 
 	t.Run("prompt command in batch mode", func(t *testing.T) {

--- a/meta_commands.go
+++ b/meta_commands.go
@@ -117,7 +117,6 @@ func ParseMetaCommand(input string) (Statement, error) {
 		if args == "" {
 			return nil, errors.New("\\R requires a prompt string")
 		}
-		// Note: args will have trailing spaces trimmed due to strings.TrimSpace on input
 		return &PromptMetaCommand{PromptString: args}, nil
 	default:
 		return nil, fmt.Errorf("unsupported meta command: \\%s", command)
@@ -156,7 +155,10 @@ func (p *PromptMetaCommand) isMetaCommand() {}
 
 // Execute updates the CLI_PROMPT system variable
 func (p *PromptMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
-	if err := session.systemVariables.Set("CLI_PROMPT", p.PromptString); err != nil {
+	// Add a trailing space to the prompt for better UX (separation between prompt and input)
+	// This ensures compatibility with Google Cloud Spanner CLI behavior
+	promptWithSpace := p.PromptString + " "
+	if err := session.systemVariables.Set("CLI_PROMPT", promptWithSpace); err != nil {
 		return nil, fmt.Errorf("failed to set prompt: %w", err)
 	}
 	return &Result{}, nil

--- a/meta_commands.go
+++ b/meta_commands.go
@@ -117,6 +117,7 @@ func ParseMetaCommand(input string) (Statement, error) {
 		if args == "" {
 			return nil, errors.New("\\R requires a prompt string")
 		}
+		// Note: args will have trailing spaces trimmed due to strings.TrimSpace on input
 		return &PromptMetaCommand{PromptString: args}, nil
 	default:
 		return nil, fmt.Errorf("unsupported meta command: \\%s", command)

--- a/meta_commands.go
+++ b/meta_commands.go
@@ -114,10 +114,11 @@ func ParseMetaCommand(input string) (Statement, error) {
 		}
 		return &SourceMetaCommand{FilePath: words[0]}, nil
 	case "R":
-		if args == "" {
+		trimmedArgs := strings.TrimSpace(args)
+		if trimmedArgs == "" {
 			return nil, errors.New("\\R requires a prompt string")
 		}
-		return &PromptMetaCommand{PromptString: args}, nil
+		return &PromptMetaCommand{PromptString: trimmedArgs}, nil
 	default:
 		return nil, fmt.Errorf("unsupported meta command: \\%s", command)
 	}

--- a/meta_commands_test.go
+++ b/meta_commands_test.go
@@ -138,6 +138,11 @@ func TestParseMetaCommand(t *testing.T) {
 			want:  &PromptMetaCommand{PromptString: "my custom prompt>"},
 		},
 		{
+			name:  "prompt command with only trailing space",
+			input: "\\R prompt ",
+			want:  &PromptMetaCommand{PromptString: "prompt"},
+		},
+		{
 			name:    "prompt command without string",
 			input:   "\\R",
 			wantErr: true,
@@ -293,33 +298,39 @@ func TestPromptMetaCommand_Execute(t *testing.T) {
 	}{
 		{
 			name:           "set simple prompt",
-			promptString:   "my-prompt> ",
+			promptString:   "my-prompt>",
 			initialPrompt:  "",
-			expectedPrompt: "my-prompt> ",
+			expectedPrompt: "my-prompt> ",  // Space added automatically
 		},
 		{
 			name:           "set prompt with percent expansion",
-			promptString:   "%n@%p> ",
+			promptString:   "%n@%p>",
 			initialPrompt:  "",
-			expectedPrompt: "%n@%p> ",
+			expectedPrompt: "%n@%p> ",  // Space added automatically
 		},
 		{
 			name:           "overwrite existing prompt",
-			promptString:   "new-prompt> ",
+			promptString:   "new-prompt>",
 			initialPrompt:  "old-prompt> ",
-			expectedPrompt: "new-prompt> ",
+			expectedPrompt: "new-prompt> ",  // Space added automatically
 		},
 		{
 			name:           "empty prompt string",
 			promptString:   "",
 			initialPrompt:  "test> ",
-			expectedPrompt: "",
+			expectedPrompt: " ",  // Just a space
 		},
 		{
 			name:           "complex prompt with multiple expansions",
-			promptString:   "[%n/%d@%i:%p] %R%R> ",
+			promptString:   "[%n/%d@%i:%p] %R%R>",
 			initialPrompt:  "",
-			expectedPrompt: "[%n/%d@%i:%p] %R%R> ",
+			expectedPrompt: "[%n/%d@%i:%p] %R%R> ",  // Space added automatically
+		},
+		{
+			name:           "prompt already ending with space",
+			promptString:   "prompt ",
+			initialPrompt:  "",
+			expectedPrompt: "prompt  ",  // Double space (original + added)
 		},
 	}
 

--- a/meta_commands_test.go
+++ b/meta_commands_test.go
@@ -374,12 +374,6 @@ func TestPromptMetaCommand_Execute(t *testing.T) {
 			initialPrompt:  "",
 			expectedPrompt: "[%n/%d@%i:%p] %R%R> ",  // Space added automatically
 		},
-		{
-			name:           "prompt already ending with space",
-			promptString:   "prompt ",
-			initialPrompt:  "",
-			expectedPrompt: "prompt  ",  // Double space (original + added)
-		},
 	}
 
 	for _, tt := range tests {

--- a/meta_commands_test.go
+++ b/meta_commands_test.go
@@ -122,6 +122,26 @@ func TestParseMetaCommand(t *testing.T) {
 			input:   "not a meta command",
 			wantErr: true,
 		},
+		{
+			name:  "prompt command simple",
+			input: "\\R spanner> ",
+			want:  &PromptMetaCommand{PromptString: "spanner>"},
+		},
+		{
+			name:  "prompt command with percent expansion",
+			input: "\\R %n@%p> ",
+			want:  &PromptMetaCommand{PromptString: "%n@%p>"},
+		},
+		{
+			name:  "prompt command with extra spaces",
+			input: "  \\R   my custom prompt>  ",
+			want:  &PromptMetaCommand{PromptString: "my custom prompt>"},
+		},
+		{
+			name:    "prompt command without string",
+			input:   "\\R",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -148,6 +168,14 @@ func TestParseMetaCommand(t *testing.T) {
 						}
 					} else {
 						t.Errorf("ParseMetaCommand(%q) returned %T, want *SourceMetaCommand", tt.input, got)
+					}
+				case *PromptMetaCommand:
+					if prompt, ok := got.(*PromptMetaCommand); ok {
+						if prompt.PromptString != want.PromptString {
+							t.Errorf("ParseMetaCommand(%q) = %q, want %q", tt.input, prompt.PromptString, want.PromptString)
+						}
+					} else {
+						t.Errorf("ParseMetaCommand(%q) returned %T, want *PromptMetaCommand", tt.input, got)
 					}
 				}
 			}
@@ -238,12 +266,90 @@ func TestMetaCommandStatement_Interface(t *testing.T) {
 	var _ Statement = (*SourceMetaCommand)(nil)
 	var _ MetaCommandStatement = (*SourceMetaCommand)(nil)
 
+	// Verify that PromptMetaCommand implements both interfaces
+	var _ Statement = (*PromptMetaCommand)(nil)
+	var _ MetaCommandStatement = (*PromptMetaCommand)(nil)
+
 	// Test the marker method
 	cmd := &ShellMetaCommand{Command: "test"}
 	cmd.isMetaCommand() // This should compile
 
 	srcCmd := &SourceMetaCommand{FilePath: "test.sql"}
 	srcCmd.isMetaCommand() // This should compile
+
+	promptCmd := &PromptMetaCommand{PromptString: "test> "}
+	promptCmd.isMetaCommand() // This should compile
+}
+
+func TestPromptMetaCommand_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		promptString   string
+		initialPrompt  string
+		expectedPrompt string
+		wantErr        bool
+	}{
+		{
+			name:           "set simple prompt",
+			promptString:   "my-prompt> ",
+			initialPrompt:  "",
+			expectedPrompt: "my-prompt> ",
+		},
+		{
+			name:           "set prompt with percent expansion",
+			promptString:   "%n@%p> ",
+			initialPrompt:  "",
+			expectedPrompt: "%n@%p> ",
+		},
+		{
+			name:           "overwrite existing prompt",
+			promptString:   "new-prompt> ",
+			initialPrompt:  "old-prompt> ",
+			expectedPrompt: "new-prompt> ",
+		},
+		{
+			name:           "empty prompt string",
+			promptString:   "",
+			initialPrompt:  "test> ",
+			expectedPrompt: "",
+		},
+		{
+			name:           "complex prompt with multiple expansions",
+			promptString:   "[%n/%d@%i:%p] %R%R> ",
+			initialPrompt:  "",
+			expectedPrompt: "[%n/%d@%i:%p] %R%R> ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sysVars := newSystemVariablesWithDefaults()
+			if tt.initialPrompt != "" {
+				sysVars.Prompt = tt.initialPrompt
+			}
+			session := &Session{
+				systemVariables: &sysVars,
+			}
+
+			cmd := &PromptMetaCommand{PromptString: tt.promptString}
+			result, err := cmd.Execute(ctx, session)
+			
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if result == nil {
+					t.Error("Execute() returned nil result")
+				}
+				if sysVars.Prompt != tt.expectedPrompt {
+					t.Errorf("Execute() prompt = %q, want %q", sysVars.Prompt, tt.expectedPrompt)
+				}
+			}
+		})
+	}
 }
 
 func TestParseMetaCommand_SingleCharacterOnly(t *testing.T) {

--- a/meta_commands_test.go
+++ b/meta_commands_test.go
@@ -138,6 +138,11 @@ func TestParseMetaCommand(t *testing.T) {
 			want:  &PromptMetaCommand{PromptString: "my custom prompt>"},
 		},
 		{
+			name:  "prompt command with only spaces",
+			input: "\\R    ",
+			wantErr: true,
+		},
+		{
 			name:  "prompt command with only trailing space",
 			input: "\\R prompt ",
 			want:  &PromptMetaCommand{PromptString: "prompt"},


### PR DESCRIPTION
## Summary
- Implement `\R <prompt_string>` meta-command to change the prompt dynamically
- Compatible with Google Cloud Spanner CLI behavior
- Updates the `CLI_PROMPT` system variable with automatic trailing space

## Changes
- Add `PromptMetaCommand` struct that implements `MetaCommandStatement` interface
- Update `ParseMetaCommand` to handle `\R` command syntax
- Add comprehensive unit tests for parsing and execution
- Add integration tests for interactive mode behavior
- Update documentation in README.md and docs/meta_commands.md

## Implementation Details

### Key Design Decisions

1. **Trailing Space Handling**: The `\R` command automatically adds a trailing space to the prompt string for better UX and compatibility with Google Cloud Spanner CLI. This ensures proper separation between the prompt and user input.

2. **Interface Design**: All meta-commands implement `MetaCommandStatement` which embeds `Statement`, ensuring type safety and consistency. This allows us to verify at compile time that all meta-commands are valid statements.

3. **Execution Flow**: The `\R` command updates the prompt by calling `systemVariables.Set("CLI_PROMPT", promptWithSpace)`, maintaining consistency with the `SET CLI_PROMPT = ...` statement.

4. **Error Handling**: Empty prompt commands (`\R` without arguments) return a clear error message, matching the pattern of other meta-commands.

5. **Input Processing**: The input string is trimmed (consistent with other meta-commands), but a space is always appended when setting the prompt. This means `\R spanner>` results in `CLI_PROMPT="spanner> "`.

## Testing
- Unit tests cover all parsing scenarios (simple prompt, percent expansion, empty prompt error)
- Integration tests verify interactive mode behavior
- All existing tests pass with `make check`

## Manual Test Instructions
1. Start spanner-mycli: `./spanner-mycli --embedded-emulator -p test -i test -d test`
2. Test basic prompt change: `\R mycli>`
3. Test with percent expansion: `\R [%p/%i/%d]>`
4. Verify change: `SHOW VARIABLE CLI_PROMPT;` (should show trailing space)
5. Test error case: `\R` (should show error)

Fixes #346