### PR TITLE
chore: clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,11 @@ docs-update:
 	@echo "Updating help output for README.md..."
 	@mkdir -p tmp
 	@script -q tmp/help_output.txt sh -c "stty cols 200; go run . --help"
-	@sed -n '/Usage:/,$$p' tmp/help_output.txt | sed '1s/.*Usage:/Usage:/' > tmp/help_clean.txt
+	@sed -n '/Usage:/,$$p' tmp/help_output.txt | sed '1s/.*Usage:/Usage:/' > tmp/help_clean.txt; \
+	if [ ! -s tmp/help_clean.txt ]; then \
+		echo "ERROR: 'Usage:' not found in help output" >&2; \
+		exit 1; \
+	fi
 	@go run . --statement-help > tmp/statement_help.txt
 	@echo "Generated files:"
 	@echo "  - tmp/help_clean.txt: --help output for README.md"


### PR DESCRIPTION
## Summary
- Remove obsolete `build-tools` target (Go 1.24 auto-downloads tools via go.mod tool directive)
- Remove broken `gh-review` target (used non-existent `reviews analyze` subcommand)
- Remove `.claude` symlink hack from `worktree-setup` (unnecessary and problematic in worktrees)
- Consolidate `.PHONY` declaration at top of file instead of scattered mid-file
- Remove emojis from all echo messages for cleaner output
- Add explanatory comment for `docs-update` explaining why `script(1)` is needed (go-flags uses `ioctl(TIOCGWINSZ)` for terminal width, ignoring `COLUMNS` env var)
- Move `test-quick` target to logical position near other test targets
- Update `help-dev` to reflect removed targets and align column spacing

## Test plan
- [x] `make check` passes (test + lint + fmt-check)
- [x] `make help-dev` output verified
- [x] `make docs-update` still works correctly with `script(1)` approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)