### PR TITLE
refactor(core): extract metrics and filesafety sub-packages

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
 
+	"github.com/apstndb/spanner-mycli/internal/mycli/filesafety"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -264,7 +265,7 @@ func (c *Cli) updateSystemVariables(result *Result) {
 // executeSourceFile executes SQL statements from a file
 func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 	// Use common file safety checks (nil uses DefaultMaxFileSize - 100MB)
-	contents, err := SafeReadFile(filePath, nil)
+	contents, err := filesafety.SafeReadFile(filePath, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/mycli/cli_output.go
+++ b/internal/mycli/cli_output.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apstndb/go-runewidthex"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
 	"github.com/go-sprout/sprout"
 	"github.com/go-sprout/sprout/group/hermetic"
 	"github.com/mattn/go-runewidth"
@@ -185,7 +186,7 @@ type OutputContext struct {
 	CommitTimestamp string
 	Stats           *QueryStats
 	CommitStats     *sppb.CommitResponse_CommitStats
-	Metrics         *ExecutionMetrics
+	Metrics         *metrics.ExecutionMetrics
 }
 
 func sproutFuncMap() template.FuncMap {

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package mycli
+package filesafety
 
 import (
 	"fmt"

--- a/internal/mycli/filesafety/file_safety_test.go
+++ b/internal/mycli/filesafety/file_safety_test.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package mycli
+package filesafety
 
 import (
 	"os"

--- a/internal/mycli/metrics/execution_metrics.go
+++ b/internal/mycli/metrics/execution_metrics.go
@@ -1,4 +1,4 @@
-package mycli
+package metrics
 
 import (
 	"fmt"

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -28,6 +28,7 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/gsqlutils/stmtkind"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/go-json-experiment/json/jsontext"
@@ -218,8 +219,8 @@ type Result struct {
 
 	BatchInfo      *BatchInfo
 	PartitionCount int
-	Streamed       bool              // Indicates rows were streamed and not buffered
-	Metrics        *ExecutionMetrics // Performance metrics for query execution
+	Streamed       bool                      // Indicates rows were streamed and not buffered
+	Metrics        *metrics.ExecutionMetrics // Performance metrics for query execution
 }
 
 type Row []string


### PR DESCRIPTION
## Summary
Phase 2 of #497: Extract independent subsystems from `internal/mycli/` into focused sub-packages. After dependency analysis, 2 of the original 4 candidates were extracted (the other 2 are deferred due to coupling concerns).

## Key Changes
- **internal/mycli/metrics/**: Extracted `ExecutionMetrics`, `MemoryStats`, `GetMemoryStats()`, `LogMemoryStats()`, `CompareMemoryStats()` — pure stdlib, zero back-references
- **internal/mycli/filesafety/**: Extracted `FileSafetyOptions`, `SafeReadFile()`, `ValidateFileSafety()`, constants — pure stdlib, zero back-references
- **internal/mycli/execute_sql.go**: Updated imports, renamed local `metrics` params to `m` to avoid shadowing the `metrics` package import
- **internal/mycli/streaming.go**: Updated imports and param names
- **internal/mycli/cli.go, cli_output.go, statement_processing.go, sample_databases.go**: Updated imports and qualified references

## Deferred Candidates
| Package | Reason |
|---------|--------|
| `stream/` (StreamManager) | Deeply embedded in `systemVariables` struct, 7+ production files — high coupling |
| `sysvar/` (var_handler) | Unexported `errSetterReadOnly` used across multiple files — medium coupling |

## Test Plan
- [x] `make check` passes (test + lint + fmt-check)
- [x] `go build ./...` compiles all packages
- [x] `go vet ./...` passes
- [x] `filesafety` tests run in their own package

Fixes #497
