### PR TITLE
feat(fuzzy-finder): add table completion for MUTATE statement

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -909,6 +909,10 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		HandleSubmatch: func(matched []string) (Statement, error) {
 			return &MutateStatement{Table: unquoteIdentifier(matched[1]), Operation: matched[2], Body: matched[3]}, nil
 		},
+		Completion: []fuzzyArgCompletion{{
+			PrefixPattern:  regexp.MustCompile(`(?i)^\s*MUTATE\s+(\S*)$`),
+			CompletionType: fuzzyCompleteTable,
+		}},
 	},
 	// Query Profiles
 	{

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -165,6 +165,21 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgPrefix:      "Sin",
 			wantArgStartPos:    15,
 		},
+		// Argument completion: MUTATE → table
+		{
+			name:               "MUTATE with trailing space",
+			input:              "MUTATE ",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "",
+			wantArgStartPos:    7,
+		},
+		{
+			name:               "MUTATE with partial table",
+			input:              "MUTATE Sin",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "Sin",
+			wantArgStartPos:    7,
+		},
 		// Argument completion: DROP DATABASE → database
 		{
 			name:               "DROP DATABASE with trailing space",


### PR DESCRIPTION
## Summary
Add fuzzy table completion to the MUTATE statement, so `MUTATE <Ctrl+T>` triggers fuzzy table selection.

## Key Changes
- **client_side_statement_def.go**: Add `Completion` field with `fuzzyCompleteTable` to the MUTATE statement definition
- **fuzzy_finder_test.go**: Add test cases for MUTATE table completion (trailing space and partial table name)

## Test Plan
- [x] `make check` passes
- [x] Manual testing completed — `MUTATE <Ctrl+T>` opens fuzzy finder with table candidates

Fixes #512
