### PR TITLE
feat(fuzzy-finder): add UNSET PARAM statement and param name completion

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -49,6 +49,7 @@ const (
 	fuzzyCompleteSequence
 	fuzzyCompleteModel
 	fuzzyCompleteSchema
+	fuzzyCompleteParam
 )
 
 func (t fuzzyCompletionType) String() string {
@@ -77,6 +78,8 @@ func (t fuzzyCompletionType) String() string {
 		return "model"
 	case fuzzyCompleteSchema:
 		return "schema"
+	case fuzzyCompleteParam:
+		return "param"
 	default:
 		return fmt.Sprintf("unhandled fuzzyCompletionType: %d", t)
 	}
@@ -940,6 +943,11 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		HandleSubmatch: func(matched []string) (Statement, error) {
 			return &SetParamTypeStatement{Name: matched[1], Type: matched[2]}, nil
 		},
+		Completion: []fuzzyArgCompletion{{
+			PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+PARAM\s+([^\s=]*)$`),
+			CompletionType: fuzzyCompleteParam,
+			Suffix:         " ",
+		}},
 	},
 	{
 		Descriptions: []clientSideStatementDescription{
@@ -964,6 +972,22 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		HandleSubmatch: func(matched []string) (Statement, error) {
 			return &ShowParamsStatement{}, nil
 		},
+	},
+	{
+		Descriptions: []clientSideStatementDescription{
+			{
+				Usage:  `Unset query parameter`,
+				Syntax: `UNSET PARAM <name>`,
+			},
+		},
+		Pattern: regexp.MustCompile(`(?is)^UNSET\s+PARAM\s+(\S+)$`),
+		HandleSubmatch: func(matched []string) (Statement, error) {
+			return &UnsetParamStatement{Name: matched[1]}, nil
+		},
+		Completion: []fuzzyArgCompletion{{
+			PrefixPattern:  regexp.MustCompile(`(?i)^\s*UNSET\s+PARAM\s+(\S*)$`),
+			CompletionType: fuzzyCompleteParam,
+		}},
 	},
 	// Mutation
 	{

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -514,6 +514,53 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgPrefix:      "",
 			wantArgStartPos:    19,
 		},
+		// Argument completion: SET PARAM → param
+		{
+			name:               "SET PARAM with trailing space",
+			input:              "SET PARAM ",
+			wantCompletionType: fuzzyCompleteParam,
+			wantArgPrefix:      "",
+			wantArgStartPos:    10,
+			wantSuffix:         " ",
+		},
+		{
+			name:               "SET PARAM with partial name",
+			input:              "SET PARAM my_p",
+			wantCompletionType: fuzzyCompleteParam,
+			wantArgPrefix:      "my_p",
+			wantArgStartPos:    10,
+			wantSuffix:         " ",
+		},
+		{
+			name:               "set param lowercase",
+			input:              "set param ",
+			wantCompletionType: fuzzyCompleteParam,
+			wantArgPrefix:      "",
+			wantArgStartPos:    10,
+			wantSuffix:         " ",
+		},
+		// Argument completion: UNSET PARAM → param
+		{
+			name:               "UNSET PARAM with trailing space",
+			input:              "UNSET PARAM ",
+			wantCompletionType: fuzzyCompleteParam,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "UNSET PARAM with partial name",
+			input:              "UNSET PARAM my_p",
+			wantCompletionType: fuzzyCompleteParam,
+			wantArgPrefix:      "my_p",
+			wantArgStartPos:    12,
+		},
+		{
+			name:               "unset param lowercase",
+			input:              "unset param ",
+			wantCompletionType: fuzzyCompleteParam,
+			wantArgPrefix:      "",
+			wantArgStartPos:    12,
+		},
 		// Statement name completion (fallback)
 		{
 			name:               "USE without space falls through to statement name",

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -670,6 +670,22 @@ func TestParameterStatements(t *testing.T) {
 			},
 		},
 		{
+			desc: "UNSET PARAM removes a parameter",
+			stmtResults: []stmtResult{
+				srKeep("SET PARAM a = 1"),
+				srKeep("SET PARAM b = 2"),
+				srKeep("UNSET PARAM a"),
+				{
+					"SHOW PARAMS",
+					&Result{
+						KeepVariables: true,
+						TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),
+						Rows:          sliceOf(toRow("b", "VALUE", "2")),
+					},
+				},
+			},
+		},
+		{
 			desc: "CLI_TRY_PARTITION_QUERY with parameters",
 			stmtResults: []stmtResult{
 				srKeep("SET CLI_TRY_PARTITION_QUERY = TRUE"),

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -916,6 +916,11 @@ TABLE Singers (42)
 			want:  &ShowParamsStatement{},
 		},
 		{
+			desc:  "UNSET PARAM statement",
+			input: `UNSET PARAM my_param`,
+			want:  &UnsetParamStatement{Name: "my_param"},
+		},
+		{
 			desc:  "SHOW DDLS statement",
 			input: `SHOW DDLS`,
 			want:  &ShowDdlsStatement{},

--- a/internal/mycli/statements_params.go
+++ b/internal/mycli/statements_params.go
@@ -3,6 +3,7 @@ package mycli
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 
@@ -34,6 +35,20 @@ func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*R
 		Rows:          rows,
 		KeepVariables: true,
 	}, nil
+}
+
+type UnsetParamStatement struct {
+	Name string
+}
+
+func (s *UnsetParamStatement) isDetachedCompatible() {}
+
+func (s *UnsetParamStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	if _, ok := session.systemVariables.Params[s.Name]; !ok {
+		return nil, fmt.Errorf("unknown parameter: %s", s.Name)
+	}
+	delete(session.systemVariables.Params, s.Name)
+	return &Result{KeepVariables: true}, nil
 }
 
 type SetParamTypeStatement struct {


### PR DESCRIPTION
## Summary

Add `UNSET PARAM` statement to remove query parameters, and fuzzy completion (Ctrl+T) for parameter names in both `SET PARAM` and `UNSET PARAM` statements.

## Key Changes

- **client_side_statement_def.go**: Add `fuzzyCompleteParam` completion type with `String()` support; add UNSET PARAM statement definition with completion pattern; add completion to SET PARAM (type form) with space suffix
- **statements_params.go**: Add `UnsetParamStatement` struct — deletes parameter from session, returns error if param doesn't exist, works in detached mode
- **fuzzy_finder.go**: Add `fetchParamCandidates()` reading in-memory params (no network call), showing `name [KIND] sql` format; wire into `fetchCandidates()` switch and `completionHeader()` ("Query Parameters")
- **fuzzy_finder_test.go**: Add 6 `TestDetectFuzzyContext` cases for SET PARAM and UNSET PARAM (including case-insensitive)
- **statement_processing_test.go**: Add UNSET PARAM parsing test
- **integration_test.go**: Add UNSET PARAM integration test (SET two params, UNSET one, verify via SHOW PARAMS)

## Known Limitations

`SET PARAM` completion is only reachable after typing `SET PARAM ` (with trailing space) because `SET ` triggers system variable completion first. Tracked in #532.

## Test Plan

- [x] `make check` passes (test + lint + fmt-check)
- [x] Manual testing: `SET PARAM` / `UNSET PARAM` completion works with Ctrl+T
- [x] Manual testing: `UNSET PARAM` removes parameter, errors on non-existent

Fixes #524
