### PR TITLE
feat: add session-init-only variables validation mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ build-tools:
 	go install tool
 	@echo "✅ Tools installed successfully"
 	@echo "💡 Use: go tool gh-helper --help"
-	test
 
 clean:
 	rm -f spanner-mycli

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build-tools:
 	go install tool
 	@echo "✅ Tools installed successfully"
 	@echo "💡 Use: go tool gh-helper --help"
+	test
 
 clean:
 	rm -f spanner-mycli

--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -75,8 +75,7 @@ var sessionInitOnlyVariables = []string{
 
 **Behavior**:
 - Can be set via `--set` flag before session creation
-- After session creation, attempts to change the value will return an error with the current value
-- Idempotent sets (setting to the same value) are allowed
+- After session creation, any attempt to set the value will return an error
 - The validation in `systemVariables.Set()` handles case-insensitive variable names correctly
 
 ### Development Workflow

--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -52,15 +52,15 @@ This document provides detailed patterns and best practices for implementing sys
 Some variables can only be set before session creation because they control client initialization behavior that cannot be changed after the session is established. These are defined in the `sessionInitOnlyVariables` map in `system_variables.go`.
 
 **Implementation Pattern**:
-1. Add the variable name to `sessionInitOnlyVariables` map
+1. Add the variable name to `sessionInitOnlyVariables` slice
 2. Use standard accessor (e.g., `boolAccessor`) - the validation is automatic
 3. Document in the Description that it must be set before session creation
 
 **Example**:
 ```go
-// In sessionInitOnlyVariables map
-var sessionInitOnlyVariables = map[string]struct{}{
-    "CLI_ENABLE_ADC_PLUS": {},
+// In sessionInitOnlyVariables slice
+var sessionInitOnlyVariables = []string{
+    "CLI_ENABLE_ADC_PLUS",
     // Add more variables here as needed
 }
 

--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -47,6 +47,38 @@ This document provides detailed patterns and best practices for implementing sys
 - **Testing Strategy**: System variables test pattern in `system_variables_test.go` covers both SET/GET operations and proper error handling for unimplemented setters
 - **Code Organization**: System variable definitions follow clear patterns that make adding new variables straightforward
 
+### Session-Init-Only Variables
+
+Some variables can only be set before session creation because they control client initialization behavior that cannot be changed after the session is established. These are defined in the `sessionInitOnlyVariables` map in `system_variables.go`.
+
+**Implementation Pattern**:
+1. Add the variable name to `sessionInitOnlyVariables` map
+2. Use standard accessor (e.g., `boolAccessor`) - the validation is automatic
+3. Document in the Description that it must be set before session creation
+
+**Example**:
+```go
+// In sessionInitOnlyVariables map
+var sessionInitOnlyVariables = map[string]struct{}{
+    "CLI_ENABLE_ADC_PLUS": {},
+    // Add more variables here as needed
+}
+
+// In systemVariableDefMap
+"CLI_ENABLE_ADC_PLUS": {
+    Description: "A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true.",
+    Accessor: boolAccessor(func(variables *systemVariables) *bool {
+        return &variables.EnableADCPlus
+    }),
+},
+```
+
+**Behavior**:
+- Can be set via `--set` flag before session creation
+- After session creation, attempts to change the value will return an error with the current value
+- Idempotent sets (setting to the same value) are allowed
+- The validation in `systemVariables.Set()` handles case-insensitive variable names correctly
+
 ### Development Workflow
 
 - **Workflow**: phantom + tmux horizontal split works well for focused system variable implementation

--- a/session.go
+++ b/session.go
@@ -1024,7 +1024,8 @@ func (s *Session) startHeartbeat() {
 			s.tcMutex.Lock()
 			defer s.tcMutex.Unlock()
 			if s.tc != nil && s.tc.mode == transactionModeReadWrite && s.tc.sendHeartbeat {
-				err := heartbeat(s.tc.RWTxn(), s.currentPriority())
+				// Always use LOW priority for heartbeat to avoid interfering with real work
+				err := heartbeat(s.tc.RWTxn(), sppb.RequestOptions_PRIORITY_LOW)
 				if err != nil {
 					slog.Error("heartbeat error", "err", err)
 				}

--- a/system_variables.go
+++ b/system_variables.go
@@ -302,6 +302,11 @@ func (sv *systemVariables) Set(name string, value string) error {
 		// For example, CLI_ENABLE_ADC_PLUS affects adminClient creation which happens
 		// during initial session setup, not during database connection.
 		if sv.CurrentSession != nil {
+			// NOTE: We intentionally do not include the current value in the error message
+			// or allow idempotent sets (setting to the same value). This is a deliberate
+			// design choice: session-init-only variables should reject ALL SET operations
+			// after session creation to make it crystal clear that these settings cannot
+			// be changed once the session is established.
 			return fmt.Errorf("%s cannot be changed after session creation", upperName)
 		}
 	}

--- a/system_variables.go
+++ b/system_variables.go
@@ -295,8 +295,13 @@ func (sv *systemVariables) Set(name string, value string) error {
 
 	// Check if this is a session-init-only variable
 	if slices.Contains(sessionInitOnlyVariables, upperName) {
-		// Check if session is already initialized
-		if sv.CurrentSession != nil && sv.CurrentSession.client != nil {
+		// Check if session is already initialized.
+		// We check only CurrentSession != nil, not client != nil, because these variables
+		// configure client options at CLI startup. Changes after session creation have no effect,
+		// even in detached mode when the client will be created later via USE command.
+		// For example, CLI_ENABLE_ADC_PLUS affects adminClient creation which happens
+		// during initial session setup, not during database connection.
+		if sv.CurrentSession != nil {
 			// Get current value for comparison.
 			// Call Get with upperName to ensure the key in the returned map is predictable.
 			currentValues, err := sv.Get(upperName)

--- a/system_variables.go
+++ b/system_variables.go
@@ -294,14 +294,7 @@ func (sv *systemVariables) Set(name string, value string) error {
 	}
 
 	// Check if this is a session-init-only variable
-	isInitOnly := false
-	for _, v := range sessionInitOnlyVariables {
-		if v == upperName {
-			isInitOnly = true
-			break
-		}
-	}
-	if isInitOnly {
+	if slices.Contains(sessionInitOnlyVariables, upperName) {
 		// Check if session is already initialized
 		if sv.CurrentSession != nil && sv.CurrentSession.client != nil {
 			// Get current value for comparison.

--- a/system_variables.go
+++ b/system_variables.go
@@ -266,7 +266,15 @@ var _ error = &errSetterUnimplemented{}
 var _ error = &errGetterUnimplemented{}
 var _ error = &errAdderUnimplemented{}
 
-// sessionInitOnlyVariables contains variables that can only be set before session creation
+// sessionInitOnlyVariables contains variables that can only be set before session creation.
+// These variables typically control client initialization behavior that cannot be changed
+// after the session is established. Attempting to change these after session creation
+// will return an error showing the current value.
+//
+// To add a new session-init-only variable:
+// 1. Add the variable name to this map
+// 2. Ensure the variable has a proper Setter in systemVariableDefMap
+// 3. Document in the variable's Description that it must be set before session creation
 var sessionInitOnlyVariables = map[string]struct{}{
 	"CLI_ENABLE_ADC_PLUS": {},
 	// Add more variables here as needed in the future

--- a/system_variables.go
+++ b/system_variables.go
@@ -272,15 +272,15 @@ var _ error = &errAdderUnimplemented{}
 // will return an error showing the current value.
 //
 // To add a new session-init-only variable:
-// 1. Add the variable name to this map
+// 1. Add the variable name to this slice
 // 2. Ensure the variable has a proper Setter in systemVariableDefMap
 // 3. Document in the variable's Description that it must be set before session creation
-var sessionInitOnlyVariables = map[string]struct{}{
-	"CLI_ENABLE_ADC_PLUS": {},
+var sessionInitOnlyVariables = []string{
+	"CLI_ENABLE_ADC_PLUS",
 	// Add more variables here as needed in the future
 	// For example:
-	// "CLI_ENABLE_TRACING": {},
-	// "CLI_ENABLE_CLIENT_METRICS": {},
+	// "CLI_ENABLE_TRACING",
+	// "CLI_ENABLE_CLIENT_METRICS",
 }
 
 func (sv *systemVariables) Set(name string, value string) error {
@@ -294,7 +294,14 @@ func (sv *systemVariables) Set(name string, value string) error {
 	}
 
 	// Check if this is a session-init-only variable
-	if _, isInitOnly := sessionInitOnlyVariables[upperName]; isInitOnly {
+	isInitOnly := false
+	for _, v := range sessionInitOnlyVariables {
+		if v == upperName {
+			isInitOnly = true
+			break
+		}
+	}
+	if isInitOnly {
 		// Check if session is already initialized
 		if sv.CurrentSession != nil && sv.CurrentSession.client != nil {
 			// Get current value for comparison.

--- a/system_variables.go
+++ b/system_variables.go
@@ -289,10 +289,12 @@ func (sv *systemVariables) Set(name string, value string) error {
 	if _, isInitOnly := sessionInitOnlyVariables[upperName]; isInitOnly {
 		// Check if session is already initialized
 		if sv.CurrentSession != nil && sv.CurrentSession.client != nil {
-			// Get current value for comparison
-			currentValues, err := sv.Get(name)
+			// Get current value for comparison.
+			// Call Get with upperName to ensure the key in the returned map is predictable.
+			currentValues, err := sv.Get(upperName)
 			if err != nil {
-				return fmt.Errorf("%s cannot be changed after session creation", upperName)
+				// Wrap the error to provide more context for debugging.
+				return fmt.Errorf("cannot change %s after session creation, failed to get current value: %w", upperName, err)
 			}
 			
 			currentValue := currentValues[upperName]

--- a/system_variables.go
+++ b/system_variables.go
@@ -302,23 +302,7 @@ func (sv *systemVariables) Set(name string, value string) error {
 		// For example, CLI_ENABLE_ADC_PLUS affects adminClient creation which happens
 		// during initial session setup, not during database connection.
 		if sv.CurrentSession != nil {
-			// Get current value for comparison without calling sv.Get() to avoid deadlocks with mutexes.
-			getter := a.Accessor.Getter
-			if getter == nil {
-				return fmt.Errorf("cannot change %s after session creation, variable is not readable", upperName)
-			}
-			currentValues, err := getter(sv, upperName)
-			if err != nil {
-				// Wrap the error to provide more context for debugging.
-				return fmt.Errorf("cannot change %s after session creation, failed to get current value: %w", upperName, err)
-			}
-			
-			currentValue := currentValues[upperName]
-			
-			// Check if actually trying to change the value
-			if !strings.EqualFold(currentValue, value) {
-				return fmt.Errorf("%s cannot be changed after session creation. Current value: %s", upperName, currentValue)
-			}
+			return fmt.Errorf("%s cannot be changed after session creation", upperName)
 		}
 	}
 

--- a/system_variables_test.go
+++ b/system_variables_test.go
@@ -1056,6 +1056,7 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 		initialValue   string
 		setValue       string
 		hasSession     bool
+		detached       bool // Whether session is detached (no client)
 		expectError    bool
 		expectedErrMsg string
 	}{
@@ -1133,6 +1134,17 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 			hasSession:   true,
 			expectError:  false,
 		},
+		{
+			name:         "change after detached session creation should fail",
+			variableName: "CLI_ENABLE_ADC_PLUS",
+			variableCase: "CLI_ENABLE_ADC_PLUS",
+			initialValue: "true",
+			setValue:     "false",
+			hasSession:   true,
+			detached:     true,
+			expectError:  true,
+			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation. Current value: TRUE",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1145,8 +1157,10 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 
 			// Simulate session creation if needed
 			if tt.hasSession {
-				sv.CurrentSession = &Session{
-					client: &spanner.Client{}, // Mock client to simulate initialized session
+				sv.CurrentSession = &Session{}
+				// Set client for non-detached sessions
+				if !tt.detached {
+					sv.CurrentSession.client = &spanner.Client{} // Mock client to simulate initialized session
 				}
 			}
 

--- a/system_variables_test.go
+++ b/system_variables_test.go
@@ -1169,7 +1169,8 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 				}
 
 				// Verify the value was set correctly (for non-session cases or idempotent sets)
-				if tt.variableName == "CLI_ENABLE_ADC_PLUS" {
+				switch tt.variableName {
+				case "CLI_ENABLE_ADC_PLUS":
 					expectedValue := tt.setValue == "true" || tt.setValue == "TRUE"
 					if !tt.hasSession || tt.initialValue == tt.setValue || strings.EqualFold(tt.initialValue, tt.setValue) {
 						// Value should be updated or remain the same for idempotent sets
@@ -1177,7 +1178,7 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 							t.Errorf("expected EnableADCPlus to be %v, got %v", expectedValue, sv.EnableADCPlus)
 						}
 					}
-				} else if tt.variableName == "CLI_ASYNC_DDL" {
+				case "CLI_ASYNC_DDL":
 					expectedValue := tt.setValue == "true" || tt.setValue == "TRUE"
 					if sv.AsyncDDL != expectedValue {
 						t.Errorf("expected AsyncDDL to be %v, got %v", expectedValue, sv.AsyncDDL)
@@ -1195,13 +1196,14 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 			// Check that the value returned by Get matches expectation
 			gotValue := values[tt.variableName]
 			var expectedGetValue string
-			if tt.variableName == "CLI_ENABLE_ADC_PLUS" {
+			switch tt.variableName {
+			case "CLI_ENABLE_ADC_PLUS":
 				if sv.EnableADCPlus {
 					expectedGetValue = "TRUE"
 				} else {
 					expectedGetValue = "FALSE"
 				}
-			} else if tt.variableName == "CLI_ASYNC_DDL" {
+			case "CLI_ASYNC_DDL":
 				if sv.AsyncDDL {
 					expectedGetValue = "TRUE"
 				} else {

--- a/system_variables_test.go
+++ b/system_variables_test.go
@@ -535,8 +535,8 @@ func TestSystemVariablesSetGet(t *testing.T) {
 		{desc: "CLI_IMPERSONATE_SERVICE_ACCOUNT", name: "CLI_IMPERSONATE_SERVICE_ACCOUNT", unimplementedSet: true,
 			sysVars: &systemVariables{ImpersonateServiceAccount: "test@example.com"},
 			want:    singletonMap("CLI_IMPERSONATE_SERVICE_ACCOUNT", "test@example.com")},
-		{desc: "CLI_ENABLE_ADC_PLUS", name: "CLI_ENABLE_ADC_PLUS", unimplementedSet: true,
-			sysVars: &systemVariables{EnableADCPlus: true},
+		{desc: "CLI_ENABLE_ADC_PLUS", name: "CLI_ENABLE_ADC_PLUS", value: "true",
+			sysVars: &systemVariables{EnableADCPlus: false}, // Start with false to test setting
 			want:    singletonMap("CLI_ENABLE_ADC_PLUS", "TRUE")},
 		{desc: "CLI_MCP", name: "CLI_MCP", unimplementedSet: true,
 			sysVars: &systemVariables{MCP: true},

--- a/system_variables_test.go
+++ b/system_variables_test.go
@@ -1095,25 +1095,7 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 			setValue:     "false",
 			hasSession:   true,
 			expectError:  true,
-			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation. Current value: TRUE",
-		},
-		{
-			name:         "idempotent set after session creation - same value",
-			variableName: "CLI_ENABLE_ADC_PLUS",
-			variableCase: "CLI_ENABLE_ADC_PLUS",
-			initialValue: "true",
-			setValue:     "true",
-			hasSession:   true,
-			expectError:  false,
-		},
-		{
-			name:         "idempotent set after session creation - different case",
-			variableName: "CLI_ENABLE_ADC_PLUS",
-			variableCase: "cli_enable_adc_plus",
-			initialValue: "true",
-			setValue:     "TRUE",
-			hasSession:   true,
-			expectError:  false,
+			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
 		},
 		{
 			name:         "change after session with lowercase variable name",
@@ -1123,7 +1105,7 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 			setValue:     "false",
 			hasSession:   true,
 			expectError:  true,
-			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation. Current value: TRUE",
+			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
 		},
 		{
 			name:         "non-session-init-only variable can be changed",
@@ -1143,7 +1125,7 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 			hasSession:   true,
 			detached:     true,
 			expectError:  true,
-			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation. Current value: TRUE",
+			expectedErrMsg: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
 		},
 	}
 
@@ -1182,12 +1164,12 @@ func TestSessionInitOnlyVariables(t *testing.T) {
 					return
 				}
 
-				// Verify the value was set correctly (for non-session cases or idempotent sets)
+				// Verify the value was set correctly (only for non-session cases)
 				switch tt.variableName {
 				case "CLI_ENABLE_ADC_PLUS":
 					expectedValue := tt.setValue == "true" || tt.setValue == "TRUE"
-					if !tt.hasSession || tt.initialValue == tt.setValue || strings.EqualFold(tt.initialValue, tt.setValue) {
-						// Value should be updated or remain the same for idempotent sets
+					if !tt.hasSession {
+						// Value should be updated
 						if sv.EnableADCPlus != expectedValue {
 							t.Errorf("expected EnableADCPlus to be %v, got %v", expectedValue, sv.EnableADCPlus)
 						}


### PR DESCRIPTION
## Summary
This PR introduces a generic mechanism to enforce that certain system variables can only be set before session creation, preventing configuration changes that would have no effect after the session is established.

## Motivation
Some system variables like `CLI_ENABLE_ADC_PLUS` only take effect during session initialization. Allowing users to change these after session creation gives a false impression that the change is applied, when in reality it has no effect.

## Changes
- Added `sessionInitOnlyVariables` slice to define variables that cannot be changed after session creation
- Added validation logic in `systemVariables.Set()` to check session state before allowing changes
- Made `CLI_ENABLE_ADC_PLUS` writable but restricted to pre-session changes
- Used LOW priority for heartbeat operations to avoid thread-safety issues

## Behavior
1. **Before session creation**: Variables can be set freely (e.g., via `--set` flag)
2. **After session creation**: ALL SET operations are rejected with a clear error message

## Design Decision
We intentionally do not:
- Include the current value in error messages
- Allow idempotent sets (setting to the same value)

This makes it crystal clear that these settings are completely immutable after session creation.

## Example
```sql
-- Before session creation
$ spanner-mycli --set CLI_ENABLE_ADC_PLUS=false ...

-- After session creation
> SET CLI_ENABLE_ADC_PLUS = false;
ERROR: CLI_ENABLE_ADC_PLUS cannot be changed after session creation

> SET CLI_ENABLE_ADC_PLUS = true;  -- Even setting to current value
ERROR: CLI_ENABLE_ADC_PLUS cannot be changed after session creation
```

## Testing
- Added comprehensive unit tests for the validation mechanism
- Tests cover various scenarios including case-insensitive variable names and detached sessions

## Related Issues
During development, we also discovered and fixed:
- Thread-safety issue with heartbeat operations (fixed by using LOW priority)
- Potential deadlock in validation logic (fixed by avoiding recursive calls)
EOF < /dev/null