### PR TITLE
fix: update enumer calls to use Go 1.24 tool management

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,6 +18,9 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
+      - name: Install tools
+        run: |
+          go install -modfile=go.mod github.com/dmarkham/enumer
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,9 +18,11 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
       - name: Install tools
         run: |
-          go install -modfile=go.mod github.com/dmarkham/enumer
+          go install tool
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/enums/enums.go
+++ b/enums/enums.go
@@ -2,7 +2,7 @@ package enums
 
 // DisplayMode represents different output display formats
 //
-//go:generate enumer -type=DisplayMode -trimprefix=DisplayMode -transform=snake_upper
+//go:generate go tool enumer -type=DisplayMode -trimprefix=DisplayMode -transform=snake_upper
 type DisplayMode int
 
 const (
@@ -19,7 +19,7 @@ const (
 
 // AutocommitDMLMode represents the DML autocommit behavior
 //
-//go:generate enumer -type=AutocommitDMLMode -trimprefix=AutocommitDMLMode -transform=snake_upper
+//go:generate go tool enumer -type=AutocommitDMLMode -trimprefix=AutocommitDMLMode -transform=snake_upper
 type AutocommitDMLMode int
 
 const (
@@ -29,7 +29,7 @@ const (
 
 // ParseMode represents statement parsing behavior
 //
-//go:generate enumer -type=ParseMode -trimprefix=ParseMode -transform=snake_upper
+//go:generate go tool enumer -type=ParseMode -trimprefix=ParseMode -transform=snake_upper
 type ParseMode int
 
 const (
@@ -41,7 +41,7 @@ const (
 
 // ExplainFormat represents EXPLAIN output format
 //
-//go:generate enumer -type=ExplainFormat -trimprefix=ExplainFormat -transform=snake_upper
+//go:generate go tool enumer -type=ExplainFormat -trimprefix=ExplainFormat -transform=snake_upper
 type ExplainFormat int
 
 const (
@@ -53,7 +53,7 @@ const (
 
 // StreamingMode represents the streaming output mode.
 //
-//go:generate enumer -type=StreamingMode -trimprefix=StreamingMode -transform=snake_upper
+//go:generate go tool enumer -type=StreamingMode -trimprefix=StreamingMode -transform=snake_upper
 type StreamingMode int
 
 const (


### PR DESCRIPTION
## Summary
Fixes the goreleaser workflow that was failing for v0.22.0 release with the error:
```
enumer: executable file not found in $PATH
```

## Problem
The goreleaser workflow runs `go generate ./...` which requires the `enumer` tool, but it wasn't installed in the CI environment.

## Solution
1. **Updated goreleaser workflow**:
   - Added Go version 1.24 specification for tool management support
   - Added `go install tool` step to install all tools from go.mod tool directive
   - Follows the same pattern used in the Makefile's `build-tools` target

2. **Updated enumer go:generate directives**:
   - Changed from `enumer` to `go tool enumer` in all go:generate directives
   - Ensures enumer is called through Go's tool management system
   - Consistent with Go 1.24's tool directive approach

## Changes
- `.github/workflows/goreleaser.yml`: Added tool installation step and Go 1.24 version
- `enums/enums.go`: Updated all 5 go:generate directives to use `go tool enumer`

## Testing
- Verified `go generate ./enums` works locally with the updated directives
- The fix will be fully validated when the next tag is pushed and goreleaser runs

Relates to the failed v0.22.0 release attempt: https://github.com/apstndb/spanner-mycli/actions/runs/16889732016