### PR TITLE
chore: fix local artifact ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,21 +7,23 @@ dist/
 credentials.json
 
 # System files - safe to delete anywhere
-.DS_Store     # macOS system file
+.DS_Store
 
 # IDE and tool directories - DO NOT delete in main workspace, safe to delete ONLY in phantom worktrees
-.idea         # JetBrains IDE settings
-.claude       # Claude Code session data
-!.claude/settings.json  # Exception: project-wide Claude Code settings (team shared)
+.idea/
+.claude/
+!.claude/settings.json
 
 # Cache and temporary files - safe to delete anywhere
-.cache/       # Application cache directory
-tmp/          # Development temporary files (e.g., help output generation)
-.tmp/         # Temporary directory for cloning external repos (hidden from go test)
+.cache/
+tmp/
+.tmp/
+.worktrees/
 
-# Configuration files with secrets - may contain sensitive connection info, check before deleting
+# Local configuration files with secrets or machine-specific settings
+.env
+.mcp.json
 .*.cnf
-
 
 # Phantom worktree notes - temporary development notes, safe to delete anywhere
 .notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ credentials.json
 
 # IDE and tool directories - DO NOT delete in main workspace, safe to delete ONLY in phantom worktrees
 .idea/
-.claude/**
+.claude/*
 !.claude/settings.json
 
 # Cache and temporary files - safe to delete anywhere

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ credentials.json
 
 # IDE and tool directories - DO NOT delete in main workspace, safe to delete ONLY in phantom worktrees
 .idea/
-.claude/
+.claude/**
 !.claude/settings.json
 
 # Cache and temporary files - safe to delete anywhere


### PR DESCRIPTION
## Summary
- fix malformed root `.gitignore` patterns that included inline comments as literal text
- ignore local-only workspace artifacts such as `.env`, `.mcp.json`, and `.worktrees/`

## Test Plan
- [x] not applicable (ignore rules only)
