### PR TITLE
fix(format): fix table overflow when column count exceeds available width

### DIFF
--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -139,13 +139,18 @@ func adjustToSum(limit int, vs []int) ([]int, int) {
 		return vs, remains
 	}
 
+	n := len(vs)
+	if n == 0 {
+		return vs, limit
+	}
+
 	// Build sorted unique thresholds (descending) once.
 	rev := slices.SortedFunc(slices.Values(lo.Uniq(vs)), desc)
 
 	curVs := vs
 	for i := 1; i < len(rev); i++ {
 		threshold := rev[i]
-		clipped := make([]int, len(vs))
+		clipped := make([]int, n)
 		total := 0
 		for j, v := range vs {
 			clipped[j] = min(v, threshold)
@@ -161,6 +166,30 @@ func adjustToSum(limit int, vs []int) ([]int, int) {
 	for _, v := range curVs {
 		total += v
 	}
+
+	// If threshold clipping was insufficient (many columns with large headers),
+	// fall back to equal distribution. Each element is at least 1 to avoid
+	// zero-width columns that bypass wrapping.
+	if total > limit {
+		base := max(limit/n, 1)
+		curVs = make([]int, n)
+		for i := range curVs {
+			curVs[i] = base
+		}
+		// Distribute remainder among first columns.
+		if base*n < limit {
+			extra := limit - base*n
+			for i := range extra {
+				curVs[i]++
+			}
+		}
+		total = 0
+		for _, v := range curVs {
+			total += v
+		}
+		return curVs, max(limit-total, 0)
+	}
+
 	return curVs, limit - total
 }
 

--- a/internal/mycli/format/width_strategy_greedy.go
+++ b/internal/mycli/format/width_strategy_greedy.go
@@ -98,16 +98,19 @@ func (GreedyFrequencyStrategy) CalculateWidths(wc *widthCalculator, availableWid
 		}
 	}
 
-	bestIdx := 0
-	bestShortage := longestWidths[0] - adjustedWidths[0]
-	for i := 1; i < len(headers); i++ {
-		shortage := longestWidths[i] - adjustedWidths[i]
-		if shortage > bestShortage {
-			bestShortage = shortage
-			bestIdx = i
+	remainder := availableWidth - sumWidths(adjustedWidths)
+	if remainder > 0 {
+		bestIdx := 0
+		bestShortage := longestWidths[0] - adjustedWidths[0]
+		for i := 1; i < len(headers); i++ {
+			shortage := longestWidths[i] - adjustedWidths[i]
+			if shortage > bestShortage {
+				bestShortage = shortage
+				bestIdx = i
+			}
 		}
+		adjustedWidths[bestIdx] += remainder
 	}
-	adjustedWidths[bestIdx] += availableWidth - sumWidths(adjustedWidths)
 
 	slog.Debug("final", "info", formatIntermediate(availableWidth, adjustedWidths))
 

--- a/internal/mycli/format/width_test.go
+++ b/internal/mycli/format/width_test.go
@@ -170,6 +170,15 @@ func TestAdjustToSum(t *testing.T) {
 			wantWidths:  []int{3, 3, 3},
 			wantRemains: 1,
 		},
+		{
+			// When minimum unique threshold × numCols still exceeds limit,
+			// fall back to equal distribution with floor of 1.
+			name:        "many columns overflow falls back to equal distribution",
+			limit:       19,
+			vs:          []int{13, 12, 10, 11, 16, 14, 9, 11, 12, 12, 9, 21, 9, 13, 11, 19, 13, 28, 23, 23},
+			wantWidths:  []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			wantRemains: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,6 +268,19 @@ func TestCalculateWidth(t *testing.T) {
 			rows:        []Row{StringsToRow("1", "NULL")},
 			screenWidth: 20,
 		},
+		{
+			name: "many columns like INFORMATION_SCHEMA.COLUMNS",
+			columns: []string{
+				"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "COLUMN_NAME",
+				"ORDINAL_POSITION", "COLUMN_DEFAULT", "DATA_TYPE", "IS_NULLABLE",
+				"SPANNER_TYPE", "IS_GENERATED", "IS_HIDDEN", "GENERATION_EXPRESSION",
+				"IS_STORED", "SPANNER_STATE", "IS_IDENTITY", "IDENTITY_GENERATION",
+				"IDENTITY_KIND", "IDENTITY_START_WITH_COUNTER", "IDENTITY_SKIP_RANGE_MIN",
+				"IDENTITY_SKIP_RANGE_MAX",
+			},
+			rows:        []Row{StringsToRow("", "INFORMATION_SCHEMA", "COLUMNS", "TABLE_CATALOG", "1", "NULL", "NULL", "NO", "STRING(MAX)", "NEVER", "false", "NULL", "NULL", "NULL", "NO", "NULL", "NULL", "NULL", "NULL", "NULL")},
+			screenWidth: 120,
+		},
 	}
 
 	for _, tt := range tests {
@@ -273,6 +295,17 @@ func TestCalculateWidth(t *testing.T) {
 				if w < minColumnWidth {
 					t.Errorf("width[%d] = %d, expected >= %d (minColumnWidth)", i, w, minColumnWidth)
 				}
+			}
+			// Total column widths + overhead should not exceed screenWidth unless
+			// overflow is unavoidable (numCols × minColumnWidth + overhead > screenWidth).
+			overheadWidth := 4 + 3*(len(tt.columns)-1)
+			totalWidth := overheadWidth
+			for _, w := range widths {
+				totalWidth += w
+			}
+			minTableWidth := overheadWidth + len(tt.columns)*minColumnWidth
+			if totalWidth > tt.screenWidth && totalWidth > minTableWidth {
+				t.Errorf("total table width %d exceeds screenWidth %d and minTableWidth %d (widths=%v)", totalWidth, tt.screenWidth, minTableWidth, widths)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fix table output overflowing screen width when column count is large (e.g., `INFORMATION_SCHEMA.COLUMNS` with 20 columns). The root cause was `adjustToSum` being unable to reduce column widths below the minimum unique header width threshold, leaving all columns at that floor even when their sum far exceeds the available width.

## Key Changes

- **width.go**: Add equal-distribution fallback to `adjustToSum` when threshold clipping is insufficient. Each column gets at least width 1 to avoid zero-width columns that bypass `tabwrap.Wrap`. When `numCols × 1 > limit`, the 1-character overflow per column is unavoidable but minimal.
- **width_strategy_greedy.go**: Guard remainder distribution with `remainder > 0` check. Previously, when `applyColumnFloors` caused total width to exceed `availableWidth`, the negative remainder would subtract width from a column, creating a zero-width column that bypasses wrapping entirely.
- **width_test.go**: Add `adjustToSum` test case for many-column overflow. Add `INFORMATION_SCHEMA.COLUMNS`-like test case to `TestCalculateWidth` with total-width assertion that accounts for unavoidable overflow.

## Behavior at extreme widths

When `numCols × minColumnWidth + overhead > screenWidth` (e.g., 20 columns at screenWidth=80), the table will overflow by at most `numCols × minColumnWidth + overhead - screenWidth` characters (1 char in the COLUMNS case). This is the minimum possible overflow — every column gets exactly 1 character of content width.

## Test Plan

- [x] `make check` passes
- [x] `TestAdjustToSum/many_columns_overflow_falls_back_to_equal_distribution` verifies fallback
- [x] `TestCalculateWidth/many_columns_like_INFORMATION_SCHEMA.COLUMNS` verifies end-to-end at screenWidth=120
- [x] Manual verification with embedded emulator

Fixes #575
