### PR TITLE
fix: exclude generated columns from DUMP INSERT statements

### DIFF
--- a/dependency_resolver_test.go
+++ b/dependency_resolver_test.go
@@ -116,7 +116,7 @@ func TestDependencyResolver_TopologicalSort(t *testing.T) {
 					"Employees": {
 						TableName: "Employees",
 						ForeignKeys: []FKReference{
-							{ParentTable: "Employees", ChildTable: "Employees", ChildColumn: "ManagerId"},
+							{ConstraintName: "FK_Employees_Manager", ParentTable: "Employees", ChildTable: "Employees"},
 						},
 						Level: 0,
 					},
@@ -421,8 +421,8 @@ func TestDependencyResolver_ComplexScenarios(t *testing.T) {
 			"Posts": {
 				TableName: "Posts",
 				ForeignKeys: []FKReference{
-					{ParentTable: "Users", ChildTable: "Posts", ChildColumn: "AuthorId"},
-					{ParentTable: "Users", ChildTable: "Posts", ChildColumn: "EditorId"},
+					{ConstraintName: "FK_Posts_Author", ParentTable: "Users", ChildTable: "Posts"},
+					{ConstraintName: "FK_Posts_Editor", ParentTable: "Users", ChildTable: "Posts"},
 				},
 				Level: 0,
 			},
@@ -557,8 +557,6 @@ func TestDependencyResolver_MultiColumnFK(t *testing.T) {
 						ConstraintName: "FK_User",
 						ParentTable:    "Users",
 						ChildTable:     "UserPreferences",
-						ChildColumn:    "UserId", // Would be first column of multi-column FK
-						ParentColumn:   "Id",
 					},
 				},
 				Level: 0,

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -167,10 +167,12 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 	}
 
 	// Set post-execution fields that were not handled by the processor
+	metrics.CompletionTime = time.Now()
 	if sysVars.Profile {
 		after := GetMemoryStats()
 		metrics.MemoryAfter = &after
 	}
+	result.Metrics = metrics
 
 	return result, nil
 }

--- a/execute_sql.go
+++ b/execute_sql.go
@@ -136,8 +136,13 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 		return nil, err
 	}
 
-	// Use the transaction directly for the query with PROFILE mode
-	iter := txn.Query(ctx, stmt)
+	// Prepare query options to preserve profile mode and priority
+	opts := spanner.QueryOptions{
+		Mode:     sppb.ExecuteSqlRequest_PROFILE.Enum(),
+		Priority: sysVars.RPCPriority,
+	}
+	// Use the transaction directly with query options
+	iter := txn.QueryWithOptions(ctx, stmt, opts)
 
 	// Decide whether to use streaming or buffered mode
 	useStreaming, processor := decideExecutionMode(ctx, session, fc, sysVars)

