### PR TITLE
feat(fuzzy-finder): add table completion for DUMP TABLES and SHOW CREATE TABLE

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -216,6 +216,10 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 				CompletionType: fuzzyCompleteChangeStream,
 			},
 			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+TABLE\s+(\S*)$`),
+				CompletionType: fuzzyCompleteTable,
+			},
+			{
 				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+VIEW\s+(\S*)$`),
 				CompletionType: fuzzyCompleteView,
 			},
@@ -329,6 +333,10 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 			tables := splitTableNames(matched[1])
 			return &DumpTablesStatement{Tables: tables}, nil
 		},
+		Completion: []fuzzyArgCompletion{{
+			PrefixPattern:  regexp.MustCompile(`(?i)^\s*DUMP\s+TABLES\s+(?:.*,\s*)?(\S*)$`),
+			CompletionType: fuzzyCompleteTable,
+		}},
 	},
 	// Operations
 	{

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -183,6 +183,42 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgPrefix:      "Sin",
 			wantArgStartPos:    7,
 		},
+		// Argument completion: DUMP TABLES → table
+		{
+			name:               "DUMP TABLES with trailing space",
+			input:              "DUMP TABLES ",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "DUMP TABLES with partial table",
+			input:              "DUMP TABLES Sin",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "Sin",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "dump tables lowercase",
+			input:              "dump tables ",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "DUMP TABLES second table after comma",
+			input:              "DUMP TABLES Singers, ",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "",
+			wantArgStartPos:    21,
+		},
+		{
+			name:               "DUMP TABLES second table partial",
+			input:              "DUMP TABLES Singers, Al",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "Al",
+			wantArgStartPos:    21,
+		},
 		// Argument completion: DROP DATABASE → database
 		{
 			name:               "DROP DATABASE with trailing space",
@@ -409,6 +445,28 @@ func TestDetectFuzzyContext(t *testing.T) {
 			name:               "show create model lowercase",
 			input:              "show create model ",
 			wantCompletionType: fuzzyCompleteModel,
+			wantArgPrefix:      "",
+			wantArgStartPos:    18,
+		},
+		// Argument completion: SHOW CREATE TABLE → table
+		{
+			name:               "SHOW CREATE TABLE with trailing space",
+			input:              "SHOW CREATE TABLE ",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "",
+			wantArgStartPos:    18,
+		},
+		{
+			name:               "SHOW CREATE TABLE with partial name",
+			input:              "SHOW CREATE TABLE Sin",
+			wantCompletionType: fuzzyCompleteTable,
+			wantArgPrefix:      "Sin",
+			wantArgStartPos:    18,
+		},
+		{
+			name:               "show create table lowercase",
+			input:              "show create table ",
+			wantCompletionType: fuzzyCompleteTable,
 			wantArgPrefix:      "",
 			wantArgStartPos:    18,
 		},


### PR DESCRIPTION
## Summary
Add `fuzzyCompleteTable` completion to two statements that accept table name arguments but previously lacked fuzzy completion.

## Key Changes
- **client_side_statement_def.go**: Add `Completion` entry to DUMP TABLES with regex supporting comma-separated multi-table input; add `fuzzyCompleteTable` to SHOW CREATE's existing completion list for TABLE type
- **fuzzy_finder_test.go**: Add 8 test cases (5 for DUMP TABLES including comma-separated scenarios, 3 for SHOW CREATE TABLE)

## Test Plan
- [x] `make check` passes
- [x] Manual testing completed

Fixes #518
