### PR TITLE
refactor: replace CurrentSession *Session with inTransaction callback

### DIFF
--- a/internal/mycli/main_test.go
+++ b/internal/mycli/main_test.go
@@ -720,10 +720,10 @@ func Test_initializeSystemVariables(t *testing.T) {
 
 			// Use cmp.Diff for comparison, ignoring unexported fields and specific fields
 			// that are hard to compare directly (e.g., *template.Template, *descriptorpb.FileDescriptorSet)
-			// and those that are set later in run() (e.g., EnableProgressBar, CurrentSession, WithoutAuthentication)
+			// and those that are set later in run() (e.g., EnableProgressBar, WithoutAuthentication)
 			if diff := cmp.Diff(tt.want, *got,
 				cmpopts.IgnoreUnexported(systemVariables{}),
-				cmpopts.IgnoreFields(systemVariables{}, "Display.OutputTemplate", "Internal.ProtoDescriptor", "Display.EnableProgressBar", "CurrentSession", "Connection.WithoutAuthentication", "Registry"), // Removed Params from here
+				cmpopts.IgnoreFields(systemVariables{}, "Display.OutputTemplate", "Internal.ProtoDescriptor", "Display.EnableProgressBar", "Connection.WithoutAuthentication", "Registry"), // Removed Params from here
 				cmpopts.IgnoreFields(systemVariables{}, "Display.ParsedAnalyzeColumns"),
 				cmpopts.EquateApproxTime(time.Microsecond),
 				protocmp.Transform(),
@@ -811,6 +811,7 @@ func Test_newSystemVariablesWithDefaults(t *testing.T) {
 
 	if diff := cmp.Diff(want, got,
 		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreUnexported(systemVariables{}),
 		cmpopts.IgnoreFields(systemVariables{}, "Display.OutputTemplate", "Display.ParsedAnalyzeColumns", "Registry"), // Ignore template and function pointer comparisons
 	); diff != "" {
 		t.Errorf("newSystemVariablesWithDefaults() mismatch (-want +got):\n%s", diff)
@@ -1014,6 +1015,7 @@ func Test_createSystemVariablesFromOptions(t *testing.T) {
 
 			// Compare key fields
 			if diff := cmp.Diff(test.want, *got,
+				cmpopts.IgnoreUnexported(systemVariables{}),
 				cmpopts.IgnoreFields(systemVariables{}, "Display.ParsedAnalyzeColumns", "Display.OutputTemplate", "Registry"), // Ignore complex fields for this test
 				cmpopts.EquateEmpty(),
 			); diff != "" {

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -290,7 +290,7 @@ func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.Cl
 		txn:             NewTransactionManager(client, sysVars, clientConfig),
 		systemVariables: sysVars,
 	}
-	sysVars.CurrentSession = session
+	sysVars.inTransaction = session.InTransaction
 
 	return session, nil
 }
@@ -324,7 +324,7 @@ func NewAdminSession(ctx context.Context, sysVars *systemVariables, opts ...opti
 		txn:             NewTransactionManager(nil, sysVars, clientConfig),
 		systemVariables: sysVars,
 	}
-	sysVars.CurrentSession = session
+	sysVars.inTransaction = session.InTransaction
 
 	// Validate instance exists
 	exists, err := session.InstanceExists()

--- a/internal/mycli/session_modes_unit_test.go
+++ b/internal/mycli/session_modes_unit_test.go
@@ -41,8 +41,7 @@ func TestDetachedSessionSystemVariables(t *testing.T) {
 		adminClient:     nil, // we won't actually use the admin client in these tests
 		systemVariables: sysVars,
 	}
-	// Important: Set CurrentSession reference
-	sysVars.CurrentSession = session
+	sysVars.inTransaction = session.InTransaction
 
 	// Just test that SHOW VARIABLES works without error
 	t.Run("SHOW VARIABLES works in AdminOnly session", func(t *testing.T) {

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -172,8 +172,9 @@ type systemVariables struct {
 	// managed via dedicated SET/UNSET PARAM statements (statements_params.go).
 	Params map[string]ast.Node
 
-	// link to session
-	CurrentSession *Session
+	// inTransaction reports whether there is an active transaction.
+	// nil means no session has been created yet.
+	inTransaction func() bool
 
 	// StreamManager manages tee output functionality
 	StreamManager *streamio.StreamManager

--- a/internal/mycli/system_variables_test.go
+++ b/internal/mycli/system_variables_test.go
@@ -206,8 +206,7 @@ func (b *sysVarsBuilder) withDirectedRead(d *sppb.DirectedReadOptions) *sysVarsB
 	return b
 }
 
-func (b *sysVarsBuilder) withSession(s *Session) *sysVarsBuilder { b.sv.CurrentSession = s; return b }
-func (b *sysVarsBuilder) build() *systemVariables                { return b.sv }
+func (b *sysVarsBuilder) build() *systemVariables { return b.sv }
 
 // Proto Descriptor File Tests (Array/List Variables)
 
@@ -808,7 +807,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 		// - setName: The variable name to use in Set operation (may differ in case for testing)
 		// - setValue: The value to set
 		// - hasSession: Whether a session exists (if true, Set should fail for CLI_ENABLE_ADC_PLUS)
-		// - hasClient: Whether the session has a client (for testing detached sessions)
 		// - expectedError: Expected error message (empty if no error expected)
 		// - expectedValue: Expected value after the operation
 
@@ -818,7 +816,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 			setName       string
 			setValue      string
 			hasSession    bool
-			hasClient     bool
 			expectedError string
 			expectedValue string
 		}{
@@ -847,7 +844,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 				setName:       "CLI_ENABLE_ADC_PLUS",
 				setValue:      "false",
 				hasSession:    true,
-				hasClient:     true,
 				expectedError: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
 				expectedValue: "TRUE", // Should remain at default value
 			},
@@ -859,7 +855,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 				setName:       "cli_enable_adc_plus",
 				setValue:      "false",
 				hasSession:    true,
-				hasClient:     true,
 				expectedError: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
 				expectedValue: "TRUE",
 			},
@@ -869,19 +864,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 				setName:       "Cli_Enable_Adc_Plus",
 				setValue:      "false",
 				hasSession:    true,
-				hasClient:     true,
-				expectedError: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
-				expectedValue: "TRUE",
-			},
-
-			// Test detached session (session without client) also enforces restriction
-			{
-				desc:          "restriction applies to detached session",
-				varName:       "CLI_ENABLE_ADC_PLUS",
-				setName:       "CLI_ENABLE_ADC_PLUS",
-				setValue:      "false",
-				hasSession:    true,
-				hasClient:     false, // Detached session
 				expectedError: "CLI_ENABLE_ADC_PLUS cannot be changed after session creation",
 				expectedValue: "TRUE",
 			},
@@ -893,7 +875,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 				setName:       "CLI_ASYNC_DDL",
 				setValue:      "true",
 				hasSession:    true,
-				hasClient:     true,
 				expectedValue: "TRUE",
 			},
 			{
@@ -902,7 +883,6 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 				setName:       "CLI_VERBOSE",
 				setValue:      "true",
 				hasSession:    true,
-				hasClient:     true,
 				expectedValue: "TRUE",
 			},
 		}
@@ -914,12 +894,9 @@ func TestSystemVariables_SpecialBehaviors(t *testing.T) {
 				// Start with default values
 				sv := newSystemVariablesWithDefaultsForTest()
 
-				// Create session if needed
+				// Set inTransaction callback if session is needed
 				if tt.hasSession {
-					sv.CurrentSession = &Session{}
-					if tt.hasClient {
-						sv.CurrentSession.client = &spanner.Client{} // Mock client
-					}
+					sv.inTransaction = func() bool { return false }
 				}
 
 				// Attempt to set the variable
@@ -1014,12 +991,9 @@ func TestSystemVariables_SetGetOperations(t *testing.T) {
 				singletonMap("CLI_ENDPOINT", "localhost:9010"))
 		})
 