--- a/statements_dump.go
+++ b/statements_dump.go
@@ -87,6 +87,10 @@ func buildSelectQueryWithColumns(columns []string, tableName string) string {
 // NOTE: INFORMATION_SCHEMA queries cannot be used in read-write transactions.
 func getWritableColumnsWithTxn(ctx context.Context, txn *spanner.ReadOnlyTransaction, tableName string) ([]string, error) {
 	// Split table name to handle schema-qualified names (e.g., "myschema.Users" or just "Users")
+	// Cloud Spanner supports named schemas and schema-qualified table names (FQNs) as documented in:
+	// https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#names
+	// Table identifiers can only contain letters, numbers, and underscores, but schema-qualified
+	// names use dot notation to separate schema and table names.
 	parts := strings.Split(tableName, ".")
 	var tableSchema, tableNameOnly string
 


### PR DESCRIPTION
## Summary

This PR fixes issue #467 by excluding generated columns from DUMP INSERT statements. The fix ensures that DUMP output can be successfully reimported without errors.

## Problem

DUMP statements incorrectly included generated columns (STORED, virtual, TOKENLIST) in their INSERT statements, causing import failures with the error:
```
Cannot specify a value for column <COL> because it is a generated column
```

## Solution

Query `INFORMATION_SCHEMA.COLUMNS` with `IS_GENERATED = 'NEVER'` filter to identify writable columns, then build SELECT queries with only those columns for data export.

## Key Implementation Insights

### 1. Transaction Consistency Is Critical
**Problem**: Race conditions between schema queries and data export could cause inconsistencies if schema changes occur between operations.

**Solution**: Execute all INFORMATION_SCHEMA queries and data export within a single read-only transaction using the new `withReadOnlyTransactionOrStart` helper.

### 2. Deadlock Prevention Through Direct Transaction Usage
**Initial Issue**: Methods like `executeSQLWithFormat` and `RunQueryWithStats` acquire transaction locks internally, causing deadlocks when called within `withReadOnlyTransaction` callbacks.

**Evolution of Solution**:
1. First attempt: Created "Locked" variants of methods → Still deadlocked
2. Second attempt: Pass transaction context through all layers → Too complex
3. **Final solution**: Use `txn.QueryWithOptions()` directly instead of Session methods that manage their own transactions

This fundamental insight led to creating `executeSQLImplWithTxn` that bypasses Session transaction management while preserving query options (PROFILE mode and RPC priority).

### 3. Proper Column Quoting
Reserved SQL keywords used as column names must be quoted with backticks. The implementation uses:
```go
quotedColumns[i] = fmt.Sprintf("`%s`", col)
```

### 4. Schema-Qualified Table Name Support
**Added during review**: Enhanced table name parsing to support both simple and schema-qualified names (e.g., "myschema.Users"), making the implementation future-proof for non-default schemas. Cloud Spanner uses dots exclusively for schema qualification - table identifiers themselves can only contain letters, numbers, and underscores.

### 5. Complete Metrics Handling
**Fixed during review**: Ensured proper profiling support by:
- Setting `metrics.CompletionTime` for accurate timing
- Attaching metrics object to result for display
- Preserving PROFILE mode through `txn.QueryWithOptions()`

### 6. Code Refactoring Considerations
During review, we identified opportunities to reduce code duplication:
- Extracted `prepareFormatConfig()` to share format configuration logic
- Removed unnecessary wrapper functions like `getTablesForExportWithTxn`
- **Important**: Preserved metrics collection timing accuracy - `txn.QueryWithOptions()` must be called AFTER metrics initialization

## Implementation Details

### Core Components

1. **`getWritableColumnsWithTxn()`**: Queries INFORMATION_SCHEMA within transaction
2. **`buildSelectQueryWithColumns()`**: Constructs SELECT with quoted columns
3. **`executeSQLWithFormatAndTxn()`**: Executes SQL using provided transaction
4. **`withReadOnlyTransactionOrStart()`**: Ensures transaction context exists
5. **`executeSQLImplWithTxn()`**: New function that executes SQL within a transaction with proper query options

### Dependency Resolver Improvements

- Converted to struct-based processing using `spanner.SelectAll`
- Used `*string` instead of `spanner.NullString` for nullable values
- Added DISTINCT to queries to eliminate deduplication logic
- Simplified FKReference structure to essential fields only

## Testing

Added comprehensive test `TestDumpWithGeneratedColumns` that:
- Creates a table with multiple generated column types
- Verifies generated columns are excluded from INSERT statements
- Uses deterministic timestamps for predictable output
- Validates the exported SQL can be reimported successfully

## Related Discussions

This implementation revealed several architectural considerations:
- INFORMATION_SCHEMA queries cannot be used in read-write transactions
- Transaction management in spanner-mycli requires careful lock ordering
- The balance between code reuse and maintaining correct execution semantics (especially for profiling)
- Importance of preserving query options (PROFILE mode, RPC priority) when using transactions directly

Fixes #467

🤖 Generated with [Claude Code](https://claude.ai/code)
