### PR TITLE
feat(fuzzy-finder): add schema completion for SHOW TABLES and SHOW CREATE SCHEMA

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -48,6 +48,7 @@ const (
 	fuzzyCompleteChangeStream
 	fuzzyCompleteSequence
 	fuzzyCompleteModel
+	fuzzyCompleteSchema
 )
 
 func (t fuzzyCompletionType) String() string {
@@ -74,6 +75,8 @@ func (t fuzzyCompletionType) String() string {
 		return "sequence"
 	case fuzzyCompleteModel:
 		return "model"
+	case fuzzyCompleteSchema:
+		return "schema"
 	default:
 		return fmt.Sprintf("unhandled fuzzyCompletionType: %d", t)
 	}
@@ -235,6 +238,10 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+MODEL\s+(\S*)$`),
 				CompletionType: fuzzyCompleteModel,
 			},
+			{
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+CREATE\s+SCHEMA\s+(\S*)$`),
+				CompletionType: fuzzyCompleteSchema,
+			},
 		},
 	},
 	{
@@ -249,6 +256,10 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		HandleSubmatch: func(matched []string) (Statement, error) {
 			return &ShowTablesStatement{Schema: unquoteIdentifier(matched[1])}, nil
 		},
+		Completion: []fuzzyArgCompletion{{
+			PrefixPattern:  regexp.MustCompile(`(?i)^\s*SHOW\s+TABLES\s+(\S*)$`),
+			CompletionType: fuzzyCompleteSchema,
+		}},
 	},
 	{
 		Descriptions: []clientSideStatementDescription{

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -470,6 +470,50 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgPrefix:      "",
 			wantArgStartPos:    18,
 		},
+		// Argument completion: SHOW TABLES → schema
+		{
+			name:               "SHOW TABLES with trailing space",
+			input:              "SHOW TABLES ",
+			wantCompletionType: fuzzyCompleteSchema,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "SHOW TABLES with partial arg",
+			input:              "SHOW TABLES My",
+			wantCompletionType: fuzzyCompleteSchema,
+			wantArgPrefix:      "My",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "show tables lowercase",
+			input:              "show tables ",
+			wantCompletionType: fuzzyCompleteSchema,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+		},
+		// Argument completion: SHOW CREATE SCHEMA → schema
+		{
+			name:               "SHOW CREATE SCHEMA with trailing space",
+			input:              "SHOW CREATE SCHEMA ",
+			wantCompletionType: fuzzyCompleteSchema,
+			wantArgPrefix:      "",
+			wantArgStartPos:    19,
+		},
+		{
+			name:               "SHOW CREATE SCHEMA with partial arg",
+			input:              "SHOW CREATE SCHEMA My",
+			wantCompletionType: fuzzyCompleteSchema,
+			wantArgPrefix:      "My",
+			wantArgStartPos:    19,
+		},
+		{
+			name:               "show create schema lowercase",
+			input:              "show create schema ",
+			wantCompletionType: fuzzyCompleteSchema,
+			wantArgPrefix:      "",
+			wantArgStartPos:    19,
+		},
 		// Statement name completion (fallback)
 		{
 			name:               "USE without space falls through to statement name",


### PR DESCRIPTION
## Summary
Add fuzzy completion for schema names in `SHOW TABLES [schema]` and `SHOW CREATE SCHEMA <name>` statements, closing the gap where these statements had no argument completion.

## Key Changes
- **client_side_statement_def.go**: Added `fuzzyCompleteSchema` enum value with `"schema"` string representation. Added completion entry to SHOW CREATE statement for `SCHEMA` type, and added `Completion` field to SHOW TABLES statement definition.
- **fuzzy_finder.go**: Added `schemaCache` field, `"Schemas"` header, network/cache/dispatch plumbing, and `fetchSchemaCandidates()` which queries `INFORMATION_SCHEMA.SCHEMATA` for schema names (single-column query, distinct from `fetchSchemaObjectCandidates` which expects 2 columns for schema-qualified objects).
- **fuzzy_finder_test.go**: Added 6 `TestDetectFuzzyContext` cases covering both statements with trailing space, partial arg, and lowercase variants.

## Design Decision
`fetchSchemaCandidates` uses a direct single-column query (`SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA`) instead of reusing `fetchSchemaObjectCandidates` (which expects 2 columns: schema, name). Schemas are the namespace themselves, not objects within a namespace.

## Test Plan
- [x] `make check` passes (test + lint + fmt-check)
- [x] `TestDetectFuzzyContext` passes for all 6 new schema completion cases
- [x] `go_diagnostics` clean on all modified files

Fixes #520
