### PR TITLE
feat(fuzzy-finder): add per-type fuzzy completion for SHOW CREATE

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -43,6 +43,11 @@ const (
 	fuzzyCompleteVariableValue
 	fuzzyCompleteRole
 	fuzzyCompleteOperation
+	fuzzyCompleteView
+	fuzzyCompleteIndex
+	fuzzyCompleteChangeStream
+	fuzzyCompleteSequence
+	fuzzyCompleteModel
 )
 
 func (t fuzzyCompletionType) String() string {
@@ -59,6 +64,16 @@ func (t fuzzyCompletionType) String() string {
 		return "role"
 	case fuzzyCompleteOperation:
 		return "operation"
+	case fuzzyCompleteView:
+		return "view"
+	case fuzzyCompleteIndex:
+		return "index"
+	case fuzzyCompleteChangeStream:
+		return "change_stream"
+	case fuzzyCompleteSequence:
+		return "sequence"
+	case fuzzyCompleteModel:
+		return "model"
 	default:
 		return fmt.Sprintf("unhandled fuzzyCompletionType: %d", t)
 	}
@@ -194,6 +209,28 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 			objectType := strings.ToUpper(whitespaceRe.ReplaceAllString(matched[1], " "))
 			schema, name := extractSchemaAndName(unquoteIdentifier(matched[2]))
 			return &ShowCreateStatement{ObjectType: objectType, Schema: schema, Name: name}, nil
+		},
+		Completion: []fuzzyArgCompletion{
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+CHANGE\s+STREAM\s+(\S*)$`),
+				CompletionType: fuzzyCompleteChangeStream,
+			},
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+VIEW\s+(\S*)$`),
+				CompletionType: fuzzyCompleteView,
+			},
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+INDEX\s+(\S*)$`),
+				CompletionType: fuzzyCompleteIndex,
+			},
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+SEQUENCE\s+(\S*)$`),
+				CompletionType: fuzzyCompleteSequence,
+			},
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+MODEL\s+(\S*)$`),
+				CompletionType: fuzzyCompleteModel,
+			},
 		},
 	},
 	{

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -302,6 +302,116 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgPrefix:      "",
 			wantArgStartPos:    15,
 		},
+		// Argument completion: SHOW CREATE VIEW → view
+		{
+			name:               "SHOW CREATE VIEW with trailing space",
+			input:              "SHOW CREATE VIEW ",
+			wantCompletionType: fuzzyCompleteView,
+			wantArgPrefix:      "",
+			wantArgStartPos:    17,
+		},
+		{
+			name:               "SHOW CREATE VIEW with partial name",
+			input:              "SHOW CREATE VIEW My",
+			wantCompletionType: fuzzyCompleteView,
+			wantArgPrefix:      "My",
+			wantArgStartPos:    17,
+		},
+		{
+			name:               "show create view lowercase",
+			input:              "show create view ",
+			wantCompletionType: fuzzyCompleteView,
+			wantArgPrefix:      "",
+			wantArgStartPos:    17,
+		},
+		// Argument completion: SHOW CREATE INDEX → index
+		{
+			name:               "SHOW CREATE INDEX with trailing space",
+			input:              "SHOW CREATE INDEX ",
+			wantCompletionType: fuzzyCompleteIndex,
+			wantArgPrefix:      "",
+			wantArgStartPos:    18,
+		},
+		{
+			name:               "SHOW CREATE INDEX with partial name",
+			input:              "SHOW CREATE INDEX Idx",
+			wantCompletionType: fuzzyCompleteIndex,
+			wantArgPrefix:      "Idx",
+			wantArgStartPos:    18,
+		},
+		{
+			name:               "show create index lowercase",
+			input:              "show create index ",
+			wantCompletionType: fuzzyCompleteIndex,
+			wantArgPrefix:      "",
+			wantArgStartPos:    18,
+		},
+		// Argument completion: SHOW CREATE CHANGE STREAM → change stream
+		{
+			name:               "SHOW CREATE CHANGE STREAM with trailing space",
+			input:              "SHOW CREATE CHANGE STREAM ",
+			wantCompletionType: fuzzyCompleteChangeStream,
+			wantArgPrefix:      "",
+			wantArgStartPos:    26,
+		},
+		{
+			name:               "SHOW CREATE CHANGE STREAM with partial name",
+			input:              "SHOW CREATE CHANGE STREAM My",
+			wantCompletionType: fuzzyCompleteChangeStream,
+			wantArgPrefix:      "My",
+			wantArgStartPos:    26,
+		},
+		{
+			name:               "show create change stream lowercase",
+			input:              "show create change stream ",
+			wantCompletionType: fuzzyCompleteChangeStream,
+			wantArgPrefix:      "",
+			wantArgStartPos:    26,
+		},
+		// Argument completion: SHOW CREATE SEQUENCE → sequence
+		{
+			name:               "SHOW CREATE SEQUENCE with trailing space",
+			input:              "SHOW CREATE SEQUENCE ",
+			wantCompletionType: fuzzyCompleteSequence,
+			wantArgPrefix:      "",
+			wantArgStartPos:    21,
+		},
+		{
+			name:               "SHOW CREATE SEQUENCE with partial name",
+			input:              "SHOW CREATE SEQUENCE My",
+			wantCompletionType: fuzzyCompleteSequence,
+			wantArgPrefix:      "My",
+			wantArgStartPos:    21,
+		},
+		{
+			name:               "show create sequence lowercase",
+			input:              "show create sequence ",
+			wantCompletionType: fuzzyCompleteSequence,
+			wantArgPrefix:      "",
+			wantArgStartPos:    21,
+		},
+		// Argument completion: SHOW CREATE MODEL → model
+		{
+			name:               "SHOW CREATE MODEL with trailing space",
+			input:              "SHOW CREATE MODEL ",
+			wantCompletionType: fuzzyCompleteModel,
+			wantArgPrefix:      "",
+			wantArgStartPos:    18,
+		},
+		{
+			name:               "SHOW CREATE MODEL with partial name",
+			input:              "SHOW CREATE MODEL My",
+			wantCompletionType: fuzzyCompleteModel,
+			wantArgPrefix:      "My",
+			wantArgStartPos:    18,
+		},
+		{
+			name:               "show create model lowercase",
+			input:              "show create model ",
+			wantCompletionType: fuzzyCompleteModel,
+			wantArgPrefix:      "",
+			wantArgStartPos:    18,
+		},
 		// Statement name completion (fallback)
 		{
 			name:               "USE without space falls through to statement name",


### PR DESCRIPTION
## Summary

Add per-type fuzzy completion for `SHOW CREATE <type>` so that pressing Ctrl+T after the type keyword suggests matching schema objects. Supports 5 types: VIEW, INDEX, CHANGE STREAM, SEQUENCE, and MODEL.

## Key Changes

- **client_side_statement_def.go**: Add 5 new `fuzzyCompletionType` constants and `Completion` entries on the existing SHOW CREATE definition with prefix patterns (CHANGE STREAM ordered first since it's multi-word)
- **fuzzy_finder.go**: Extract `fetchSchemaObjectCandidates` shared helper for INFORMATION_SCHEMA queries, refactor `fetchTableCandidates` to use it, add 5 new fetch functions (`fetchViewCandidates`, `fetchIndexCandidates`, `fetchChangeStreamCandidates`, `fetchSequenceCandidates`, `fetchModelCandidates`), 5 cache fields with schema-generation awareness, and update all switch statements (`requiresNetwork`, `getCachedCandidates`, `setCachedCandidates`, `fetchCandidates`, `completionHeader`)
- **fuzzy_finder_test.go**: Add 15 test cases (3 per type) to `TestDetectFuzzyContext` covering trailing space, partial name, and case-insensitive matching

## Development Insights

### Design Decision
Instead of the original "hidden statement definitions" approach from the issue, we add multiple `Completion` entries to the **existing** SHOW CREATE `clientSideStatementDef`. This follows the established pattern (USE has database+role, SET has variable+value) and avoids new infrastructure.

### INFORMATION_SCHEMA Column Names
Each table has different naming conventions: VIEWS uses `TABLE_SCHEMA`/`TABLE_NAME`, INDEXES uses `TABLE_SCHEMA`/`INDEX_NAME`, CHANGE_STREAMS uses `CHANGE_STREAM_SCHEMA`/`CHANGE_STREAM_NAME`, SEQUENCES uses `SCHEMA`/`NAME`, MODELS uses `MODEL_SCHEMA`/`MODEL_NAME`.

## Not in Scope
TABLE (#512/#518), ROLE (#513), SCHEMA (#520) — tracked separately.

## Test Plan
- [x] `make check` passes (test + lint + fmt-check)
- [x] Unit tests: `TestDetectFuzzyContext` covers prefix pattern matching for all 5 types
- [x] Manual testing: verified all 5 completion types work with live Spanner connection

Fixes #519
