### PR TITLE
feat: add CSV output format support with multiple CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are differences between spanner-mycli and spanner-cli that include not onl
   * Support `--skip-column-names` flag to suppress column headers in output (useful for scripting)
   * Support `--host` and `--port` flags as first-class options
   * Support `--deployment-endpoint` as an alias for `--endpoint`
-  * Support `--html` and `--xml` output format options with proper escaping (security-enhanced compared to reference implementation)
+  * Support `--html`, `--xml`, and `--csv` output format options with proper escaping (security-enhanced compared to reference implementation)
 * Generalized concepts to extend without a lot of original syntax
   * Generalized system variables concept inspired by Spanner JDBC properties
     * `SET <name> = <value>` statement
@@ -113,6 +113,8 @@ spanner:
   -t, --table                                             Display output in table format for batch mode.
       --html                                              Display output in HTML format.
       --xml                                               Display output in XML format.
+      --csv                                               Display output in CSV format.
+      --format=[table|tab|vertical|html|xml|csv]         Output format (alternative to individual format flags)
   -v, --verbose                                           Display verbose output.
       --credential=                                       Use the specific credential file
       --prompt=                                           Set the prompt to the specified format (default: spanner%t> )
@@ -888,8 +890,9 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 > - `TAB` - Tab-separated values (default for batch mode)
 > - `HTML` - HTML table format (compatible with Google Cloud Spanner CLI)
 > - `XML` - XML format (compatible with Google Cloud Spanner CLI)
+> - `CSV` - Comma-separated values (RFC 4180 compliant with automatic escaping)
 >
-> You can change the output format at runtime using `SET CLI_FORMAT = 'HTML';` or use command-line flags `--table`, `--html`, or `--xml`.
+> You can change the output format at runtime using `SET CLI_FORMAT = 'CSV';` or use command-line flags `--table`, `--html`, `--xml`, or `--csv`.
 
 ### Batch statements
 

--- a/cli_output.go
+++ b/cli_output.go
@@ -725,6 +725,8 @@ func printCSVTable(out io.Writer, columnNames []string, rows []Row, skipColumnNa
 	}
 
 	csvWriter := csv.NewWriter(out)
