### PR TITLE
feat(format): add NoWrapCell for data-driven column minimum widths

### DIFF
--- a/internal/mycli/format/config.go
+++ b/internal/mycli/format/config.go
@@ -61,6 +61,21 @@ func (c StyledCell) Format() string {
 func (c StyledCell) RawText() string        { return c.Text }
 func (c StyledCell) WithText(s string) Cell { return StyledCell{Text: s, Style: c.Style} }
 
+// NoWrapCell wraps any Cell to indicate its content should preferably not be wrapped.
+// Strategies use this to compute PreferredMinWidth per column so that short values
+// like NULL, true, false are kept intact when space allows.
+type NoWrapCell struct {
+	Cell
+}
+
+func (c NoWrapCell) WithText(s string) Cell { return NoWrapCell{Cell: c.Cell.WithText(s)} }
+
+// IsNoWrap reports whether c is a NoWrapCell.
+func IsNoWrap(c Cell) bool {
+	_, ok := c.(NoWrapCell)
+	return ok
+}
+
 // StringsToRow converts a slice of strings to a Row of PlainCell.
 // Used by client-side statements and tests that construct rows from plain strings.
 func StringsToRow(ss ...string) Row {

--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -16,9 +16,9 @@ import (
 	"github.com/samber/lo"
 )
 
-// minColumnWidth is the minimum width for any column.
-// Prevents very short columns from splitting common short values (NULL, true, false, etc.).
-const minColumnWidth = 4
+// minColumnWidth is the hard minimum width for any column.
+// The meaningful minimum is now data-driven via NoWrapCell and PreferredMinWidth.
+const minColumnWidth = 1
 
 // CalculateWidth calculates optimal column widths for table rendering using the default
 // GreedyFrequencyStrategy. columnNames are the plain column names, verboseHeaders are
@@ -38,9 +38,51 @@ func CalculateWidthWithStrategy(ws enums.WidthStrategy, columnNames []string, ve
 
 	slog.Debug("screen width info", "screenWidth", screenWidth, "availableWidth", availableWidth)
 
-	hints := make([]ColumnHint, len(columnNames))
+	hints := deriveColumnHints(wc, len(columnNames), rows)
 	strategy := NewWidthStrategy(ws)
 	return strategy.CalculateWidths(wc, availableWidth, verboseHeaders, rows, hints)
+}
+
+// deriveColumnHints scans rows and computes PreferredMinWidth per column
+// from NoWrapCell instances. The preferred min width is the maximum width
+// among all NoWrapCell values in that column.
+func deriveColumnHints(wc *widthCalculator, numCols int, rows []Row) []ColumnHint {
+	hints := make([]ColumnHint, numCols)
+	for _, row := range rows {
+		for i, cell := range row {
+			if i >= numCols {
+				break
+			}
+			if IsNoWrap(cell) {
+				w := wc.maxWidth(cell.RawText())
+				hints[i].PreferredMinWidth = max(hints[i].PreferredMinWidth, w)
+			}
+		}
+	}
+	return hints
+}
+
+// applyColumnFloors applies per-column minimum widths using hints.
+// When budget allows, it uses PreferredMinWidth from hints (soft constraint).
+// When the total would exceed availableWidth, it falls back to minColumnWidth only.
+func applyColumnFloors(widths []int, hints []ColumnHint, availableWidth int) {
+	origWidths := slices.Clone(widths)
+
+	for i := range widths {
+		preferred := minColumnWidth
+		if i < len(hints) {
+			preferred = max(preferred, hints[i].PreferredMinWidth)
+		}
+		widths[i] = max(widths[i], preferred)
+	}
+
+	// Soft degradation: if preferred mins exceed budget, fall back to hard minimum only.
+	if lo.Sum(widths) > availableWidth {
+		copy(widths, origWidths)
+		for i := range widths {
+			widths[i] = max(widths[i], minColumnWidth)
+		}
+	}
 }
 
 // MaxWithIdx returns the index and value of the maximum element in seq.

--- a/internal/mycli/format/width_strategy.go
+++ b/internal/mycli/format/width_strategy.go
@@ -18,7 +18,10 @@ import "github.com/apstndb/spanner-mycli/enums"
 
 // ColumnHint carries per-column metadata that strategies can use for allocation.
 type ColumnHint struct {
-	NoWrap bool // Reserved for #567: if true, the column should not be wrapped.
+	// PreferredMinWidth is the width needed to avoid wrapping all NoWrap cells
+	// in this column. Strategies should try to satisfy this but may go below
+	// if space is tight.
+	PreferredMinWidth int
 }
 
 // WidthStrategy defines the interface for pluggable column width algorithms.

--- a/internal/mycli/format/width_strategy_greedy.go
+++ b/internal/mycli/format/width_strategy_greedy.go
@@ -30,7 +30,7 @@ import (
 type GreedyFrequencyStrategy struct{}
 
 func (GreedyFrequencyStrategy) CalculateWidths(wc *widthCalculator, availableWidth int,
-	headers []string, rows []Row, _ []ColumnHint,
+	headers []string, rows []Row, hints []ColumnHint,
 ) []int {
 	formatIntermediate := func(remainsWidth int, adjustedWidths []int) string {
 		return fmt.Sprintf("remaining %v, adjustedWidths: %v", remainsWidth-lo.Sum(adjustedWidths), adjustedWidths)
@@ -38,10 +38,7 @@ func (GreedyFrequencyStrategy) CalculateWidths(wc *widthCalculator, availableWid
 
 	adjustedWidths := adjustByHeader(headers, availableWidth)
 
-	// Enforce minimum column width for readability.
-	for i := range adjustedWidths {
-		adjustedWidths[i] = max(adjustedWidths[i], minColumnWidth)
-	}
+	applyColumnFloors(adjustedWidths, hints, availableWidth)
 
 	slog.Debug("adjustByName", "info", formatIntermediate(availableWidth, adjustedWidths))
 

--- a/internal/mycli/format/width_strategy_marginal.go
+++ b/internal/mycli/format/width_strategy_marginal.go
@@ -28,7 +28,7 @@ import (
 type MarginalCostStrategy struct{}
 
 func (MarginalCostStrategy) CalculateWidths(wc *widthCalculator, availableWidth int,
-	headers []string, rows []Row, _ []ColumnHint,
+	headers []string, rows []Row, hints []ColumnHint,
 ) []int {
 	numCols := len(headers)
 
@@ -45,11 +45,9 @@ func (MarginalCostStrategy) CalculateWidths(wc *widthCalculator, availableWidth 
 		}
 	}
 
-	// Start with header-proportional allocation + minColumnWidth floor.
+	// Start with header-proportional allocation + preferred/min width floor.
 	adjustedWidths := adjustByHeader(headers, availableWidth)
-	for i := range adjustedWidths {
-		adjustedWidths[i] = max(adjustedWidths[i], minColumnWidth)
-	}
+	applyColumnFloors(adjustedWidths, hints, availableWidth)
 
 	remaining := availableWidth - lo.Sum(adjustedWidths)
 	if remaining <= 0 {

--- a/internal/mycli/format/width_strategy_proportional.go
+++ b/internal/mycli/format/width_strategy_proportional.go
@@ -27,7 +27,7 @@ import (
 type ProportionalStrategy struct{}
 
 func (ProportionalStrategy) CalculateWidths(wc *widthCalculator, availableWidth int,
-	headers []string, rows []Row, _ []ColumnHint,
+	headers []string, rows []Row, hints []ColumnHint,
 ) []int {
 	numCols := len(headers)
 
@@ -45,11 +45,9 @@ func (ProportionalStrategy) CalculateWidths(wc *widthCalculator, availableWidth 
 		}
 	}
 
-	// Start with header-proportional allocation + minColumnWidth floor.
+	// Start with header-proportional allocation + preferred/min width floor.
 	adjustedWidths := adjustByHeader(headers, availableWidth)
-	for i := range adjustedWidths {
-		adjustedWidths[i] = max(adjustedWidths[i], minColumnWidth)
-	}
+	applyColumnFloors(adjustedWidths, hints, availableWidth)
 
 	// Compute deficit per column: how much more each column wants.
 	deficits := make([]int, numCols)

--- a/internal/mycli/format/width_strategy_test.go
+++ b/internal/mycli/format/width_strategy_test.go
@@ -208,3 +208,61 @@ func TestStrategyMinColumnWidth(t *testing.T) {
 		})
 	}
 }
+
+// TestStrategyRespectsPreferredMinWidth ensures all strategies respect PreferredMinWidth
+// from hints when space allows.
+func TestStrategyRespectsPreferredMinWidth(t *testing.T) {
+	t.Parallel()
+
+	wc := newTestWidthCalculator()
+	headers := []string{"a", "b"}
+	rows := []Row{
+		{NoWrapCell{Cell: PlainCell{Text: "NULL"}}, PlainCell{Text: "x"}},
+	}
+	// hints[0] has PreferredMinWidth=4 (NULL), hints[1] has 0 (no NoWrap)
+	hints := []ColumnHint{{PreferredMinWidth: 4}, {}}
+
+	for _, ws := range enums.WidthStrategyValues() {
+		t.Run(ws.String(), func(t *testing.T) {
+			t.Parallel()
+			s := NewWidthStrategy(ws)
+			// Wide screen: enough space to satisfy preferred min
+			widths := s.CalculateWidths(wc, 40, headers, rows, hints)
+			if widths[0] < 4 {
+				t.Errorf("widths[0] = %d, want >= 4 (PreferredMinWidth for NULL)", widths[0])
+			}
+		})
+	}
+}
+
+// TestStrategyGracefulDegradation ensures strategies degrade gracefully
+// when screen is too narrow to satisfy PreferredMinWidth for all columns.
+func TestStrategyGracefulDegradation(t *testing.T) {
+	t.Parallel()
+
+	wc := newTestWidthCalculator()
+	headers := []string{"a", "b", "c", "d", "e"}
+	rows := []Row{StringsToRow("x", "y", "z", "w", "v")}
+	// All columns want 5 chars (total=25), but we only give 10.
+	hints := []ColumnHint{
+		{PreferredMinWidth: 5},
+		{PreferredMinWidth: 5},
+		{PreferredMinWidth: 5},
+		{PreferredMinWidth: 5},
+		{PreferredMinWidth: 5},
+	}
+
+	for _, ws := range enums.WidthStrategyValues() {
+		t.Run(ws.String(), func(t *testing.T) {
+			t.Parallel()
+			s := NewWidthStrategy(ws)
+			widths := s.CalculateWidths(wc, 10, headers, rows, hints)
+			for i, w := range widths {
+				// Hard floor is minColumnWidth=1, should not panic or go below.
+				if w < minColumnWidth {
+					t.Errorf("widths[%d] = %d, want >= %d", i, w, minColumnWidth)
+				}
+			}
+		})
+	}
+}

--- a/internal/mycli/format/width_test.go
+++ b/internal/mycli/format/width_test.go
@@ -292,3 +292,69 @@ func sliceToSeq[E any](s []E) func(func(E) bool) {
 func newTestWidthCalculator() *widthCalculator {
 	return &widthCalculator{Condition: tabwrap.NewCondition()}
 }
+
+func TestNoWrapCell(t *testing.T) {
+	t.Parallel()
+
+	inner := StyledCell{Text: "NULL", Style: "\033[2m"}
+	cell := NoWrapCell{Cell: inner}
+
+	if cell.Format() != inner.Format() {
+		t.Errorf("Format() = %q, want %q", cell.Format(), inner.Format())
+	}
+	if cell.RawText() != "NULL" {
+		t.Errorf("RawText() = %q, want %q", cell.RawText(), "NULL")
+	}
+	if !IsNoWrap(cell) {
+		t.Error("IsNoWrap(NoWrapCell) = false, want true")
+	}
+	if IsNoWrap(inner) {
+		t.Error("IsNoWrap(StyledCell) = true, want false")
+	}
+
+	// WithText preserves NoWrap wrapping.
+	replaced := cell.WithText("replaced")
+	if !IsNoWrap(replaced) {
+		t.Error("WithText result should be NoWrapCell")
+	}
+	if replaced.RawText() != "replaced" {
+		t.Errorf("WithText().RawText() = %q, want %q", replaced.RawText(), "replaced")
+	}
+}
+
+func TestDeriveColumnHints(t *testing.T) {
+	t.Parallel()
+
+	wc := newTestWidthCalculator()
+
+	rows := []Row{
+		{NoWrapCell{Cell: PlainCell{Text: "NULL"}}, PlainCell{Text: "Alice"}},
+		{NoWrapCell{Cell: PlainCell{Text: "NULL"}}, PlainCell{Text: "Bob"}},
+		{PlainCell{Text: "hello"}, NoWrapCell{Cell: PlainCell{Text: "false"}}},
+	}
+	hints := deriveColumnHints(wc, 2, rows)
+
+	if hints[0].PreferredMinWidth != 4 {
+		t.Errorf("hints[0].PreferredMinWidth = %d, want 4 (width of NULL)", hints[0].PreferredMinWidth)
+	}
+	if hints[1].PreferredMinWidth != 5 {
+		t.Errorf("hints[1].PreferredMinWidth = %d, want 5 (width of false)", hints[1].PreferredMinWidth)
+	}
+}
+
+func TestDeriveColumnHintsNoNoWrap(t *testing.T) {
+	t.Parallel()
+
+	wc := newTestWidthCalculator()
+
+	rows := []Row{
+		{PlainCell{Text: "hello"}, PlainCell{Text: "world"}},
+	}
+	hints := deriveColumnHints(wc, 2, rows)
+
+	for i, h := range hints {
+		if h.PreferredMinWidth != 0 {
+			t.Errorf("hints[%d].PreferredMinWidth = %d, want 0 (no NoWrapCells)", i, h.PreferredMinWidth)
+		}
+	}
+}

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -272,10 +272,11 @@ func initializeAdminSession(t *testing.T) (clients *spanemuboost.Clients, sessio
 // p creates a PlainCell for test expectations.
 func p(text string) format.PlainCell { return format.PlainCell{Text: text} }
 
-// n creates a StyledCell with dim style for test expectations (used for actual Spanner NULL values).
+// n creates a NoWrapCell wrapping a StyledCell with dim style for test expectations
+// (used for actual Spanner NULL values).
 // The dim style matches the default CLI_TYPE_STYLES="NULL=dim".
-func n(text string) format.StyledCell {
-	return format.StyledCell{Text: text, Style: "\033[2m"}
+func n(text string) format.NoWrapCell {
+	return format.NoWrapCell{Cell: format.StyledCell{Text: text, Style: "\033[2m"}}
 }
 
 func compareResult[T any](t *testing.T, got T, expected T, customCmpOptions ...cmp.Option) {
@@ -596,7 +597,7 @@ func paramCasesToStmtResults(paramCases []paramCase) []stmtResult {
 		selectParts = append(selectParts, fmt.Sprintf("@%s AS `%s`", s.name, s.name))
 		fields = append(fields, typector.NameTypeToStructTypeField(s.name, s.typ))
 		if s.isNull {
-			row = append(row, format.StyledCell{Text: s.output, Style: "\033[2m"})
+			row = append(row, format.NoWrapCell{Cell: format.StyledCell{Text: s.output, Style: "\033[2m"}})
 		} else {
 			row = append(row, format.PlainCell{Text: s.output})
 		}

--- a/internal/mycli/row_iter.go
+++ b/internal/mycli/row_iter.go
@@ -118,7 +118,7 @@ func spannerRowToRow(fc *spanvalue.FormatConfig, typeStyles map[sppb.TypeCode]st
 			// The rendering layer (FormatConfig.Styled) decides whether to call
 			// Format() (styled) or RawText() (plain).
 			if _, isNull := gcv.Value.GetKind().(*structpb.Value_NullValue); isNull {
-				result[i] = format.StyledCell{Text: text, Style: nullStyle}
+				result[i] = format.NoWrapCell{Cell: format.StyledCell{Text: text, Style: nullStyle}}
 			} else if style, ok := typeStyles[gcv.Type.GetCode()]; ok {
 				result[i] = format.StyledCell{Text: text, Style: style}
 			} else {


### PR DESCRIPTION
## Summary

- Add `NoWrapCell` type that wraps any `Cell` to indicate its content should preferably not be wrapped
- Add `deriveColumnHints()` to compute `PreferredMinWidth` per column from `NoWrapCell` instances
- Update `ColumnHint` with `PreferredMinWidth` field (replaces reserved `NoWrap bool`)
- Add `applyColumnFloors()` shared helper with soft degradation: uses preferred min when budget allows, falls back to hard minimum when it doesn't fit
- Wrap NULL cells as `NoWrapCell` in `spannerRowToRow()`
- Reduce `minColumnWidth` from 4 to 1 (meaningful minimum is now data-driven)

## Motivation

The hardcoded `minColumnWidth = 4` was implicit knowledge that NULL is 4 characters. This change makes the constraint data-driven and soft: columns with `NoWrapCell` values prefer to be wide enough to avoid wrapping those values, but degrade gracefully when screen space is insufficient.

## Test plan

- [x] `NoWrapCell` type: Format/RawText delegation, WithText preserves wrapper, IsNoWrap helper
- [x] `deriveColumnHints`: computes correct PreferredMinWidth from NoWrapCell widths
- [x] All strategies respect PreferredMinWidth when space allows
- [x] Graceful degradation when preferred mins exceed available width
- [x] `make check` passes (test + lint + fmt-check)

Fixes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)