### PR TITLE
refactor: separate ReadTimestamp and CommitTimestamp in Result struct

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -246,18 +246,12 @@ func (c *Cli) executeStatementInteractive(ctx context.Context, stmt Statement, i
 }
 
 func (c *Cli) updateSystemVariables(result *Result) {
-	// Update timestamps based on whether the statement had a result set
-	// Statements with result sets update ReadTimestamp, others update CommitTimestamp
-	if result.TableHeader != nil {
-		c.SystemVariables.ReadTimestamp = result.Timestamp
-		c.SystemVariables.CommitTimestamp = time.Time{}
-	} else {
-		c.SystemVariables.ReadTimestamp = time.Time{}
-		c.SystemVariables.CommitTimestamp = result.Timestamp
-	}
+	// Update timestamps - both ReadTimestamp and CommitTimestamp are now separate fields
+	c.SystemVariables.ReadTimestamp = result.ReadTimestamp
+	c.SystemVariables.CommitTimestamp = result.CommitTimestamp
 
 	if result.CommitStats != nil {
-		c.SystemVariables.CommitResponse = &sppb.CommitResponse{CommitStats: result.CommitStats, CommitTimestamp: timestamppb.New(result.Timestamp)}
+		c.SystemVariables.CommitResponse = &sppb.CommitResponse{CommitStats: result.CommitStats, CommitTimestamp: timestamppb.New(result.CommitTimestamp)}
 	} else {
 		c.SystemVariables.CommitResponse = nil
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -487,10 +487,10 @@ func TestResultLine(t *testing.T) {
 				Stats: QueryStats{
 					ElapsedTime: "10 msec",
 				},
-				Timestamp: ts,
+				CommitTimestamp: ts,
 			},
 			verbose: true,
-			want:    fmt.Sprintf("Query OK, 3 rows affected (10 msec)\ntimestamp:            %s\n", timestamp),
+			want:    fmt.Sprintf("Query OK, 3 rows affected (10 msec)\ncommit_timestamp:     %s\n", timestamp),
 		},
 		{
 			desc: "mutation in verbose mode (both of timestamp and mutation count exist)",
@@ -500,11 +500,11 @@ func TestResultLine(t *testing.T) {
 				Stats: QueryStats{
 					ElapsedTime: "10 msec",
 				},
-				CommitStats: &sppb.CommitResponse_CommitStats{MutationCount: 6},
-				Timestamp:   ts,
+				CommitStats:     &sppb.CommitResponse_CommitStats{MutationCount: 6},
+				CommitTimestamp: ts,
 			},
 			verbose: true,
-			want:    fmt.Sprintf("Query OK, 3 rows affected (10 msec)\ntimestamp:            %s\nmutation_count:       6\n", timestamp),
+			want:    fmt.Sprintf("Query OK, 3 rows affected (10 msec)\ncommit_timestamp:     %s\nmutation_count:       6\n", timestamp),
 		},
 		{
 			desc: "mutation in verbose mode (timestamp not exist)",
@@ -560,11 +560,11 @@ func TestResultLine(t *testing.T) {
 					OptimizerVersion:           "2",
 					OptimizerStatisticsPackage: "auto_20210829_05_22_28UTC",
 				},
-				Timestamp: ts,
+				ReadTimestamp: ts,
 			},
 			verbose: true,
 			want: fmt.Sprintf(`3 rows in set (10 msec)
-timestamp:            %s
+read_timestamp:       %s
 cpu time:             5 msec
 rows scanned:         10 rows
 deleted rows scanned: 1 rows
@@ -582,10 +582,10 @@ optimizer statistics: auto_20210829_05_22_28UTC
 					ElapsedTime:  "10 msec",
 					RowsReturned: "3",
 				},
-				Timestamp: ts,
+				ReadTimestamp: ts,
 			},
 			verbose: true,
-			want:    fmt.Sprintf("3 rows in set (10 msec)\ntimestamp:            %s\n", timestamp),
+			want:    fmt.Sprintf("3 rows in set (10 msec)\nread_timestamp:       %s\n", timestamp),
 		},
 		// New test cases for issue #414
 		{

--- a/integration_test.go
+++ b/integration_test.go
@@ -243,7 +243,8 @@ func compareResult[T any](t *testing.T, got T, expected T, customCmpOptions ...c
 	t.Helper()
 	opts := sliceOf[cmp.Option](
 		cmpopts.IgnoreFields(Result{}, "Stats"),
-		cmpopts.IgnoreFields(Result{}, "Timestamp"),
+		cmpopts.IgnoreFields(Result{}, "ReadTimestamp"),
+		cmpopts.IgnoreFields(Result{}, "CommitTimestamp"),
 		// Commit Stats is only provided by real instances
 		cmpopts.IgnoreFields(Result{}, "CommitStats"),
 		// Metrics are collected but not part of test expectations

--- a/output_default.tmpl
+++ b/output_default.tmpl
@@ -1,6 +1,7 @@
 {{- /*gotype: github.com/apstndb/spanner-mycli.OutputContext */ -}}
 {{if .Verbose -}}
-{{with .Timestamp -}}                       timestamp:            {{.}}{{"\n"}}{{end -}}
+{{with .ReadTimestamp -}}                   read_timestamp:       {{.}}{{"\n"}}{{end -}}
+{{with .CommitTimestamp -}}                 commit_timestamp:     {{.}}{{"\n"}}{{end -}}
 {{with .CommitStats.GetMutationCount -}}    mutation_count:       {{.}}{{"\n"}}{{end -}}
 {{if not .IsExecutedDML -}}
 {{with .Stats.CPUTime -}}                   cpu time:             {{.}}{{"\n"}}{{end -}}

--- a/output_full.tmpl
+++ b/output_full.tmpl
@@ -1,6 +1,7 @@
 {{- /*gotype: github.com/apstndb/spanner-mycli.OutputContext */ -}}
 {{if .Verbose -}}
-{{with .Timestamp -}}                       timestamp:            {{.}}{{"\n"}}{{end -}}
+{{with .ReadTimestamp -}}                   read_timestamp:       {{.}}{{"\n"}}{{end -}}
+{{with .CommitTimestamp -}}                 commit_timestamp:     {{.}}{{"\n"}}{{end -}}
 {{with .CommitStats.GetMutationCount -}}    mutation_count:       {{.}}{{"\n"}}{{end -}}
 {{with .Stats.ElapsedTime -}}               elapsed time:         {{.}}{{"\n"}}{{end -}}
 {{with .Stats.CPUTime -}}                   cpu time:             {{.}}{{"\n"}}{{end -}}

--- a/statement_processing.go
+++ b/statement_processing.go
@@ -160,10 +160,11 @@ type Result struct {
 	// IsExecutedDML indicates this is an executed DML statement (INSERT/UPDATE/DELETE) that can report affected rows
 	IsExecutedDML bool
 
-	Timestamp     time.Time
-	ForceVerbose  bool
-	CommitStats   *sppb.CommitResponse_CommitStats
-	KeepVariables bool
+	ReadTimestamp   time.Time // For SELECT/read-only transactions
+	CommitTimestamp time.Time // For COMMIT/DML operations
+	ForceVerbose    bool
+	CommitStats     *sppb.CommitResponse_CommitStats
+	KeepVariables   bool
 
 	TableHeader TableHeader
 

--- a/statements_explain_describe.go
+++ b/statements_explain_describe.go
@@ -111,7 +111,7 @@ func (s *ExplainLastQueryStatement) Execute(ctx context.Context, session *Sessio
 		return nil, err
 	}
 
-	result.Timestamp = session.systemVariables.LastQueryCache.Timestamp
+	result.ReadTimestamp = session.systemVariables.LastQueryCache.Timestamp
 	return result, nil
 }
 
@@ -216,10 +216,10 @@ func (s *DescribeStatement) Execute(ctx context.Context, session *Session) (*Res
 	}
 
 	result := &Result{
-		AffectedRows: len(rows),
-		TableHeader:  toTableHeader(describeColumnNames),
-		Timestamp:    timestamp,
-		Rows:         rows,
+		AffectedRows:  len(rows),
+		TableHeader:   toTableHeader(describeColumnNames),
+		ReadTimestamp: timestamp,
+		Rows:          rows,
 	}
 
 	return result, nil
@@ -245,7 +245,7 @@ func executeExplain(ctx context.Context, session *Session, sql string, isDML boo
 		return nil, err
 	}
 
-	result.Timestamp = timestamp
+	result.ReadTimestamp = timestamp
 	// EXPLAIN doesn't execute the statement, so it's not actually DML even if explaining DML
 
 	return result, nil
@@ -299,14 +299,14 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		if err != nil {
 			slog.Warn("failed to get read-only transaction timestamp", "err", err, "sql", sql)
 		} else {
-			result.Timestamp = ts
+			result.ReadTimestamp = ts
 		}
 	}
 
 	session.systemVariables.LastQueryCache = &LastQueryCache{
 		QueryPlan:  plan,
 		QueryStats: stats,
-		Timestamp:  result.Timestamp,
+		Timestamp:  result.ReadTimestamp,
 	}
 
 	return result, nil
@@ -393,7 +393,7 @@ func executeExplainAnalyzeDML(ctx context.Context, session *Session, sql string,
 	result.IsExecutedDML = true
 	result.AffectedRows = int(dmlResult.Affected)
 	result.AffectedRowsType = rowCountTypeExact
-	result.Timestamp = dmlResult.CommitResponse.CommitTs
+	result.CommitTimestamp = dmlResult.CommitResponse.CommitTs
 
 	return result, nil
 }

--- a/statements_mutations.go
+++ b/statements_mutations.go
@@ -47,8 +47,8 @@ func (s *MutateStatement) Execute(ctx context.Context, session *Session) (*Resul
 		return nil, err
 	}
 	return &Result{
-		CommitStats: result.CommitResponse.CommitStats,
-		Timestamp:   result.CommitResponse.CommitTs,
+		CommitStats:     result.CommitResponse.CommitStats,
+		CommitTimestamp: result.CommitResponse.CommitTs,
 	}, nil
 }
 

--- a/statements_partitioned_query.go
+++ b/statements_partitioned_query.go
@@ -35,11 +35,11 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 	}
 
 	return &Result{
-		TableHeader:  toTableHeader("Partition_Token"),
-		Rows:         rows,
-		AffectedRows: len(rows),
-		Timestamp:    ts,
-		ForceWrap:    true,
+		TableHeader:   toTableHeader("Partition_Token"),
+		Rows:          rows,
+		AffectedRows:  len(rows),
+		ReadTimestamp: ts,
+		ForceWrap:     true,
 	}, nil
 }
 
@@ -67,11 +67,11 @@ func (s *TryPartitionedQueryStatement) Execute(ctx context.Context, session *Ses
 	}
 
 	return &Result{
-		TableHeader:  toTableHeader("Root_Partitionable"),
-		Rows:         sliceOf(toRow("TRUE")),
-		AffectedRows: 1,
-		Timestamp:    ts,
-		ForceWrap:    true,
+		TableHeader:   toTableHeader("Root_Partitionable"),
+		Rows:          sliceOf(toRow("TRUE")),
+		AffectedRows:  1,
+		ReadTimestamp: ts,
+		ForceWrap:     true,
 	}, nil
 }
 

--- a/statements_transaction.go
+++ b/statements_transaction.go
@@ -65,7 +65,7 @@ func (s *BeginStatement) Execute(ctx context.Context, session *Session) (*Result
 		}
 
 		return &Result{
-			Timestamp: ts,
+			ReadTimestamp: ts,
 		}, nil
 	}
 
@@ -96,7 +96,7 @@ func (s *SetTransactionStatement) Execute(ctx context.Context, session *Session)
 		if err != nil {
 			return nil, err
 		}
-		result.Timestamp = ts
+		result.ReadTimestamp = ts
 		return result, nil
 	} else {
 		err := session.BeginReadWriteTransaction(ctx, attrs.isolationLevel, attrs.priority)
@@ -140,7 +140,7 @@ func (s *CommitStatement) Execute(ctx context.Context, session *Session) (*Resul
 			return nil, err
 		}
 
-		result.Timestamp = resp.CommitTs
+		result.CommitTimestamp = resp.CommitTs
 		result.CommitStats = resp.CommitStats
 		return result, nil
 	default:
@@ -196,6 +196,6 @@ func (s *BeginRoStatement) Execute(ctx context.Context, session *Session) (*Resu
 	}
 
 	return &Result{
-		Timestamp: ts,
+		ReadTimestamp: ts,
 	}, nil
 }


### PR DESCRIPTION
## Summary
This PR implements the refactoring described in #419 to separate the overloaded `Timestamp` field in the `Result` struct into two distinct fields: `ReadTimestamp` and `CommitTimestamp`.

## Problem
Previously, the `Result` struct had a single `Timestamp` field that was used for both:
- Read timestamps (for SELECT queries and read-only transactions)
- Commit timestamps (for COMMIT operations and DML statements)

This overloading made the code harder to understand and maintain.

## Changes
1. **Result struct refactoring**: Split `Timestamp` into `ReadTimestamp` and `CommitTimestamp` fields
2. **Updated all Result creation sites**:
   - `execute_sql.go`: Set `ReadTimestamp` for SELECT queries
   - `statements_transaction.go`: Set appropriate timestamp based on transaction type
   - `statements_mutations.go`: Set `CommitTimestamp` for mutations
   - `statements_explain_describe.go`: Use appropriate timestamp type
   - `statements_partitioned_query.go`: Set `ReadTimestamp` for partitioned queries
3. **System variable updates**: Modified `cli.go` to handle both timestamp types correctly
4. **Output template improvements**:
   - `output_default.tmpl` and `output_full.tmpl` now display:
     - `read_timestamp:` for read operations
     - `commit_timestamp:` for write operations
5. **OutputContext updates**: Added separate fields for both timestamp types
6. **Test updates**: Fixed all tests to use correct timestamp fields and expected output

## Benefits
- ✅ **Clearer semantics**: No ambiguity about what type of timestamp is being used
- ✅ **Better verbose output**: Timestamps are displayed with appropriate labels
- ✅ **Improved maintainability**: Clear separation of concerns
- ✅ **Type safety**: Less chance of using wrong timestamp type

## Testing
- All existing tests have been updated and pass successfully
- `make check` passes with no errors or warnings
- Verified that:
  - SELECT statements show `read_timestamp` in verbose mode
  - COMMIT/DML statements show `commit_timestamp` in verbose mode

Fixes #419