### PR TITLE
docs: update file paths to reflect internal/mycli/ restructuring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,15 +65,16 @@ For full gh-helper command reference, see [dev-docs/issue-management.md](dev-doc
 ## Core Architecture Overview
 
 ### Critical Components
-- **main.go**: Entry point, CLI argument parsing
-- **session.go**: Database session management
-- **statements.go**: Core SQL statement processing
-- **system_variables.go**: System variable management
-- **client_side_statement_def.go**: **CRITICAL** - Defines all client-side statement patterns
+- **main.go**: Thin entry point, calls `internal/mycli.Main()`
+- **internal/mycli/app.go**: CLI argument parsing, configuration, `Main()` entry point
+- **internal/mycli/session.go**: Database session management
+- **internal/mycli/statements.go**: Core SQL statement processing
+- **internal/mycli/system_variables.go**: System variable management
+- **internal/mycli/client_side_statement_def.go**: **CRITICAL** - Defines all client-side statement patterns
 
 ### System Variable Conventions
 - CLI-specific variables **MUST** use `CLI_` prefix
-- All registrations in `system_variables_registry.go`
+- All registrations in `internal/mycli/system_variables_registry.go`
 - Details: [dev-docs/patterns/system-variables.md](dev-docs/patterns/system-variables.md)
 
 ### Regex Pattern Guidelines

--- a/dev-docs/architecture-guide.md
+++ b/dev-docs/architecture-guide.md
@@ -4,20 +4,23 @@ This document provides detailed architectural information for spanner-mycli deve
 
 ## Core Components
 
+All core Go source files reside in `internal/mycli/`. The root `main.go` is a thin wrapper.
+
 ### Entry Point and Configuration
-- **main.go**: Entry point, CLI argument parsing, configuration management
-- **session.go**: Database session management and Spanner client connections
-- **session_transaction_context.go**: Transaction context types and encapsulation methods
+- **main.go** (root): Thin entry point, calls `mycli.Main(version, installFrom)`
+- **internal/mycli/app.go**: `Main()` function, CLI argument parsing, configuration management
+- **internal/mycli/session.go**: Database session management and Spanner client connections
+- **internal/mycli/session_transaction_context.go**: Transaction context types and encapsulation methods
 
 ### Interactive Interface
-- **cli.go**: Main interactive CLI interface and batch processing
-- **cli_output.go**: Output formatting and display logic
-- **cli_readline.go**: Terminal input handling and readline integration
-- **cli_mcp.go**: MCP (Model Context Protocol) server integration
+- **internal/mycli/cli.go**: Main interactive CLI interface and batch processing
+- **internal/mycli/cli_output.go**: Output formatting and display logic
+- **internal/mycli/cli_readline.go**: Terminal input handling and readline integration
+- **internal/mycli/cli_mcp.go**: MCP (Model Context Protocol) server integration
 
 ### SQL Processing
-- **statements.go**: Core SQL statement processing and execution
-- **statements_*.go**: Specialized statement handlers:
+- **internal/mycli/statements.go**: Core SQL statement processing and execution
+- **internal/mycli/statements_*.go**: Specialized statement handlers:
   - `statements_mutations.go`: DML and mutation operations
   - `statements_schema.go`: DDL and schema operations
   - `statements_explain_describe.go`: Query analysis and introspection
@@ -27,8 +30,8 @@ This document provides detailed architectural information for spanner-mycli deve
   - `statements_query_profile.go`: Query profiling and performance analysis
 
 ### Configuration and Variables
-- **system_variables.go**: System variable definitions and management
-- **client_side_statement_def.go**: **CRITICAL** - Defines all client-side statement patterns and handlers
+- **internal/mycli/system_variables.go**: System variable definitions and management
+- **internal/mycli/client_side_statement_def.go**: **CRITICAL** - Defines all client-side statement patterns and handlers
 
 ## Output Handling Architecture
 
@@ -64,7 +67,7 @@ When implementing features that write output:
 
 ## Client-Side Statement System
 
-The `client_side_statement_def.go` file is the heart of spanner-mycli's extended SQL syntax.
+The `internal/mycli/client_side_statement_def.go` file is the heart of spanner-mycli's extended SQL syntax.
 
 ### Core Components
 
@@ -116,7 +119,7 @@ The `client_side_statement_def.go` file is the heart of spanner-mycli's extended
 
 ### Step-by-Step Process
 
-1. **Add Definition**: Add new entry to `clientSideStatementDefs` slice in `client_side_statement_def.go`
+1. **Add Definition**: Add new entry to `clientSideStatementDefs` slice in `internal/mycli/client_side_statement_def.go`
    ```go
    {
        Regex: regexp.MustCompile(`(?is)^SHOW\s+MY_FEATURE(?:\s+(.*))?$`),
@@ -489,19 +492,25 @@ make clean
 
 ```
 spanner-mycli/
-├── main.go                          # Entry point
-├── cli*.go                          # CLI interface components
-├── session.go                       # Session management
-├── statements*.go                   # Statement processing
-├── system_variables.go              # System variable management
-├── client_side_statement_def.go     # Statement definitions (CRITICAL)
-├── execute_sql.go                   # SQL execution logic
-├── internal/                        # Internal packages
-├── testdata/                        # Test fixtures
+├── main.go                          # Thin entry point (calls internal/mycli.Main())
+├── internal/
+│   ├── mycli/                       # Core application code (package mycli)
+│   │   ├── app.go                   # Main() function, CLI argument parsing
+│   │   ├── cli*.go                  # CLI interface components
+│   │   ├── session.go               # Session management
+│   │   ├── statements*.go           # Statement processing
+│   │   ├── system_variables.go      # System variable management
+│   │   ├── client_side_statement_def.go  # Statement definitions (CRITICAL)
+│   │   ├── execute_sql.go           # SQL execution logic
+│   │   ├── testdata/                # Test fixtures
+│   │   ├── samples/                 # Sample files
+│   │   └── official_docs/           # Upstream documentation
+│   ├── protostruct/                 # Protocol buffer utilities
+│   └── proto*/                      # Generated protobuf code
+├── enums/                           # Enum type definitions
 ├── docs/                            # User documentation
 ├── dev-docs/                        # Developer documentation
-├── bin/                             # Development tool symlinks (created by make build-tools)
-└── official_docs/                   # Upstream documentation
+└── bin/                             # Development tool symlinks (created by make build-tools)
 ```
 
 ## Related Documentation

--- a/dev-docs/issue-management.md
+++ b/dev-docs/issue-management.md
@@ -49,7 +49,7 @@ gh pr create --title "feat: new feature" --body "Description"
 go tool gh-helper reviews wait --timeout 15m
 
 # 3. For subsequent pushes: ALWAYS request Gemini review
-git add . && git commit -m "fix: address feedback" && git push
+git add <specific-files> && git commit -m "fix: address feedback" && git push
 go tool gh-helper reviews wait <PR> --request-review --timeout 15m
 ```
 
@@ -581,7 +581,7 @@ When working with sub-issues:
 ## Implementation Plan
 
 ### Phase 1: Core Implementation (independently mergeable)
-- **Files to Modify**: `main.go:90-95`, `system_variables.go:606`
+- **Files to Modify**: `internal/mycli/app.go:90-95`, `internal/mycli/system_variables.go:606`
 - **System Variable**: `CLI_FEATURE_NAME` (default: false)
 - **Implementation**: Brief description of approach
 - **Testing**: Test strategy and coverage

--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -16,7 +16,7 @@ This document provides detailed patterns and best practices for implementing sys
 
 3. **Implementation Template**:
    ```go
-   // In system_variables_registry.go
+   // In internal/mycli/system_variables_registry.go
    
    // Read/write variable (boolean)
    r.Register("CLI_VARIABLE_NAME", 
@@ -35,7 +35,7 @@ This document provides detailed patterns and best practices for implementing sys
            "Description explaining read-only nature"))
    ```
 
-4. **Testing Requirements**: Add comprehensive test cases to `system_variables_test.go` covering both successful operations and proper error handling for unimplemented setters
+4. **Testing Requirements**: Add comprehensive test cases to `internal/mycli/system_variables_test.go` covering both successful operations and proper error handling for unimplemented setters
 
 5. **Documentation**: Include clear descriptions explaining purpose, default values, and any access restrictions
 
@@ -44,8 +44,8 @@ This document provides detailed patterns and best practices for implementing sys
 - **Pattern**: Use generic VarHandler types (BoolVar, StringVar, IntVar, etc.) for type-safe variable handling
 - **Architecture**: Session behavior variables should be read-only to prevent runtime session state changes that could cause inconsistencies
 - **Error Handling**: The registry automatically handles type validation and returns appropriate errors
-- **Testing Strategy**: System variables test pattern in `system_variables_test.go` covers both SET/GET operations and proper error handling
-- **Code Organization**: All variable registrations are centralized in `system_variables_registry.go`
+- **Testing Strategy**: System variables test pattern in `internal/mycli/system_variables_test.go` covers both SET/GET operations and proper error handling
+- **Code Organization**: All variable registrations are centralized in `internal/mycli/system_variables_registry.go`
 
 ### Session-Init-Only Variables
 
@@ -57,7 +57,7 @@ Some variables can only be set before session creation because they control clie
 
 **Example**:
 ```go
-// In system_variables_registry.go
+// In internal/mycli/system_variables_registry.go
 r.Register("CLI_ENABLE_ADC_PLUS",
     BoolVar(&sv.EnableADCPlus).
         WithValidator(func(v bool) error {
@@ -235,7 +235,7 @@ if session.systemVariables.AsyncDDL {
 
 **Implementation Template**:
 ```go
-// In system_variables_registry.go
+// In internal/mycli/system_variables_registry.go
 r.Register("CLI_ASYNC_DDL",
     BoolVar(&sv.AsyncDDL).
         WithDescription("A boolean indicating whether DDL statements should be executed asynchronously. The default is false."))

--- a/dev-docs/testing-guidelines.md
+++ b/dev-docs/testing-guidelines.md
@@ -145,12 +145,12 @@ func TestPlatformSpecific(t *testing.T) {
 ## Priority Areas for Coverage Improvement
 
 ### High Priority
-1. **Core SQL Processing** (`statements.go`)
+1. **Core SQL Processing** (`internal/mycli/statements.go`)
    - Statement parsing and execution
    - Error handling paths
    - Edge cases in query processing
 
-2. **Session Management** (`session.go`)
+2. **Session Management** (`internal/mycli/session.go`)
    - Connection lifecycle
    - Transaction handling
    - Concurrent operations
@@ -159,13 +159,13 @@ func TestPlatformSpecific(t *testing.T) {
    - `internal/protostruct` - Protocol buffer utilities
    - Other internal utilities (excluding generated code)
 
-4. **System Variables** (`system_variables.go`)
+4. **System Variables** (`internal/mycli/system_variables.go`)
    - Variable validation
    - Type conversions
    - Default value handling
 
 ### Medium Priority
-1. **Client-side Statements** (`client_side_statement_def.go`)
+1. **Client-side Statements** (`internal/mycli/client_side_statement_def.go`)
    - Pattern matching
    - Command execution
    - Error scenarios


### PR DESCRIPTION
## Summary
Update all documentation references to reflect the package restructuring from PR #500 where Go source files moved from root to `internal/mycli/`.

## Key Changes
- **CLAUDE.md**: Updated Critical Components section with `internal/mycli/` paths, clarified `main.go` as thin wrapper
- **dev-docs/architecture-guide.md**: Updated Core Components paths, `client_side_statement_def.go` references, and File Organization directory structure diagram
- **dev-docs/testing-guidelines.md**: Updated Priority Areas filenames with `internal/mycli/` prefix
- **dev-docs/patterns/system-variables.md**: Updated code example comments referencing `system_variables_registry.go`
- **dev-docs/issue-management.md**: Updated template example file paths

## Test Plan
- [ ] Documentation-only change, no code affected
- [ ] All file paths verified to match actual locations after PR #500