### PR TITLE
feat(format): add JSONL (JSON Lines) output format

### DIFF
--- a/enums/displaymode_enumer.go
+++ b/enums/displaymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _DisplayModeName = "UNSPECIFIEDTABLETABLE_COMMENTTABLE_DETAIL_COMMENTVERTICALTABHTMLXMLCSVSQL_INSERTSQL_INSERT_OR_IGNORESQL_INSERT_OR_UPDATE"
+const _DisplayModeName = "UNSPECIFIEDTABLETABLE_COMMENTTABLE_DETAIL_COMMENTVERTICALTABHTMLXMLCSVJSONLSQL_INSERTSQL_INSERT_OR_IGNORESQL_INSERT_OR_UPDATE"
 
-var _DisplayModeIndex = [...]uint8{0, 11, 16, 29, 49, 57, 60, 64, 67, 70, 80, 100, 120}
+var _DisplayModeIndex = [...]uint8{0, 11, 16, 29, 49, 57, 60, 64, 67, 70, 75, 85, 105, 125}
 
-const _DisplayModeLowerName = "unspecifiedtabletable_commenttable_detail_commentverticaltabhtmlxmlcsvsql_insertsql_insert_or_ignoresql_insert_or_update"
+const _DisplayModeLowerName = "unspecifiedtabletable_commenttable_detail_commentverticaltabhtmlxmlcsvjsonlsql_insertsql_insert_or_ignoresql_insert_or_update"
 
 func (i DisplayMode) String() string {
 	if i < 0 || i >= DisplayMode(len(_DisplayModeIndex)-1) {
@@ -33,12 +33,13 @@ func _DisplayModeNoOp() {
 	_ = x[DisplayModeHTML-(6)]
 	_ = x[DisplayModeXML-(7)]
 	_ = x[DisplayModeCSV-(8)]
-	_ = x[DisplayModeSQLInsert-(9)]
-	_ = x[DisplayModeSQLInsertOrIgnore-(10)]
-	_ = x[DisplayModeSQLInsertOrUpdate-(11)]
+	_ = x[DisplayModeJSONL-(9)]
+	_ = x[DisplayModeSQLInsert-(10)]
+	_ = x[DisplayModeSQLInsertOrIgnore-(11)]
+	_ = x[DisplayModeSQLInsertOrUpdate-(12)]
 }
 
-var _DisplayModeValues = []DisplayMode{DisplayModeUnspecified, DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment, DisplayModeVertical, DisplayModeTab, DisplayModeHTML, DisplayModeXML, DisplayModeCSV, DisplayModeSQLInsert, DisplayModeSQLInsertOrIgnore, DisplayModeSQLInsertOrUpdate}
+var _DisplayModeValues = []DisplayMode{DisplayModeUnspecified, DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment, DisplayModeVertical, DisplayModeTab, DisplayModeHTML, DisplayModeXML, DisplayModeCSV, DisplayModeJSONL, DisplayModeSQLInsert, DisplayModeSQLInsertOrIgnore, DisplayModeSQLInsertOrUpdate}
 
 var _DisplayModeNameToValueMap = map[string]DisplayMode{
 	_DisplayModeName[0:11]:         DisplayModeUnspecified,
@@ -59,12 +60,14 @@ var _DisplayModeNameToValueMap = map[string]DisplayMode{
 	_DisplayModeLowerName[64:67]:   DisplayModeXML,
 	_DisplayModeName[67:70]:        DisplayModeCSV,
 	_DisplayModeLowerName[67:70]:   DisplayModeCSV,
-	_DisplayModeName[70:80]:        DisplayModeSQLInsert,
-	_DisplayModeLowerName[70:80]:   DisplayModeSQLInsert,
-	_DisplayModeName[80:100]:       DisplayModeSQLInsertOrIgnore,
-	_DisplayModeLowerName[80:100]:  DisplayModeSQLInsertOrIgnore,
-	_DisplayModeName[100:120]:      DisplayModeSQLInsertOrUpdate,
-	_DisplayModeLowerName[100:120]: DisplayModeSQLInsertOrUpdate,
+	_DisplayModeName[70:75]:        DisplayModeJSONL,
+	_DisplayModeLowerName[70:75]:   DisplayModeJSONL,
+	_DisplayModeName[75:85]:        DisplayModeSQLInsert,
+	_DisplayModeLowerName[75:85]:   DisplayModeSQLInsert,
+	_DisplayModeName[85:105]:       DisplayModeSQLInsertOrIgnore,
+	_DisplayModeLowerName[85:105]:  DisplayModeSQLInsertOrIgnore,
+	_DisplayModeName[105:125]:      DisplayModeSQLInsertOrUpdate,
+	_DisplayModeLowerName[105:125]: DisplayModeSQLInsertOrUpdate,
 }
 
 var _DisplayModeNames = []string{
@@ -77,9 +80,10 @@ var _DisplayModeNames = []string{
 	_DisplayModeName[60:64],
 	_DisplayModeName[64:67],
 	_DisplayModeName[67:70],
-	_DisplayModeName[70:80],
-	_DisplayModeName[80:100],
-	_DisplayModeName[100:120],
+	_DisplayModeName[70:75],
+	_DisplayModeName[75:85],
+	_DisplayModeName[85:105],
+	_DisplayModeName[105:125],
 }
 
 // DisplayModeString retrieves an enum value from the enum constants string name.

--- a/enums/enums.go
+++ b/enums/enums.go
@@ -15,6 +15,7 @@ const (
 	DisplayModeHTML
 	DisplayModeXML
 	DisplayModeCSV
+	DisplayModeJSONL
 	DisplayModeSQLInsert
 	DisplayModeSQLInsertOrIgnore
 	DisplayModeSQLInsertOrUpdate

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -382,6 +382,7 @@ func createStreamingProcessor(sysVars *systemVariables, out io.Writer, screenWid
 			// Table formats: buffer by default for accurate column widths
 			shouldStream = false
 		case enums.DisplayModeCSV, enums.DisplayModeTab, enums.DisplayModeVertical, enums.DisplayModeHTML, enums.DisplayModeXML,
+			enums.DisplayModeJSONL,
 			enums.DisplayModeSQLInsert, enums.DisplayModeSQLInsertOrIgnore, enums.DisplayModeSQLInsertOrUpdate:
 			// Other formats: stream by default for better performance
 			shouldStream = true

--- a/internal/mycli/format/format.go
+++ b/internal/mycli/format/format.go
@@ -72,6 +72,11 @@ func formatXML(out io.Writer, rows []Row, columnNames []string, config FormatCon
 	return ExecuteWithFormatter(NewXMLFormatter(out, config.SkipColumnNames), rows, columnNames, config)
 }
 
+// formatJSONL formats output as JSON Lines (one JSON object per row).
+func formatJSONL(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewJSONLFormatter(out), rows, columnNames, config)
+}
+
 // wrapRowStyled wraps styled (ANSI-coded) cell text with ControlSequences-aware Wrap.
 // SGR state is carried across line breaks, so each output line is independently styled.
 // The result is PlainCell containing pre-styled text — no further Format() needed.
@@ -139,6 +144,8 @@ func NewFormatter(mode Mode) (FormatFunc, error) {
 		return formatHTML, nil
 	case ModeXML:
 		return formatXML, nil
+	case ModeJSONL:
+		return formatJSONL, nil
 	default:
 		// Look up in registry for custom modes
 		if factory, ok := lookupFormatFunc(mode); ok {
@@ -186,6 +193,8 @@ func NewStreamingFormatter(mode Mode, out io.Writer, config FormatConfig) (Strea
 		return NewHTMLFormatter(out, config.SkipColumnNames), nil
 	case ModeXML:
 		return NewXMLFormatter(out, config.SkipColumnNames), nil
+	case ModeJSONL:
+		return NewJSONLFormatter(out), nil
 	case ModeTable, ModeTableComment, ModeTableDetailComment:
 		// Table formats need screenWidth, so they must be created by the caller
 		// Return a dummy formatter for isStreamingSupported check

--- a/internal/mycli/format/format_test.go
+++ b/internal/mycli/format/format_test.go
@@ -25,6 +25,7 @@ func TestNewFormatter(t *testing.T) {
 		{name: "vertical", mode: ModeVertical},
 		{name: "tab", mode: ModeTab},
 		{name: "csv", mode: ModeCSV},
+		{name: "jsonl", mode: ModeJSONL},
 		{name: "html", mode: ModeHTML},
 		{name: "xml", mode: ModeXML},
 		{name: "invalid", mode: Mode("NONEXISTENT"), wantErr: true},
@@ -65,6 +66,7 @@ func TestNewStreamingFormatter(t *testing.T) {
 		{name: "vertical", mode: ModeVertical, out: io.Discard},
 		{name: "html", mode: ModeHTML, out: io.Discard},
 		{name: "xml", mode: ModeXML, out: io.Discard},
+		{name: "jsonl", mode: ModeJSONL, out: io.Discard},
 		// Table formats with io.Discard are allowed (for isStreamingSupported check)
 		{name: "table_discard", mode: ModeTable, out: io.Discard},
 		// Table formats with real writer require screenWidth
@@ -134,7 +136,7 @@ func TestValueFormatModeFor(t *testing.T) {
 	// No t.Parallel(): mutates global registry
 
 	// Built-in modes should return DisplayValues
-	for _, mode := range []Mode{ModeTable, ModeCSV, ModeTab, ModeVertical, ModeHTML, ModeXML} {
+	for _, mode := range []Mode{ModeTable, ModeCSV, ModeTab, ModeVertical, ModeHTML, ModeXML, ModeJSONL} {
 		if got := ValueFormatModeFor(mode); got != DisplayValues {
 			t.Errorf("ValueFormatModeFor(%s) = %d, want DisplayValues", mode, got)
 		}
@@ -443,6 +445,62 @@ func TestFormatXML(t *testing.T) {
 	}
 }
 
+func TestFormatJSONL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		columns []string
+		rows    []Row
+		want    string
+	}{
+		{
+			name:    "basic",
+			columns: []string{"id", "name"},
+			rows:    []Row{StringsToRow("1", "Alice"), StringsToRow("2", "Bob")},
+			want:    `{"id":"1","name":"Alice"}` + "\n" + `{"id":"2","name":"Bob"}` + "\n",
+		},
+		{
+			name:    "special characters",
+			columns: []string{"col"},
+			rows:    []Row{StringsToRow("value with \"quotes\""), StringsToRow("value with, comma")},
+			want:    `{"col":"value with \"quotes\""}` + "\n" + `{"col":"value with, comma"}` + "\n",
+		},
+		{
+			name:    "empty rows",
+			columns: []string{"id"},
+			rows:    nil,
+			want:    "",
+		},
+		{
+			name:    "complex spanner type",
+			columns: []string{"SPANNER_TYPE"},
+			rows:    []Row{StringsToRow(`ARRAY<STRUCT<COLUMN STRING(MAX), LOCK_MODE STRING(MAX)>>`)},
+			want:    `{"SPANNER_TYPE":"ARRAY<STRUCT<COLUMN STRING(MAX), LOCK_MODE STRING(MAX)>>"}` + "\n",
+		},
+		{
+			name:    "newline in value",
+			columns: []string{"data"},
+			rows:    []Row{StringsToRow("line1\nline2")},
+			want:    `{"data":"line1\nline2"}` + "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			err := formatJSONL(&buf, tt.rows, tt.columns, FormatConfig{}, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, buf.String()); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestXMLEscape(t *testing.T) {
 	t.Parallel()
 
@@ -559,6 +617,41 @@ func TestXMLFormatterLifecycle(t *testing.T) {
 		err := f.WriteRow(StringsToRow("1"))
 		if err == nil {
 			t.Error("expected error writing before init")
+		}
+	})
+}
+
+func TestJSONLFormatterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write before init", func(t *testing.T) {
+		t.Parallel()
+		f := NewJSONLFormatter(io.Discard)
+		err := f.WriteRow(StringsToRow("1"))
+		if err == nil {
+			t.Error("expected error writing before init")
+		}
+	})
+
+	t.Run("double init is noop", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		f := NewJSONLFormatter(&buf)
+		if err := f.InitFormat([]string{"id"}, FormatConfig{}, nil); err != nil {
+			t.Fatalf("first init: %v", err)
+		}
+		if err := f.InitFormat([]string{"id"}, FormatConfig{}, nil); err != nil {
+			t.Fatalf("second init: %v", err)
+		}
+		if err := f.WriteRow(StringsToRow("1")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := f.FinishFormat(); err != nil {
+			t.Fatalf("finish: %v", err)
+		}
+		want := `{"id":"1"}` + "\n"
+		if diff := cmp.Diff(want, buf.String()); diff != "" {
+			t.Errorf("output mismatch (-want +got):\n%s", diff)
 		}
 	})
 }

--- a/internal/mycli/format/mode.go
+++ b/internal/mycli/format/mode.go
@@ -18,6 +18,7 @@ const (
 	ModeHTML               Mode = "HTML"
 	ModeXML                Mode = "XML"
 	ModeCSV                Mode = "CSV"
+	ModeJSONL              Mode = "JSONL"
 )
 
 // IsTableMode returns true if the mode is one of the table display modes.

--- a/internal/mycli/format/streaming_jsonl.go
+++ b/internal/mycli/format/streaming_jsonl.go
@@ -1,0 +1,89 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// JSONLFormatter provides JSONL (JSON Lines) formatting logic.
+// Each row is output as a single JSON object with column names as keys
+// and all values as JSON strings.
+type JSONLFormatter struct {
+	out         io.Writer
+	columns     []string
+	initialized bool
+}
+
+// NewJSONLFormatter creates a new JSONL formatter.
+func NewJSONLFormatter(out io.Writer) *JSONLFormatter {
+	return &JSONLFormatter{
+		out: out,
+	}
+}
+
+// InitFormat stores column names for use as JSON keys.
+func (f *JSONLFormatter) InitFormat(columnNames []string, config FormatConfig, previewRows []Row) error {
+	if f.initialized {
+		return nil
+	}
+
+	f.columns = columnNames
+	f.initialized = true
+	return nil
+}
+
+// WriteRow writes a single row as a JSON object on one line.
+func (f *JSONLFormatter) WriteRow(row Row) error {
+	if !f.initialized {
+		return fmt.Errorf("JSONL formatter not initialized")
+	}
+
+	enc := jsontext.NewEncoder(f.out)
+	if err := enc.WriteToken(jsontext.BeginObject); err != nil {
+		return fmt.Errorf("failed to write JSONL row: %w", err)
+	}
+
+	for i, cell := range row {
+		var columnName string
+		if i < len(f.columns) {
+			columnName = f.columns[i]
+		} else {
+			columnName = fmt.Sprintf("Column_%d", i+1)
+		}
+
+		if err := enc.WriteToken(jsontext.String(columnName)); err != nil {
+			return fmt.Errorf("failed to write JSONL key: %w", err)
+		}
+
+		if err := enc.WriteToken(jsontext.String(cell.RawText())); err != nil {
+			return fmt.Errorf("failed to write JSONL value: %w", err)
+		}
+	}
+
+	if err := enc.WriteToken(jsontext.EndObject); err != nil {
+		return fmt.Errorf("failed to write JSONL row: %w", err)
+	}
+
+	return nil
+}
+
+// FinishFormat completes JSONL output.
+func (f *JSONLFormatter) FinishFormat() error {
+	return nil
+}

--- a/internal/mycli/format/streaming_jsonl.go
+++ b/internal/mycli/format/streaming_jsonl.go
@@ -23,9 +23,11 @@ import (
 
 // JSONLFormatter provides JSONL (JSON Lines) formatting logic.
 // Each row is output as a single JSON object with column names as keys
-// and all values as JSON strings.
+// and all values as JSON strings. The jsontext.Encoder writes a newline
+// after each top-level JSON value, producing valid JSONL output.
+// Column order is preserved (unlike encoding/json with map[string]string).
 type JSONLFormatter struct {
-	out         io.Writer
+	enc         *jsontext.Encoder
 	columns     []string
 	initialized bool
 }
@@ -33,7 +35,7 @@ type JSONLFormatter struct {
 // NewJSONLFormatter creates a new JSONL formatter.
 func NewJSONLFormatter(out io.Writer) *JSONLFormatter {
 	return &JSONLFormatter{
-		out: out,
+		enc: jsontext.NewEncoder(out),
 	}
 }
 
@@ -54,8 +56,7 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 		return fmt.Errorf("JSONL formatter not initialized")
 	}
 
-	enc := jsontext.NewEncoder(f.out)
-	if err := enc.WriteToken(jsontext.BeginObject); err != nil {
+	if err := f.enc.WriteToken(jsontext.BeginObject); err != nil {
 		return fmt.Errorf("failed to write JSONL row: %w", err)
 	}
 
@@ -67,16 +68,16 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 			columnName = fmt.Sprintf("Column_%d", i+1)
 		}
 
-		if err := enc.WriteToken(jsontext.String(columnName)); err != nil {
+		if err := f.enc.WriteToken(jsontext.String(columnName)); err != nil {
 			return fmt.Errorf("failed to write JSONL key: %w", err)
 		}
 
-		if err := enc.WriteToken(jsontext.String(cell.RawText())); err != nil {
+		if err := f.enc.WriteToken(jsontext.String(cell.RawText())); err != nil {
 			return fmt.Errorf("failed to write JSONL value: %w", err)
 		}
 	}
 
-	if err := enc.WriteToken(jsontext.EndObject); err != nil {
+	if err := f.enc.WriteToken(jsontext.EndObject); err != nil {
 		return fmt.Errorf("failed to write JSONL row: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Add `--format=jsonl` output format where each row is a JSON object with column names as keys and all values as JSON strings
- Streaming enabled by default in AUTO mode for efficient large result set processing
- Follows the existing `StreamingFormatter` pattern (like CSV, TAB, etc.)

Fixes #554

## Changes

- `enums/enums.go`: Add `DisplayModeJSONL`
- `internal/mycli/format/mode.go`: Add `ModeJSONL`
- `internal/mycli/format/streaming_jsonl.go`: New `JSONLFormatter` using `jsontext.Encoder`
- `internal/mycli/format/format.go`: Wire JSONL into `NewFormatter` and `NewStreamingFormatter`
- `internal/mycli/execute_sql.go`: Add JSONL to streaming auto-detection
- Tests for JSONL output, lifecycle, and integration with existing formatter tests

## Test plan

- [x] `make check` passes (test + lint + fmt-check)
- [x] JSONL output tests cover: basic rows, special characters, complex Spanner types, newlines in values, empty rows
- [x] Formatter lifecycle tests (write before init, double init idempotency)
- [x] Existing `TestNewFormatter` and `TestNewStreamingFormatter` include JSONL entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)