### PR TITLE
feat: implement --system-command option for controlling system commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ spanner:
       --try-partition-query                               Test whether the query can be executed as partition query without execution
       --mcp                                               Run as MCP server
       --skip-system-command                               Do not allow system commands
+      --system-command=[ON|OFF]                           Enable or disable system commands (ON/OFF) (default: ON)
       --tee=                                              Append a copy of output to the specified file
       --skip-column-names                                 Suppress column headers in output
 

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -19,11 +19,23 @@ spanner> \! pwd
 
 ### Security
 
-Shell command execution can be disabled using the `--skip-system-command` flag:
+Shell command execution can be controlled using two options:
+
+1. `--skip-system-command` flag - Disables system commands
+2. `--system-command=ON/OFF` option - Enables (ON) or disables (OFF) system commands (default: ON)
 
 ```bash
+# Disable using --skip-system-command
 spanner-mycli --skip-system-command
+
+# Disable using --system-command
+spanner-mycli --system-command=OFF
+
+# Explicitly enable (default behavior)
+spanner-mycli --system-command=ON
 ```
+
+Note: When both options are used, `--skip-system-command` takes precedence.
 
 When disabled, attempting to use `\!` will result in an error:
 

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -24,4 +24,20 @@ TODO
   - Can be set via `--skip-column-names` command-line flag
   - Useful for scripting and data processing where only raw data is needed
 
+##### CLI_SKIP_SYSTEM_COMMAND
+- **Type**: BOOL
+- **Default**: FALSE
+- **Description**: Indicates whether system commands are disabled
+- **Access**: Read-only
+- **Usage**: 
+  ```sql
+  SHOW CLI_SKIP_SYSTEM_COMMAND;  -- Check if system commands are disabled
+  ```
+- **Notes**:
+  - This is a read-only variable that reflects the state set by command-line flags
+  - Can be set via `--skip-system-command` flag or `--system-command=OFF`
+  - When set to TRUE, the `\!` meta command is disabled
+  - When both flags are used, `--skip-system-command` takes precedence
+  - Security feature to prevent shell command execution in restricted environments
+
 TODO: Document other CLI_* variables

--- a/main_test.go
+++ b/main_test.go
@@ -706,6 +706,59 @@ func Test_createSystemVariablesFromOptions(t *testing.T) {
 				return sv
 			}(),
 		},
+		{
+			name: "skip-system-command flag",
+			opts: &spannerOptions{
+				SkipSystemCommand: true,
+			},
+			want: func() systemVariables {
+				sv := newSystemVariablesWithDefaults()
+				sv.LogLevel = slog.LevelWarn
+				sv.SkipSystemCommand = true
+				sv.Params = make(map[string]ast.Node)
+				return sv
+			}(),
+		},
+		{
+			name: "system-command=OFF",
+			opts: &spannerOptions{
+				SystemCommand: lo.ToPtr("OFF"),
+			},
+			want: func() systemVariables {
+				sv := newSystemVariablesWithDefaults()
+				sv.LogLevel = slog.LevelWarn
+				sv.SkipSystemCommand = true
+				sv.Params = make(map[string]ast.Node)
+				return sv
+			}(),
+		},
+		{
+			name: "system-command=ON",
+			opts: &spannerOptions{
+				SystemCommand: lo.ToPtr("ON"),
+			},
+			want: func() systemVariables {
+				sv := newSystemVariablesWithDefaults()
+				sv.LogLevel = slog.LevelWarn
+				sv.SkipSystemCommand = false
+				sv.Params = make(map[string]ast.Node)
+				return sv
+			}(),
+		},
+		{
+			name: "skip-system-command takes precedence over system-command=ON",
+			opts: &spannerOptions{
+				SkipSystemCommand: true,
+				SystemCommand:     lo.ToPtr("ON"),
+			},
+			want: func() systemVariables {
+				sv := newSystemVariablesWithDefaults()
+				sv.LogLevel = slog.LevelWarn
+				sv.SkipSystemCommand = true
+				sv.Params = make(map[string]ast.Node)
+				return sv
+			}(),
+		},
 	}
 
 	for _, test := range tests {

--- a/system_variables.go
+++ b/system_variables.go
@@ -1194,7 +1194,7 @@ var systemVariableDefMap = map[string]systemVariableDef{
 		}),
 	},
 	"CLI_SKIP_SYSTEM_COMMAND": {
-		Description: "A read-only boolean indicating whether system commands are disabled. Set via --skip-system-command flag (maintained for compatibility with official Spanner CLI).",
+		Description: "A read-only boolean indicating whether system commands are disabled. Set via --skip-system-command flag or --system-command=OFF. When both are used, --skip-system-command takes precedence.",
 		Accessor: accessor{
 			Getter: boolGetter(func(variables *systemVariables) *bool {
 				return &variables.SkipSystemCommand


### PR DESCRIPTION
## Summary

Implements `--system-command=ON/OFF` option to control system command execution, achieving compatibility with Google Cloud Spanner CLI while maintaining backward compatibility with the existing `--skip-system-command` flag.

Fixes #354

## Changes

### Implementation
- Added `--system-command` option that accepts `ON` or `OFF` values (default: ON)
- Implemented proper precedence: `--skip-system-command` takes precedence over `--system-command`
- Used pointer type (`*string`) for `SystemCommand` to distinguish between unset and explicitly set values

### Documentation
- Updated `docs/meta_commands.md` with both options and precedence information
- Added `CLI_SKIP_SYSTEM_COMMAND` to `docs/system_variables.md`
- Updated `README.md` help output to include the new option

### Tests
- Added comprehensive test cases covering all combinations:
  - `--skip-system-command` alone
  - `--system-command=OFF`
  - `--system-command=ON`
  - Precedence test when both flags are used

## Compatibility

The implementation is fully compatible with both:
- **spannercli sql**: Uses `--skip-system-command`
- **gcloud alpha spanner cli**: Uses both `--skip-system-command` and `--system-command=ON/OFF`

## Technical Insights

### Design Decisions

1. **Pointer Type for SystemCommand**
   - Used `*string` instead of `string` to distinguish between unset and explicitly set values
   - This allows proper default behavior when neither flag is specified

2. **Precedence Logic**
   - `--skip-system-command` always takes precedence, matching Google Cloud Spanner CLI behavior
   - This ensures backward compatibility and predictable behavior

3. **go-flags Choice Validation**
   - Utilized `choice:"ON" choice:"OFF"` tags for automatic validation
   - Provides clear error messages for invalid values

### Code Quality
- No redundancy: Logic is centralized in `createSystemVariablesFromOptions`
- Clear separation of concerns: Flag parsing → system variable setting → usage in meta commands
- Comprehensive test coverage with table-driven tests
- Well-documented with comments explaining compatibility and precedence

### Security Consideration
This feature provides security controls for environments where shell command execution should be restricted, preventing potential security risks from the `\!` meta command.

## Testing

```bash
# Verify both options work
./spanner-mycli --skip-system-command
./spanner-mycli --system-command=OFF
./spanner-mycli --system-command=ON

# Verify precedence
./spanner-mycli --skip-system-command --system-command=ON  # System commands disabled

# All tests pass
make check  # ✅
```

## Related Issues
- Parent issue: #342 (Compatibility improvements)
- Related: #348 (`\!` meta-command implementation)