### PR TITLE
chore(deps): update spanemuboost v0.3.3 → v0.3.4, use TestMain helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.5.0
-	github.com/apstndb/spanemuboost v0.3.3
+	github.com/apstndb/spanemuboost v0.3.4
 	github.com/apstndb/spannerplan v0.1.3
 	github.com/apstndb/spantype v0.3.8
 	github.com/apstndb/spanvalue v0.1.8

--- a/go.sum
+++ b/go.sum
@@ -2485,8 +2485,8 @@ github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82 h1:l54uIOgcH4r0lTg8xKR
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82/go.mod h1:PbqzTjsPq7Xhn8D7Vk8g/em15kd8vvEL1Y2xkI9CgGs=
 github.com/apstndb/memebridge v0.5.0 h1:WaWD0Wp3Yw1BZwyvT4bIf2XsXAA+vq9ZNxUKXXV/vZQ=
 github.com/apstndb/memebridge v0.5.0/go.mod h1:fPrWYKcg5/eaavD6RovT9qeq8K7bDhgLKOcGhqg6zo4=
-github.com/apstndb/spanemuboost v0.3.3 h1:auQLIR7FUdqujOPjQBrW8kiOQBG419w4pHQTrs5vEaI=
-github.com/apstndb/spanemuboost v0.3.3/go.mod h1:uNXjl80HX4S8hK68HCobxRrNEBLhzE+EVxkwOGuwdRM=
+github.com/apstndb/spanemuboost v0.3.4 h1:0sP11pSdCJv+pOods08pmjE7zCwqOoSef14h1NCjpe4=
+github.com/apstndb/spanemuboost v0.3.4/go.mod h1:uNXjl80HX4S8hK68HCobxRrNEBLhzE+EVxkwOGuwdRM=
 github.com/apstndb/spannerplan v0.1.3 h1:nFzTEvRL4yMzQeFdtWp3V0VaUidNA/o3T7HyIYIGk/U=
 github.com/apstndb/spannerplan v0.1.3/go.mod h1:iPN9r9R2AknoFnBFqA232cUO+2ZkHpk4Q1qeSAU9xEM=
 github.com/apstndb/spantype v0.3.8 h1:xy43Cclc2Hz6SL+3tZYuozOqJv6AML4Mv8cASgYo1O0=

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -19,10 +19,8 @@ package mycli
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -136,16 +134,8 @@ func TestMain(m *testing.M) {
 	_ = os.Unsetenv("SPANNER_PROJECT_ID")
 	_ = os.Unsetenv("SPANNER_INSTANCE_ID")
 	_ = os.Unsetenv("SPANNER_DATABASE_ID")
-	flag.Parse()
 
-	code := m.Run()
-	if err := lazyEmu.Close(); err != nil { // no-op if no test used the emulator
-		slog.Error("failed to close emulator container in TestMain", "error", err)
-		if code == 0 {
-			code = 1
-		}
-	}
-	os.Exit(code)
+	lazyEmu.TestMain(m)
 }
 
 func initializeSession(ctx context.Context, clients *spanemuboost.Clients) (session *Session, err error) {


### PR DESCRIPTION
## Summary
- Upgrade spanemuboost v0.3.3 → v0.3.4
- Use new `LazyEmulator.TestMain(m)` helper to replace `m.Run()` → `Close()` → `os.Exit()` boilerplate
- Remove unused `flag` and `log/slog` imports

## Changes

**integration_test.go** (-10 lines):
```go
// Before
func TestMain(m *testing.M) {
    _ = os.Unsetenv(...)
    flag.Parse()
    code := m.Run()
    if err := lazyEmu.Close(); err != nil {
        slog.Error(...)
        if code == 0 { code = 1 }
    }
    os.Exit(code)
}

// After
func TestMain(m *testing.M) {
    _ = os.Unsetenv(...)
    lazyEmu.TestMain(m)
}
```

## Test Plan
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)