### PR TITLE
test: add unit tests for metrics/ package

### DIFF
--- a/internal/mycli/metrics/execution_metrics_test.go
+++ b/internal/mycli/metrics/execution_metrics_test.go
@@ -232,6 +232,20 @@ func TestTotalAllocatedMB(t *testing.T) {
 			want: 50,
 		},
 		{
+			name: "no before stats",
+			m: ExecutionMetrics{
+				MemoryAfter: &MemoryStats{TotalAllocMB: 150},
+			},
+			want: -1,
+		},
+		{
+			name: "no after stats",
+			m: ExecutionMetrics{
+				MemoryBefore: &MemoryStats{TotalAllocMB: 100},
+			},
+			want: -1,
+		},
+		{
 			name: "no stats",
 			m:    ExecutionMetrics{},
 			want: -1,
@@ -264,6 +278,20 @@ func TestGCCount(t *testing.T) {
 				MemoryAfter:  &MemoryStats{NumGC: 8},
 			},
 			want: 3,
+		},
+		{
+			name: "no before stats",
+			m: ExecutionMetrics{
+				MemoryAfter: &MemoryStats{NumGC: 8},
+			},
+			want: -1,
+		},
+		{
+			name: "no after stats",
+			m: ExecutionMetrics{
+				MemoryBefore: &MemoryStats{NumGC: 5},
+			},
+			want: -1,
 		},
 		{
 			name: "no stats",


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for `internal/mycli/metrics/execution_metrics.go` which previously had zero test coverage (182 lines, 0 tests)
- Tests cover all `ExecutionMetrics` methods: `TTFB`, `TotalElapsed`, `RowIterationTime`, `ClientOverhead`, `MemoryUsedMB`, `TotalAllocatedMB`, `GCCount`
- Tests cover `parseServerTime` with all supported units (msec/sec/usec) and error cases
- Smoke test for `GetMemoryStats`

## Test plan
- [x] `go test ./internal/mycli/metrics/` passes
- [x] `make check` passes (test + lint + fmt-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)