### PR TITLE
test: add test case for DML with THEN RETURN returning no rows

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -711,6 +711,20 @@ optimizer statistics: auto_20210829_05_22_28UTC
 			want:    "Empty set (12 msec)\n",
 		},
 		{
+			desc: "DML with THEN RETURN no rows (has result set, is mutation, empty, verbose)",
+			result: &Result{
+				TableHeader:   toTableHeader("id", "name"), // Has result set from THEN RETURN
+				AffectedRows:  0,
+				IsExecutedDML: true,
+				CommitStats:   &sppb.CommitResponse_CommitStats{MutationCount: 0},
+				Stats: QueryStats{
+					ElapsedTime: "12 msec",
+				},
+			},
+			verbose: true,
+			want:    "Empty set (12 msec)\n",
+		},
+		{
 			desc: "SHOW VARIABLES (has result set)",
 			result: &Result{
 				TableHeader:  toTableHeader("name", "value"), // Has result set


### PR DESCRIPTION
## Summary

Adds a missing test case to `TestResultLine` for the scenario where a DML statement with `THEN RETURN` clause affects 0 rows.

This case has a non-nil `TableHeader` (because THEN RETURN defines a result set schema) but `AffectedRows == 0`, and should display `"Empty set"` — consistent with a SELECT returning no rows.

The test case was identified in the `misc/query-advice-output` WIP branch.

## Test case added

- `"DML with THEN RETURN no rows (has result set, is mutation, empty, verbose)"`: verifies `Empty set (12 msec)` output when `TableHeader` is set but `AffectedRows` is 0