### PR TITLE
feat: add --sample-database flag for initializing embedded emulator with official samples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,10 +62,13 @@ require (
 	cloud.google.com/go/compute/metadata v0.8.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
+	cloud.google.com/go/storage v1.56.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2118,6 +2118,8 @@ cloud.google.com/go/storage v1.40.0/go.mod h1:Rrj7/hKlG87BLqDJYtwR0fbPld8uJPbQ2u
 cloud.google.com/go/storage v1.41.0/go.mod h1:J1WCa/Z2FcgdEDuPUY8DxT5I+d9mFKsCepp5vR6Sq80=
 cloud.google.com/go/storage v1.42.0/go.mod h1:HjMXRFq65pGKFn6hxj6x3HCyR41uSB72Z0SO/Vn6JFQ=
 cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
+cloud.google.com/go/storage v1.56.1 h1:n6gy+yLnHn0hTwBFzNn8zJ1kqWfR91wzdM8hjRF4wP0=
+cloud.google.com/go/storage v1.56.1/go.mod h1:C9xuCZgFl3buo2HZU/1FncgvvOgTAs/rnh4gF4lMg0s=
 cloud.google.com/go/storagetransfer v1.5.0/go.mod h1:dxNzUopWy7RQevYFHewchb29POFv3/AaBgnhqzqiK0w=
 cloud.google.com/go/storagetransfer v1.6.0/go.mod h1:y77xm4CQV/ZhFZH75PLEXY0ROiS7Gh6pSKrM8dJyg6I=
 cloud.google.com/go/storagetransfer v1.7.0/go.mod h1:8Giuj1QNb1kfLAiWM1bN6dHzfdlDAVC9rv9abHot2W4=
@@ -2419,6 +2421,10 @@ github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3/go.mod h1:dppbR7CwXD4p
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.1/go.mod h1:itPGVDKf9cC/ov4MdvJ2QZ0khw4bfoo9jzwTJlaxy2k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 h1:UQUsRi8WTzhZntp5313l+CHIAT95ojUI2lpP/ExlZa4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 h1:owcC2UnmsZycprQ5RfRgjydWhuoxg71LUfyiQdijZuM=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0/go.mod h1:ZPpqegjbE99EPKsu3iUWV22A04wzGPcAY/ziSIQEEgs=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=

--- a/sample_databases.go
+++ b/sample_databases.go
@@ -1,0 +1,198 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"cloud.google.com/go/storage"
+	"github.com/cloudspannerecosystem/memefish"
+)
+
+const (
+	// gcsSamplesBase is the base path for Google Cloud Spanner sample databases
+	gcsSamplesBase = "gs://cloud-spanner-samples/"
+)
+
+// SampleDatabase represents a sample database configuration
+type SampleDatabase struct {
+	Dialect     databasepb.DatabaseDialect // SQL dialect
+	SchemaURI   string                     // URI to schema file (gs://, file://, https://)
+	DataURI     string                     // URI to data file (optional)
+	Description string                     // Human-readable description
+}
+
+// sampleDatabases is the registry of available sample databases
+var sampleDatabases = map[string]SampleDatabase{
+	"banking": {
+		Dialect:     databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		SchemaURI:   gcsSamplesBase + "banking/schema/banking-schema.sdl",
+		DataURI:     gcsSamplesBase + "banking/data-insert-statements/banking-inserts.sql",
+		Description: "Banking application with accounts and transactions",
+	},
+	"finance": {
+		Dialect:     databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		SchemaURI:   gcsSamplesBase + "finance/schema/finance-schema.sdl",
+		DataURI:     "",
+		Description: "Finance application schema (GoogleSQL)",
+	},
+	"finance-graph": {
+		Dialect:     databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		SchemaURI:   gcsSamplesBase + "finance-graph/schema/finance-graph-schema.sdl",
+		DataURI:     gcsSamplesBase + "finance-graph/data-insert-statements/finance-graph-inserts.sql",
+		Description: "Finance application with graph features",
+	},
+	"finance-pg": {
+		Dialect:     databasepb.DatabaseDialect_POSTGRESQL,
+		SchemaURI:   gcsSamplesBase + "finance/schema/finance-schema-pg.sdl",
+		DataURI:     "",
+		Description: "Finance application (PostgreSQL dialect)",
+	},
+	"gaming": {
+		Dialect:     databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		SchemaURI:   gcsSamplesBase + "gaming/schema/gaming-schema.sdl",
+		DataURI:     gcsSamplesBase + "gaming/data-insert-statements/gaming-inserts.sql",
+		Description: "Gaming application with players and scores",
+	},
+}
+
+// loadFromURI loads content from various URI schemes
+func loadFromURI(ctx context.Context, uri string) ([]byte, error) {
+	switch {
+	case strings.HasPrefix(uri, "gs://"):
+		// Google Cloud Storage
+		return loadFromGCS(ctx, uri)
+	case strings.HasPrefix(uri, "file://"):
+		// Local file system
+		path := strings.TrimPrefix(uri, "file://")
+		return os.ReadFile(path)
+	case strings.HasPrefix(uri, "https://") || strings.HasPrefix(uri, "http://"):
+		// HTTP(S) download
+		return loadFromHTTP(ctx, uri)
+	default:
+		return nil, fmt.Errorf("unsupported URI scheme: %s", uri)
+	}
+}
+
+// loadFromGCS loads content from Google Cloud Storage
+func loadFromGCS(ctx context.Context, uri string) ([]byte, error) {
+	// Parse gs://bucket/path/to/object
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid GCS URI: %w", err)
+	}
+
+	bucket := u.Host
+	object := strings.TrimPrefix(u.Path, "/")
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCS client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	reader, err := client.Bucket(bucket).Object(object).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open GCS object %s: %w", uri, err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	return io.ReadAll(reader)
+}
+
+// loadFromHTTP loads content from HTTP/HTTPS URLs
+func loadFromHTTP(ctx context.Context, uri string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", uri, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, uri)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// dialectToString converts a database dialect enum to a display string
+func dialectToString(dialect databasepb.DatabaseDialect) string {
+	if dialect == databasepb.DatabaseDialect_POSTGRESQL {
+		return "PostgreSQL"
+	}
+	return "GoogleSQL"
+}
+
+// ListAvailableSamples returns a formatted list of available sample databases
+func ListAvailableSamples() string {
+	var sb strings.Builder
+	sb.WriteString("Available sample databases:\n\n")
+
+	// Get sorted list of sample names
+	names := slices.Collect(maps.Keys(sampleDatabases))
+	slices.Sort(names)
+
+	// Calculate max width for formatting
+	maxNameLen := 0
+	for _, name := range names {
+		if len(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+	}
+
+	// Print samples in sorted order
+	for _, name := range names {
+		sample := sampleDatabases[name]
+		fmt.Fprintf(&sb, "  %-*s  %-11s  %s\n", maxNameLen, name, dialectToString(sample.Dialect), sample.Description)
+	}
+
+	sb.WriteString("\nUsage: spanner-mycli --embedded-emulator --sample-database=<name>\n")
+	return sb.String()
+}
+
+// ParseStatements parses DDL or DML statements from SQL/SDL content using memefish
+func ParseStatements(content []byte, filename string) ([]string, error) {
+	// Use memefish's SplitRawStatements to properly split statements
+	rawStmts, err := memefish.SplitRawStatements(filename, string(content))
+	if err != nil {
+		return nil, fmt.Errorf("failed to split statements: %w", err)
+	}
+
+	var statements []string
+	for _, rawStmt := range rawStmts {
+		stmt := strings.TrimSpace(rawStmt.Statement)
+		if stmt != "" {
+			statements = append(statements, stmt)
+		}
+	}
+
+	return statements, nil
+}

--- a/sample_databases_test.go
+++ b/sample_databases_test.go
@@ -1,0 +1,222 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
+
+func TestListAvailableSamples(t *testing.T) {
+	output := ListAvailableSamples()
+
+	// Check that all samples are listed
+	expectedSamples := []string{"banking", "finance", "finance-graph", "finance-pg", "gaming"}
+	for _, sample := range expectedSamples {
+		if !strings.Contains(output, sample) {
+			t.Errorf("ListAvailableSamples() missing sample %q", sample)
+		}
+	}
+
+	// Check for usage instruction
+	if !strings.Contains(output, "Usage:") {
+		t.Error("ListAvailableSamples() missing usage instruction")
+	}
+}
+
+func TestLoadFromHTTP(t *testing.T) {
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/test.sql" {
+			_, _ = w.Write([]byte("CREATE TABLE test (id INT64);"))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	// Test successful fetch
+	data, err := loadFromHTTP(ctx, server.URL+"/test.sql")
+	if err != nil {
+		t.Fatalf("loadFromHTTP() error = %v", err)
+	}
+
+	expected := "CREATE TABLE test (id INT64);"
+	if string(data) != expected {
+		t.Errorf("loadFromHTTP() = %q, want %q", string(data), expected)
+	}
+
+	// Test 404
+	_, err = loadFromHTTP(ctx, server.URL+"/notfound.sql")
+	if err == nil {
+		t.Error("loadFromHTTP() expected error for 404, got nil")
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	// Create temporary test file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.sql")
+	content := "INSERT INTO test VALUES (1);"
+	if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Test successful read
+	data, err := loadFromURI(ctx, "file://"+testFile)
+	if err != nil {
+		t.Fatalf("loadFromURI() error = %v", err)
+	}
+
+	if string(data) != content {
+		t.Errorf("loadFromURI() = %q, want %q", string(data), content)
+	}
+
+	// Test non-existent file
+	_, err = loadFromURI(ctx, "file:///nonexistent/file.sql")
+	if err == nil {
+		t.Error("loadFromURI() expected error for non-existent file, got nil")
+	}
+}
+
+func TestLoadFromURI_UnsupportedScheme(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := loadFromURI(ctx, "ftp://example.com/file.sql")
+	if err == nil {
+		t.Error("loadFromURI() expected error for unsupported scheme, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported URI scheme") {
+		t.Errorf("loadFromURI() error = %v, want error containing 'unsupported URI scheme'", err)
+	}
+}
+
+func TestParseStatements(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		filename string
+		want     []string
+	}{
+		{
+			name: "DDL statements",
+			content: `CREATE TABLE users (id INT64) PRIMARY KEY (id);
+CREATE INDEX idx_users ON users(id);`,
+			filename: "schema.sql",
+			want: []string{
+				"CREATE TABLE users (id INT64) PRIMARY KEY (id)",
+				"CREATE INDEX idx_users ON users(id)",
+			},
+		},
+		{
+			name: "DML statements",
+			content: `INSERT INTO users VALUES (1);
+INSERT INTO users VALUES (2);`,
+			filename: "data.sql",
+			want: []string{
+				"INSERT INTO users VALUES (1)",
+				"INSERT INTO users VALUES (2)",
+			},
+		},
+		{
+			name: "Statements with comments",
+			content: `-- This is a comment
+CREATE TABLE test (id INT64);
+/* Multi-line
+   comment */
+INSERT INTO test VALUES (1);`,
+			filename: "mixed.sql",
+			want: []string{
+				"-- This is a comment\nCREATE TABLE test (id INT64)",
+				"INSERT INTO test VALUES (1)",
+			},
+		},
+		{
+			name:     "Empty content",
+			content:  "",
+			filename: "empty.sql",
+			want:     []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseStatements([]byte(tt.content), tt.filename)
+			if err != nil {
+				t.Fatalf("ParseStatements() error = %v", err)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseStatements() returned %d statements, want %d", len(got), len(tt.want))
+				t.Errorf("Got: %v", got)
+				t.Errorf("Want: %v", tt.want)
+			}
+
+			for i := range got {
+				if i < len(tt.want) && got[i] != tt.want[i] {
+					t.Errorf("ParseStatements()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSampleDatabaseRegistry(t *testing.T) {
+	// Test that all expected samples are in registry
+	expectedSamples := map[string]databasepb.DatabaseDialect{
+		"banking":       databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		"finance":       databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		"finance-graph": databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+		"finance-pg":    databasepb.DatabaseDialect_POSTGRESQL,
+		"gaming":        databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL,
+	}
+
+	for name, expectedDialect := range expectedSamples {
+		sample, ok := sampleDatabases[name]
+		if !ok {
+			t.Errorf("Sample %q not found in registry", name)
+			continue
+		}
+
+		if sample.Dialect != expectedDialect {
+			t.Errorf("Sample %q has dialect %v, want %v", name, sample.Dialect, expectedDialect)
+		}
+
+		// Check that URIs are properly formatted
+		if !strings.HasPrefix(sample.SchemaURI, "gs://") {
+			t.Errorf("Sample %q has invalid schema URI: %q", name, sample.SchemaURI)
+		}
+
+		// finance and finance-pg don't have data URIs
+		if name != "finance" && name != "finance-pg" {
+			if !strings.HasPrefix(sample.DataURI, "gs://") {
+				t.Errorf("Sample %q has invalid data URI: %q", name, sample.DataURI)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements the `--sample-database` flag for initializing the embedded emulator with Google's official Spanner sample databases, as specified in #470.

## Changes

### New Features
- **`--sample-database=<name>`** flag to initialize emulator with official samples
- **`--list-samples`** flag to list available sample databases  
- Support for 5 official samples: `banking`, `finance`, `finance-graph`, `finance-pg`, `gaming`

### Implementation Details
- **URI-based resource loading** supporting multiple schemes:
  - `gs://` - Google Cloud Storage (for official samples)
  - `file://` - Local file system
  - `http://` / `https://` - HTTP(S) downloads
- **Integration with spanemuboost** for DDL/DML initialization
- **memefish** for proper SQL statement splitting
- **Automatic dialect detection** (PostgreSQL for `finance-pg`)

### Code Organization
- `sample_databases.go` - Core implementation with registry and URI loading
- `sample_databases_test.go` - Comprehensive test coverage
- Refactored to minimize code duplication and improve maintainability

## Test Plan

- [x] Unit tests for all URI loading functions
- [x] Tests for statement parsing
- [x] Sample registry validation tests
- [x] Manual testing with `--list-samples`
- [x] Error handling for invalid sample names
- [x] `make check` passes (all tests and lint)

## Usage Examples

```bash
# List available samples
spanner-mycli --list-samples

# Start emulator with banking sample
spanner-mycli --embedded-emulator --sample-database=banking

# Start with PostgreSQL sample
spanner-mycli --embedded-emulator --sample-database=finance-pg

# Use with specific database ID
spanner-mycli --embedded-emulator --sample-database=gaming --database=test-gaming
```

## Future Work

- Created #471 to extend URI loading functionality to other file-loading commands like `\.` meta command

Fixes #470

🤖 Generated with [Claude Code](https://claude.ai/code)