+	// Defer Flush to ensure the buffer is written to the output, even on error.
+	defer csvWriter.Flush()
 
 	if !skipColumnNames {
 		if err := csvWriter.Write(columnNames); err != nil {
@@ -738,10 +740,11 @@ func printCSVTable(out io.Writer, columnNames []string, rows []Row, skipColumnNa
 		}
 	}
 
-	// Explicitly flush to ensure all data is written
-	csvWriter.Flush()
+	// The deferred Flush() will write any remaining buffered data.
+	// We must check for an error from the writer, which can happen
+	// during a Write or the final Flush.
 	if err := csvWriter.Error(); err != nil {
-		return fmt.Errorf("csv.Writer.Flush() failed: %w", err)
+		return fmt.Errorf("csv writer error: %w", err)
 	}
 
 	return nil

--- a/cli_output.go
+++ b/cli_output.go
@@ -725,7 +725,6 @@ func printCSVTable(out io.Writer, columnNames []string, rows []Row, skipColumnNa
 	}
 
 	csvWriter := csv.NewWriter(out)
-	defer csvWriter.Flush()
 
 	if !skipColumnNames {
 		if err := csvWriter.Write(columnNames); err != nil {
@@ -737,6 +736,12 @@ func printCSVTable(out io.Writer, columnNames []string, rows []Row, skipColumnNa
 		if err := csvWriter.Write(row); err != nil {
 			return err
 		}
+	}
+
+	// Explicitly flush to ensure all data is written
+	csvWriter.Flush()
+	if err := csvWriter.Error(); err != nil {
+		return fmt.Errorf("csv.Writer.Flush() failed: %w", err)
 	}
 
 	return nil

--- a/cli_output.go
+++ b/cli_output.go
@@ -96,9 +96,9 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 	// Early return if no columns - Spanner requires at least one column in SELECT,
 	// so this only happens for edge cases where no output is expected
 	if len(columnNames) == 0 {
-		// Log edge case where we have rows but no columns
+		// Log logic error where we have rows but no columns
 		if len(result.Rows) > 0 {
-			slog.Warn("printTableData called with empty column headers but non-empty rows",
+			slog.Error("printTableData called with empty column headers but non-empty rows - this indicates a logic error",
 				"rowCount", len(result.Rows))
 		}
 		return

--- a/cli_output_test.go
+++ b/cli_output_test.go
@@ -349,8 +349,11 @@ func TestHTMLAndXMLHelpers(t *testing.T) {
 	t.Run("printHTMLTable with empty input", func(t *testing.T) {
 		var buf bytes.Buffer
 		err := printHTMLTable(&buf, []string{}, []Row{}, false)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		if err == nil {
+			t.Error("expected error for empty columns, got nil")
+		}
+		if err != nil && err.Error() != "no columns to output" {
+			t.Errorf("unexpected error message: %v", err)
 		}
 		if buf.String() != "" {
 			t.Errorf("expected empty output, got: %q", buf.String())
@@ -360,8 +363,25 @@ func TestHTMLAndXMLHelpers(t *testing.T) {
 	t.Run("printXMLResultSet with empty input", func(t *testing.T) {
 		var buf bytes.Buffer
 		err := printXMLResultSet(&buf, []string{}, []Row{}, false)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		if err == nil {
+			t.Error("expected error for empty columns, got nil")
+		}
+		if err != nil && err.Error() != "no columns to output" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+		if buf.String() != "" {
+			t.Errorf("expected empty output, got: %q", buf.String())
+		}
+	})
+
+	t.Run("printCSVTable with empty input", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := printCSVTable(&buf, []string{}, []Row{}, false)
+		if err == nil {
+			t.Error("expected error for empty columns, got nil")
+		}
+		if err != nil && err.Error() != "no columns to output" {
+			t.Errorf("unexpected error message: %v", err)
 		}
 		if buf.String() != "" {
 			t.Errorf("expected empty output, got: %q", buf.String())

--- a/cli_output_test.go
+++ b/cli_output_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/MakeNowJust/heredoc/v2"
 )
 
 func TestPrintTableDataHTML(t *testing.T) {
@@ -216,8 +218,10 @@ func TestCLIFormatSystemVariable(t *testing.T) {
 		{"set TAB", "TAB", DisplayModeTab, false},
 		{"set HTML", "HTML", DisplayModeHTML, false},
 		{"set XML", "XML", DisplayModeXML, false},
+		{"set CSV", "CSV", DisplayModeCSV, false},
 		{"set html lowercase", "html", DisplayModeHTML, false},
 		{"set xml lowercase", "xml", DisplayModeXML, false},
+		{"set csv lowercase", "csv", DisplayModeCSV, false},
 		{"set invalid", "INVALID", DisplayModeTable, true},
 	}
 
@@ -252,6 +256,7 @@ func TestCLIFormatSystemVariableGetter(t *testing.T) {
 		{DisplayModeTab, "TAB"},
 		{DisplayModeHTML, "HTML"},
 		{DisplayModeXML, "XML"},
+		{DisplayModeCSV, "CSV"},
 		{DisplayMode(999), "TABLE"}, // Invalid mode should return default
 	}
 
@@ -389,4 +394,105 @@ func TestHTMLAndXMLHelpers(t *testing.T) {
 			t.Error("XML closing tag missing")
 		}
 	})
+}
+
+func TestPrintTableDataCSV(t *testing.T) {
+	tests := []struct {
+		name         string
+		result       *Result
+		skipColNames bool
+		wantOutput   string
+	}{
+		{
+			name: "simple CSV output",
+			result: &Result{
+				TableHeader: toTableHeader("num", "str", "bool"),
+				Rows: []Row{
+					{"1", "test", "true"},
+					{"2", "data", "false"},
+				},
+			},
+			wantOutput: heredoc.Doc(`
+				num,str,bool
+				1,test,true
+				2,data,false
+			`),
+		},
+		{
+			name: "CSV with special characters",
+			result: &Result{
+				TableHeader: toTableHeader("name", "description", "value"),
+				Rows: []Row{
+					{"John, Jr.", "Says \"Hello\"", "100"},
+					{"Jane\nDoe", "Has,comma", "$50"},
+					{"Bob", "Normal text", "75"},
+				},
+			},
+			wantOutput: heredoc.Doc(`
+				name,description,value
+				"John, Jr.","Says ""Hello""",100
+				"Jane
+				Doe","Has,comma",$50
+				Bob,Normal text,75
+			`),
+		},
+		{
+			name: "CSV with skip column names",
+			result: &Result{
+				TableHeader: toTableHeader("col1", "col2"),
+				Rows: []Row{
+					{"val1", "val2"},
+					{"val3", "val4"},
+				},
+			},
+			skipColNames: true,
+			wantOutput: heredoc.Doc(`
+				val1,val2
+				val3,val4
+			`),
+		},
+		{
+			name: "empty result",
+			result: &Result{
+				TableHeader: nil,
+				Rows:        []Row{},
+			},
+			wantOutput: "",
+		},
+		{
+			name: "CSV with quotes and newlines",
+			result: &Result{
+				TableHeader: toTableHeader("text"),
+				Rows: []Row{
+					{"Line 1\nLine 2"},
+					{"\"Quoted\""},
+					{"Normal"},
+				},
+			},
+			wantOutput: heredoc.Doc(`
+				text
+				"Line 1
+				Line 2"
+				"""Quoted"""
+				Normal
+			`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			sysVars := &systemVariables{
+				CLIFormat:       DisplayModeCSV,
+				SkipColumnNames: tt.skipColNames,
+			}
+
+			printTableData(sysVars, 0, &buf, tt.result)
+
+			got := buf.String()
+			if got != tt.wantOutput {
+				t.Errorf("printTableData() = %q, want %q", got, tt.wantOutput)
+			}
+		})
+	}
 }

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -19,7 +19,7 @@ TODO
   SELECT * FROM users;  -- Output without column headers
   ```
 - **Notes**:
-  - Affects table format (`CLI_FORMAT='TABLE'`) and tab format (`CLI_FORMAT='TAB'`)
+  - Affects table format (`CLI_FORMAT='TABLE'`), tab format (`CLI_FORMAT='TAB'`), CSV format (`CLI_FORMAT='CSV'`), HTML format (`CLI_FORMAT='HTML'`), and XML format (`CLI_FORMAT='XML'`)
   - Headers are always preserved in vertical format (`CLI_FORMAT='VERTICAL'`) as they are integral to the format
   - Can be set via `--skip-column-names` command-line flag
   - Useful for scripting and data processing where only raw data is needed
@@ -53,6 +53,7 @@ TODO
   - `TAB` - Tab-separated values (default for batch mode)
   - `HTML` - HTML table format
   - `XML` - XML format
+  - `CSV` - Comma-separated values (RFC 4180 compliant)
 - **Usage**: 
   ```sql
   SET CLI_FORMAT = 'VERTICAL';
@@ -64,15 +65,20 @@ TODO
   SET CLI_FORMAT = 'XML';
   SELECT * FROM users;  -- Output as XML
   
+  SET CLI_FORMAT = 'CSV';
+  SELECT * FROM users;  -- Output as CSV (comma-separated values)
+  
   SET CLI_FORMAT = 'TABLE_DETAIL_COMMENT';
   SELECT * FROM users;  -- Output as table with execution stats, all wrapped in /* */ comments
   ```
 - **Notes**:
   - Can be set via `--html` flag (sets to HTML format)
   - Can be set via `--xml` flag (sets to XML format)
+  - Can be set via `--csv` flag (sets to CSV format)
   - Can be set via `--table` flag (sets to TABLE format in batch mode)
   - HTML and XML formats are compatible with Google Cloud Spanner CLI
-  - All special characters are properly escaped in HTML and XML formats for security
+  - All special characters are properly escaped in HTML, XML, and CSV formats for security
+  - CSV format follows RFC 4180 standard with automatic escaping of commas, quotes, and newlines
   - The format affects how query results are displayed, not how they are executed
   - `TABLE_DETAIL_COMMENT` is particularly useful with `CLI_ECHO_INPUT=TRUE` and `CLI_MARKDOWN_CODEBLOCK=TRUE` for documentation
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ type spannerOptions struct {
 	HTML                      bool              `long:"html" description:"Display output in HTML format." default-mask:"-"`
 	XML                       bool              `long:"xml" description:"Display output in XML format." default-mask:"-"`
 	CSV                       bool              `long:"csv" description:"Display output in CSV format." default-mask:"-"`
-	Format                    string            `long:"format" description:"Output format (table, tab, vertical, html, xml, csv)" choice:"table" choice:"tab" choice:"vertical" choice:"html" choice:"xml" choice:"csv" default-mask:"-"`
+	Format                    string            `long:"format" description:"Output format (table, tab, vertical, html, xml, csv)" default-mask:"-"`
 	Verbose                   bool              `long:"verbose" short:"v" description:"Display verbose output." default-mask:"-"`
 	Credential                string            `long:"credential" description:"Use the specific credential file" default-mask:"-"`
 	Prompt                    *string           `long:"prompt" description:"Set the prompt to the specified format" default-mask:"spanner%t> "`
@@ -621,6 +621,13 @@ func ValidateSpannerOptions(opts *spannerOptions) error {
 	}
 	if formatCount > 1 {
 		return fmt.Errorf("invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive")
+	}
+
+	// Validate format string if provided
+	if opts.Format != "" {
+		if _, err := parseDisplayMode(opts.Format); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/main_flags_format_test.go
+++ b/main_flags_format_test.go
@@ -51,6 +51,36 @@ func TestValidateSpannerOptions_FormatFlags(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "only --csv",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				CSV:        true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "only --format=table",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				Format:     "table",
+			},
+			wantErr: false,
+		},
+		{
+			name: "only --format=csv",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				Format:     "csv",
+			},
+			wantErr: false,
+		},
+		{
 			name: "--table and --html are mutually exclusive",
 			opts: &spannerOptions{
 				ProjectId:  "test",
@@ -60,7 +90,7 @@ func TestValidateSpannerOptions_FormatFlags(t *testing.T) {
 				HTML:       true,
 			},
 			wantErr: true,
-			errMsg:  "invalid combination: --table, --html, and --xml are mutually exclusive",
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
 		},
 		{
 			name: "--table and --xml are mutually exclusive",
@@ -72,7 +102,7 @@ func TestValidateSpannerOptions_FormatFlags(t *testing.T) {
 				XML:        true,
 			},
 			wantErr: true,
-			errMsg:  "invalid combination: --table, --html, and --xml are mutually exclusive",
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
 		},
 		{
 			name: "--html and --xml are mutually exclusive",
@@ -84,7 +114,67 @@ func TestValidateSpannerOptions_FormatFlags(t *testing.T) {
 				XML:        true,
 			},
 			wantErr: true,
-			errMsg:  "invalid combination: --table, --html, and --xml are mutually exclusive",
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
+		},
+		{
+			name: "--table and --csv are mutually exclusive",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				Table:      true,
+				CSV:        true,
+			},
+			wantErr: true,
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
+		},
+		{
+			name: "--html and --csv are mutually exclusive",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				HTML:       true,
+				CSV:        true,
+			},
+			wantErr: true,
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
+		},
+		{
+			name: "--xml and --csv are mutually exclusive",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				XML:        true,
+				CSV:        true,
+			},
+			wantErr: true,
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
+		},
+		{
+			name: "--format and --table are mutually exclusive",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				Format:     "csv",
+				Table:      true,
+			},
+			wantErr: true,
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
+		},
+		{
+			name: "--format and --html are mutually exclusive",
+			opts: &spannerOptions{
+				ProjectId:  "test",
+				InstanceId: "test",
+				DatabaseId: "test",
+				Format:     "table",
+				HTML:       true,
+			},
+			wantErr: true,
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
 		},
 		{
 			name: "all three format flags are mutually exclusive",
@@ -97,7 +187,7 @@ func TestValidateSpannerOptions_FormatFlags(t *testing.T) {
 				XML:        true,
 			},
 			wantErr: true,
-			errMsg:  "invalid combination: --table, --html, and --xml are mutually exclusive",
+			errMsg:  "invalid combination: --table, --html, --xml, --csv, and --format are mutually exclusive",
 		},
 	}
 

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -79,6 +79,10 @@ func (th simpleTableHeader) internalRender(verbose bool) []string {
 
 // toTableHeader convert slice or variable arguments to TableHeader.
 // nil or empty slice will return untyped nil.
+//
+// Note: In practice, this should never receive empty input from Spanner query results
+// because Spanner requires at least one column in SELECT queries. Empty input might
+// occur only in client-side statements or error conditions.
 func toTableHeader[T interface {
 	string | []string | *sppb.StructType_Field | []*sppb.StructType_Field
 }](ss ...T) TableHeader {

--- a/system_variables.go
+++ b/system_variables.go
@@ -702,7 +702,7 @@ var systemVariableDefMap = map[string]systemVariableDef{
 		},
 	},
 	"CLI_FORMAT": {
-		Description: "Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated), HTML (HTML table), XML (XML format).",
+		Description: "Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated), HTML (HTML table), XML (XML format), CSV (comma-separated values).",
 		Accessor: accessor{
 			Setter: func(this *systemVariables, name, value string) error {
 				// Set the output format for query results.
@@ -714,24 +714,12 @@ var systemVariableDefMap = map[string]systemVariableDef{
 				//   TAB                - Tab-separated values (default for batch mode)
 				//   HTML               - HTML table format (--html flag)
 				//   XML                - XML format (--xml flag)
-				switch strings.ToUpper(unquoteString(value)) {
-				case "TABLE":
-					this.CLIFormat = DisplayModeTable
-				case "TABLE_COMMENT":
-					this.CLIFormat = DisplayModeTableComment
-				case "TABLE_DETAIL_COMMENT":
-					this.CLIFormat = DisplayModeTableDetailComment
-				case "VERTICAL":
-					this.CLIFormat = DisplayModeVertical
-				case "TAB":
-					this.CLIFormat = DisplayModeTab
-				case "HTML":
-					this.CLIFormat = DisplayModeHTML
-				case "XML":
-					this.CLIFormat = DisplayModeXML
-				default:
+				//   CSV                - Comma-separated values (RFC 4180)
+				mode, err := parseDisplayMode(unquoteString(value))
+				if err != nil {
 					return fmt.Errorf("invalid CLI_FORMAT value: %v", value)
 				}
+				this.CLIFormat = mode
 				return nil
 			},
 			Getter: func(this *systemVariables, name string) (map[string]string, error) {
@@ -753,6 +741,8 @@ var systemVariableDefMap = map[string]systemVariableDef{
 					formatStr = "HTML"
 				case DisplayModeXML:
 					formatStr = "XML"
+				case DisplayModeCSV:
+					formatStr = "CSV"
 				default:
 					// This should never happen as we validate on setter
 					formatStr = "TABLE"


### PR DESCRIPTION
## Summary

This PR implements CSV (Comma-Separated Values) output format support for query results as the first phase of implementing structured output formats requested in #203.

Fixes #392

## Changes

- Added `DisplayModeCSV` enum value to support CSV output format
- Implemented `printCSVTable` function using Go's `encoding/csv` package for RFC 4180 compliance
- Added `--csv` flag for easy CSV format selection (similar to `--html` and `--xml`)
- Added `--format` flag as a more generic option (accepts table/tab/vertical/html/xml/csv)
- Extracted common format parsing logic into `parseDisplayMode` function to avoid code duplication
- Updated `CLI_FORMAT` system variable to accept 'CSV' value (case-insensitive)
- Added comprehensive tests for CSV output including special character handling
- Updated documentation in README.md and system_variables.md

## Implementation Insights

### Design Decisions

1. **Using `encoding/csv` package**: Instead of manual string escaping, we use Go's standard library `encoding/csv` package which automatically handles RFC 4180 compliant escaping of special characters (commas, quotes, newlines).

2. **Error Handling**: The `printCSVTable` function returns an error when there are no columns to output. This provides better error handling compared to silently producing empty output.

3. **Function Extraction**: CSV output logic was extracted into a dedicated `printCSVTable` function to ensure proper defer scoping for `csvWriter.Flush()`. This follows the same pattern as HTML and XML output functions.

4. **Human-Readable Focus**: As specified in the requirements, this CSV format is designed for human-readable output, not for database import/export operations. It uses the same column formatting as the TABLE format.

5. **Multiple CLI Options**: 
   - Added `--csv` flag for consistency with existing `--html` and `--xml` flags
   - Added `--format` flag inspired by `gcloud spanner databases execute-sql --format=` for a more generic approach
   - All format flags are mutually exclusive to prevent confusion

6. **Code Reuse**: Extracted `parseDisplayMode` function to unify format string parsing between `opts.Format` and `CLI_FORMAT` system variable, eliminating code duplication.

### Test Coverage

The implementation includes comprehensive tests covering:
- Simple CSV output
- Special characters (commas, quotes, newlines)
- Skip column names option
- Empty result handling
- Complex scenarios with mixed special characters
- Mutual exclusivity of all format flags

All tests pass successfully, ensuring robust handling of edge cases.

### Compatibility

- The CSV format is case-insensitive (accepts both 'CSV' and 'csv')
- Works with `CLI_SKIP_COLUMN_NAMES` system variable
- Compatible with all existing output control features
- Backward compatible with existing format flags

## Usage Examples

```bash
# Using the new --csv flag
spanner-mycli --csv -e "SELECT * FROM users"

# Using the generic --format flag
spanner-mycli --format=csv -e "SELECT * FROM users"

# Setting format via system variable
spanner-mycli -e "SET CLI_FORMAT = 'CSV'; SELECT * FROM users"
```

## Test Plan

- [x] Run `make check` - all tests pass
- [x] Manual testing with various SQL queries containing special characters
- [x] Verify `SET CLI_FORMAT = "CSV";` works correctly
- [x] Verify CSV output with `CLI_SKIP_COLUMN_NAMES = TRUE`
- [x] Verify error handling for queries with no results
- [x] Verify mutual exclusivity of format flags
- [x] Test new `--csv` and `--format` flags

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF < /dev/null