### PR TITLE
chore: improve release-prep skill robustness and UX

### DIFF
--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -27,9 +27,9 @@ git log ${LAST_TAG}..origin/main --oneline
 
 Parse PR numbers from the output (format: `... (#NNN)`). Use the first and last PR numbers to form the range.
 
-3. Analyze PRs for label classification:
+3. Analyze PRs for label classification. Replace `<FIRST_PR>` and `<LAST_PR>` with the PR numbers derived in step 2:
 ```bash
-go tool gh-helper releases analyze --pr-range ${FIRST_PR}-${LAST_PR}
+go tool gh-helper releases analyze --pr-range <FIRST_PR>-<LAST_PR>
 ```
 
 4. Review the analysis output for:
@@ -48,7 +48,7 @@ go tool gh-helper labels add ignore-for-release --items <PR_NUMBERS>
 
 6. Re-analyze to verify all PRs are properly labeled:
 ```bash
-go tool gh-helper releases analyze --pr-range ${FIRST_PR}-${LAST_PR}
+go tool gh-helper releases analyze --pr-range <FIRST_PR>-<LAST_PR>
 # Confirm: readyForRelease: true
 ```
 


### PR DESCRIPTION
## Summary
Improve the release-prep Claude skill to be more robust and user-friendly based on issues encountered during the v0.27.0 release.

## Key Changes
- **release-prep.md**: Replace fragile `grep -oE` regex chain (which caused shell escape errors when loaded as a skill) with natural language instructions for parsing PR numbers from `git log` output
- **release-prep.md**: Add auto-increment minor version when no version argument is provided
- **release-prep.md**: Disambiguate `<VERSION>` vs `<BOOST_VERSION>` for spanemuboost lookups
- **release-prep.md**: Use `--notes-file` instead of inline `--notes` for release note editing
- **release-prep.md**: Add explicit user confirmation step before pushing the release tag

## Development Insights

### Discoveries
- Regex patterns with parentheses in skill markdown files cause shell escape issues when loaded as Claude skills — the `grep -oE '\(#[0-9]+\)'` pattern was parsed as "Invalid regular expression: missing )"
- Natural language instructions for Claude to parse structured output (like git log) are more robust than fragile shell pipelines in skill definitions

## Test Plan
- [x] `make check` passes (no code changes, only skill definition)
- [x] Manually verified during v0.27.0 release