### PR TITLE
fix: clear environment variables in TestMain for test isolation

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -135,10 +135,9 @@ func TestMain(m *testing.M) {
 	// Clear Spanner-related environment variables that could interfere with tests.
 	// This ensures test isolation from the user's environment.
 	// Individual tests can still set these variables using t.Setenv() when needed.
-	os.Unsetenv("SPANNER_PROJECT_ID")
-	os.Unsetenv("SPANNER_INSTANCE_ID")
-	os.Unsetenv("SPANNER_DATABASE_ID")
-	
+	_ = os.Unsetenv("SPANNER_PROJECT_ID")
+	_ = os.Unsetenv("SPANNER_INSTANCE_ID")
+	_ = os.Unsetenv("SPANNER_DATABASE_ID")
 	flag.Parse()
 
 	// Skip emulator setup in short mode


### PR DESCRIPTION
## Summary
- Clear SPANNER_* environment variables in TestMain to ensure test isolation
- Tests now pass regardless of user's environment variable settings
- Individual tests can still use t.Setenv() to test environment variable behavior

## Problem
Tests were failing when users had `SPANNER_PROJECT_ID`, `SPANNER_INSTANCE_ID`, or `SPANNER_DATABASE_ID` set in their environment. The go-flags library automatically reads these environment variables, causing test failures when tests expect empty or specific values.

## Solution
Added environment variable clearing to the existing TestMain in integration_test.go. This ensures tests run in a clean environment regardless of the user's settings.

## Test Results
All tests now pass even when environment variables are set:
```bash
SPANNER_PROJECT_ID=gcpug-public-spanner \
SPANNER_INSTANCE_ID=merpay-sponsored-instance \
SPANNER_DATABASE_ID=apstndb-sampledb3 \
go test -run "TestParseArgs|TestParseFlags|TestFlagSystemVariablePrecedence"
# PASS
```

Fixes #461