### PR TITLE
docs: add JSONL format to system_variables.md and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ There are differences between spanner-mycli and spanner-cli that include not onl
   * Support `--skip-column-names` flag to suppress column headers in output (useful for scripting)
   * Support `--host` and `--port` flags as first-class options
   * Support `--deployment-endpoint` as an alias for `--endpoint`
-  * Support `--html`, `--xml`, and `--csv` output format options with proper escaping (security-enhanced compared to reference implementation)
+  * Support `--html`, `--xml`, `--csv`, and `--format=jsonl` output format options with proper escaping (security-enhanced compared to reference implementation)
+  * JSONL format produces type-aware JSON: INT64 as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects
 * Generalized concepts to extend without a lot of original syntax
   * Generalized system variables concept inspired by Spanner JDBC properties
     * `SET <name> = <value>` statement
@@ -124,7 +125,7 @@ spanner:
       --html                                              Display output in HTML format.
       --xml                                               Display output in XML format.
       --csv                                               Display output in CSV format.
-      --format=                                           Output format (table, tab, vertical, html, xml, csv)
+      --format=                                           Output format (table, tab, vertical, html, xml, csv, jsonl)
   -v, --verbose                                           Display verbose output.
       --credential=                                       Use the specific credential file
       --prompt=                                           Set the prompt to the specified format (default: spanner%t> )

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are differences between spanner-mycli and spanner-cli that include not onl
   * Support `--host` and `--port` flags as first-class options
   * Support `--deployment-endpoint` as an alias for `--endpoint`
   * Support `--html`, `--xml`, `--csv`, and `--format=jsonl` output format options with proper escaping (security-enhanced compared to reference implementation)
-  * JSONL format produces type-aware JSON: INT64 as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects
+  * JSONL format produces type-aware JSON: INT64/ENUM as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects, NULL as null
 * Generalized concepts to extend without a lot of original syntax
   * Generalized system variables concept inspired by Spanner JDBC properties
     * `SET <name> = <value>` statement

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ There are differences between spanner-mycli and spanner-cli that include not onl
   * Support `--skip-column-names` flag to suppress column headers in output (useful for scripting)
   * Support `--host` and `--port` flags as first-class options
   * Support `--deployment-endpoint` as an alias for `--endpoint`
-  * Support `--html`, `--xml`, `--csv`, and `--format=jsonl` output format options with proper escaping (security-enhanced compared to reference implementation)
-  * JSONL format produces type-aware JSON: INT64/ENUM as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects, NULL as null
+  * Support `--html`, `--xml`, and `--csv` output format options with proper escaping (security-enhanced compared to reference implementation)
+  * Support `--format=jsonl` for type-aware JSON Lines output: INT64/ENUM as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects, NULL as null
 * Generalized concepts to extend without a lot of original syntax
   * Generalized system variables concept inspired by Spanner JDBC properties
     * `SET <name> = <value>` statement

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -54,6 +54,7 @@ TODO
   - `HTML` - HTML table format
   - `XML` - XML format
   - `CSV` - Comma-separated values (RFC 4180 compliant)
+  - `JSONL` - JSON Lines (one JSON object per row with type-aware values)
   - `SQL_INSERT` - INSERT statements
   - `SQL_INSERT_OR_IGNORE` - INSERT OR IGNORE statements
   - `SQL_INSERT_OR_UPDATE` - INSERT OR UPDATE statements
@@ -70,7 +71,10 @@ TODO
   
   SET CLI_FORMAT = 'CSV';
   SELECT * FROM users;  -- Output as CSV (comma-separated values)
-  
+
+  SET CLI_FORMAT = 'JSONL';
+  SELECT * FROM users;  -- Output as JSON Lines (one JSON object per row)
+
   SET CLI_FORMAT = 'TABLE_DETAIL_COMMENT';
   SELECT * FROM users;  -- Output as table with execution stats, all wrapped in /* */ comments
   ```
@@ -78,10 +82,12 @@ TODO
   - Can be set via `--html` flag (sets to HTML format)
   - Can be set via `--xml` flag (sets to XML format)
   - Can be set via `--csv` flag (sets to CSV format)
+  - Can be set via `--format=jsonl` flag (sets to JSONL format)
   - Can be set via `--table` flag (sets to TABLE format in batch mode)
   - HTML and XML formats are compatible with Google Cloud Spanner CLI
   - All special characters are properly escaped in HTML, XML, and CSV formats for security
   - CSV format follows RFC 4180 standard with automatic escaping of commas, quotes, and newlines
+  - JSONL format produces type-aware JSON: INT64/ENUM as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects, NULL as null
   - The format affects how query results are displayed, not how they are executed
   - `TABLE_DETAIL_COMMENT` is particularly useful with `CLI_ECHO_INPUT=TRUE` and `CLI_MARKDOWN_CODEBLOCK=TRUE` for documentation
 


### PR DESCRIPTION
## Summary

Document the JSONL output format added in #580/#581.

## Key Changes

- **docs/system_variables.md**: Add JSONL to CLI_FORMAT valid values, usage example, `--format=jsonl` flag note, and type-aware JSON output description
- **README.md**: Add `--format=jsonl` to feature list and `--format` help text

## Test plan

- [x] `make check` passes
- [x] No code changes, docs only
