### PR TITLE
feat(fuzzy-finder): add role completion for USE <db> ROLE statement

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -41,6 +41,7 @@ const (
 	fuzzyCompleteVariable
 	fuzzyCompleteTable
 	fuzzyCompleteVariableValue
+	fuzzyCompleteRole
 )
 
 func (t fuzzyCompletionType) String() string {
@@ -53,6 +54,8 @@ func (t fuzzyCompletionType) String() string {
 		return "table"
 	case fuzzyCompleteVariableValue:
 		return "variable_value"
+	case fuzzyCompleteRole:
+		return "role"
 	default:
 		return fmt.Sprintf("unhandled fuzzyCompletionType: %d", t)
 	}
@@ -122,10 +125,16 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		HandleSubmatch: func(matched []string) (Statement, error) {
 			return &UseStatement{Database: unquoteIdentifier(matched[1]), Role: unquoteIdentifier(matched[2])}, nil
 		},
-		Completion: []fuzzyArgCompletion{{
-			PrefixPattern:  regexp.MustCompile(`(?i)^\s*USE\s+(\S*)$`),
-			CompletionType: fuzzyCompleteDatabase,
-		}},
+		Completion: []fuzzyArgCompletion{
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*USE\s+(\S+)\s+ROLE\s+(\S*)$`),
+				CompletionType: fuzzyCompleteRole,
+			},
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*USE\s+(\S*)$`),
+				CompletionType: fuzzyCompleteDatabase,
+			},
+		},
 	},
 	{
 		Descriptions: []clientSideStatementDescription{

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -229,6 +229,39 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgStartPos:    17,
 			wantContext:        "cli_format",
 		},
+		// Argument completion: USE <db> ROLE → role
+		{
+			name:               "USE db ROLE with trailing space",
+			input:              "USE mydb ROLE ",
+			wantCompletionType: fuzzyCompleteRole,
+			wantArgPrefix:      "",
+			wantArgStartPos:    14,
+			wantContext:        "mydb",
+		},
+		{
+			name:               "USE db ROLE with partial role",
+			input:              "USE mydb ROLE ad",
+			wantCompletionType: fuzzyCompleteRole,
+			wantArgPrefix:      "ad",
+			wantArgStartPos:    14,
+			wantContext:        "mydb",
+		},
+		{
+			name:               "use db role lowercase",
+			input:              "use db role ",
+			wantCompletionType: fuzzyCompleteRole,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+			wantContext:        "db",
+		},
+		{
+			name:               "USE db ROLE with leading spaces",
+			input:              "  USE mydb ROLE ",
+			wantCompletionType: fuzzyCompleteRole,
+			wantArgPrefix:      "",
+			wantArgStartPos:    16,
+			wantContext:        "mydb",
+		},
 		// Statement name completion (fallback)
 		{
 			name:               "USE without space falls through to statement name",


### PR DESCRIPTION
## Summary
Add fuzzy completion support for database roles in the `USE` statement. When typing `USE <db> ROLE` and pressing Ctrl+T, the fuzzy finder lists available database roles via the `ListDatabaseRoles` admin API.

## Key Changes
- **client_side_statement_def.go**: Added `fuzzyCompleteRole` enum value and role completion pattern for `USE <db> ROLE <partial>` (ordered before database pattern for correct specificity)
- **fuzzy_finder.go**: Added role completion header, network requirement, fetch dispatch, and `fetchRoleCandidates()` using `ListDatabaseRoles` API with sorted results
- **fuzzy_finder_test.go**: Added 4 test cases covering trailing space, partial input, case insensitivity, and leading spaces

## Test Plan
- [x] `make check` passes (test + lint + fmt-check)
- [x] Manual testing completed — role fuzzy finder works with Ctrl+T
- [x] Existing fuzzy completion tests pass (no regression)

Fixes #513