-		// TRANSACTION_TAG needs active transaction
 		t.Run("TRANSACTION_TAG", func(t *testing.T) {
 			t.Parallel()
-			sysVars := newTestSysVars().withSession(&Session{txn: &TransactionManager{tc: &transactionContext{
-				attrs: transactionAttributes{mode: transactionModePending},
-			}}}).build()
+			sysVars := newTestSysVars().build()
 			testSpecialVariable(t, setFunc, "TRANSACTION_TAG", "TRANSACTION_TAG", "test-tag", sysVars,
 				singletonMap("TRANSACTION_TAG", "test-tag"))
 		})

--- a/internal/mycli/var_handler.go
+++ b/internal/mycli/var_handler.go
@@ -32,10 +32,10 @@ func formatBool(b bool) string {
 //
 // TODO: Consider adding native support for session-init-only variables.
 // Currently, variables like CLI_ENABLE_ADC_PLUS use custom setters to check
-// if CurrentSession != nil, but this could be better supported as a first-class
+// if a session has been created, but this could be better supported as a first-class
 // feature. Potential implementation:
 //   - Add a sessionInitOnly bool field to VarHandler
-//   - Move the CurrentSession check logic into the Set method
+//   - Move the session-existence check logic into the Set method
 //   - This would centralize the behavior and make it declarative rather than imperative
 type VarHandler[T any] struct {
 	ptr         *T

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -167,8 +167,7 @@ func (r *VarRegistry) registerAll() {
 		base: BoolVar(&sv.Transaction.ReadOnly, "A boolean indicating whether or not the connection is in read-only mode"),
 		customSetter: func(value string) error {
 			// Custom validation for READONLY
-			if sv.CurrentSession != nil &&
-				(sv.CurrentSession.InReadOnlyTransaction() || sv.CurrentSession.InReadWriteTransaction()) {
+			if sv.inTransaction != nil && sv.inTransaction() {
 				return errSetterInTransaction
 			}
 			b, err := strconv.ParseBool(value)
@@ -432,14 +431,13 @@ func (r *VarRegistry) registerAll() {
 	})
 
 	// CLI_ENABLE_ADC_PLUS is a session-init-only variable.
-	// Currently implemented using a custom setter, but could use native support
+	// Currently implemented using a custom setter that checks inTransaction != nil
+	// to detect whether a session has been created. Could use native support
 	// for session-init-only behavior if added to VarHandler (see TODO in var_handler.go).
-	// This pattern of checking CurrentSession != nil is repeated for variables that
-	// must be set before session creation.
 	r.Register("CLI_ENABLE_ADC_PLUS", &CustomVar{
 		base: BoolVar(&sv.Connection.EnableADCPlus, "A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true."),
 		customSetter: func(value string) error {
-			if sv.CurrentSession != nil {
+			if sv.inTransaction != nil {
 				return fmt.Errorf("CLI_ENABLE_ADC_PLUS cannot be changed after session creation")
 			}
 			b, err := strconv.ParseBool(value)


### PR DESCRIPTION
## Summary
Break the bidirectional coupling between `Session` and `systemVariables` by replacing `CurrentSession *Session` with an unexported `inTransaction func() bool` callback.

Previously, `Session` held `*systemVariables` and `systemVariables` held `*Session` back — a circular reference that made `systemVariables` impossible to use standalone (testing, config validation, dry-run).

## Key Changes
- **system_variables.go**: `CurrentSession *Session` → `inTransaction func() bool` with doc comment explaining dual semantics (nil = no session, call = check transaction)
- **session.go**: Both `NewSession` and `NewAdminSession` set `session.InTransaction` method value directly instead of `session` pointer
- **var_registry.go**: READONLY setter uses `sv.inTransaction != nil && sv.inTransaction()`, CLI_ENABLE_ADC_PLUS setter uses `sv.inTransaction != nil`. Updated comments.
- **var_handler.go**: TODO comment updated to use conceptual language instead of implementation detail names
- **system_variables_test.go**: Removed `withSession` builder (unused), removed `hasClient` field, removed duplicate "detached session" test case, simplified TRANSACTION_TAG test
- **session_modes_unit_test.go**: Uses `session.InTransaction` method value
- **main_test.go**: Added `cmpopts.IgnoreUnexported` for unexported `inTransaction` field, removed `"CurrentSession"` from `IgnoreFields`

## Development Insights

### Semantic tightening
The READONLY setter now uses the existing `Session.InTransaction()` which includes pending transactions (`BEGIN` without subsequent statements), while the original `InReadOnlyTransaction() || InReadWriteTransaction()` excluded them. This is more correct — READONLY should not be changeable after `BEGIN`.

### Test cleanup
- TRANSACTION_TAG test had unnecessary session setup (it's a plain `StringVar` with no custom setter)
- "detached session" test case became identical to existing test after `hasClient` removal

## Test Plan
- [x] `make check` passes (test + lint + fmt-check)
- [x] `go_diagnostics` reports no errors on all modified files

