### PR TITLE
ci: enforce README help sync

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -1,0 +1,31 @@
+name: README sync
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  readme-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install tools
+        run: go install tool
+
+      - name: Regenerate README help
+        run: make docs-update
+
+      - name: Check README is up to date
+        run: git diff --exit-code -- README.md

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   readme-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ all-quick: fmt test-quick lint
 docs-update:
 	@echo "Updating help output for README.md..."
 	@mkdir -p tmp
-	@go tool ptyhelp patch -file README.md -marker readme-help -cols 92 -o tmp/help_clean.txt -normalize-eol=lf -- go run . --help
+	@go tool ptyhelp patch -file README.md -marker readme-help -cols 120 -o tmp/help_clean.txt -normalize-eol=lf -- go run . --help
 	@go run . --statement-help > tmp/statement_help.txt
 	@echo "Generated files:"
 	@echo "  - tmp/help_clean.txt: --help output for README.md"

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ all-quick: fmt test-quick lint
 docs-update:
 	@echo "Updating help output for README.md..."
 	@mkdir -p tmp
-	@go tool ptyhelp -cols 200 -o tmp/help_clean.txt -target-file README.md -marker readme-help -- go run . --help
-	@for f in tmp/help_clean.txt README.md; do tmp="$$f.tmp"; awk '{ sub(/\r$$/, ""); print }' "$$f" > "$$tmp" && cat "$$tmp" > "$$f" && rm "$$tmp" || { rm -f "$$tmp"; exit 1; }; done
+	@go tool ptyhelp patch -file README.md -marker readme-help -cols 92 -o tmp/help_clean.txt -normalize-eol=lf -- go run . --help
 	@go run . --statement-help > tmp/statement_help.txt
 	@echo "Generated files:"
 	@echo "  - tmp/help_clean.txt: --help output for README.md"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ spanner:
       --html                                              Display output in HTML format.
       --xml                                               Display output in XML format.
       --csv                                               Display output in CSV format.
-      --format=                                           Output format (table, tab, vertical, html, xml, csv, jsonl)
+      --format=                                           Output format (table, tab, vertical, html, xml, csv)
   -v, --verbose                                           Display verbose output.
       --credential=                                       Use the specific credential file
       --prompt=                                           Set the prompt to the specified format (default: spanner%t> )

--- a/README.md
+++ b/README.md
@@ -115,130 +115,82 @@ Usage:
   spanner-mycli [OPTIONS]
 
 spanner:
-  -p, --project=                                          (required) GCP Project ID.
-                                                          [$SPANNER_PROJECT_ID]
-  -i, --instance=                                         (required) Cloud Spanner Instance
-                                                          ID [$SPANNER_INSTANCE_ID]
-  -d, --database=                                         Cloud Spanner Database ID.
-                                                          Optional when --detached is used.
+  -p, --project=                                          (required) GCP Project ID. [$SPANNER_PROJECT_ID]
+  -i, --instance=                                         (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
+  -d, --database=                                         Cloud Spanner Database ID. Optional when --detached is used.
                                                           [$SPANNER_DATABASE_ID]
-      --detached                                          Start in detached mode, ignoring
-                                                          database env var/flag
-  -e, --execute=                                          Execute SQL statement and quit.
-                                                          --sql is an alias.
-  -f, --file=                                             Execute SQL statement from file
-                                                          and quit. --source is an alias.
-  -t, --table                                             Display output in table format
-                                                          for batch mode.
+      --detached                                          Start in detached mode, ignoring database env var/flag
+  -e, --execute=                                          Execute SQL statement and quit. --sql is an alias.
+  -f, --file=                                             Execute SQL statement from file and quit. --source is an
+                                                          alias.
+  -t, --table                                             Display output in table format for batch mode.
       --html                                              Display output in HTML format.
       --xml                                               Display output in XML format.
       --csv                                               Display output in CSV format.
-      --format=                                           Output format (table, tab,
-                                                          vertical, html, xml, csv, jsonl)
+      --format=                                           Output format (table, tab, vertical, html, xml, csv, jsonl)
   -v, --verbose                                           Display verbose output.
       --credential=                                       Use the specific credential file
-      --prompt=                                           Set the prompt to the specified
-                                                          format (default: spanner%t> )
-      --prompt2=                                          Set the prompt2 to the specified
-                                                          format (default: %P%R> )
-      --history=                                          Set the history file to the
-                                                          specified path (default:
+      --prompt=                                           Set the prompt to the specified format (default: spanner%t> )
+      --prompt2=                                          Set the prompt2 to the specified format (default: %P%R> )
+      --history=                                          Set the history file to the specified path (default:
                                                           /tmp/spanner_mycli_readline.tmp)
-      --priority=                                         Set default request priority
-                                                          (HIGH|MEDIUM|LOW)
-      --role=                                             Use the specific database role.
-                                                          --database-role is an alias.
-      --endpoint=                                         Set the Spanner API endpoint
-                                                          (host:port)
-      --host=                                             Host on which Spanner server is
-                                                          located
+      --priority=                                         Set default request priority (HIGH|MEDIUM|LOW)
+      --role=                                             Use the specific database role. --database-role is an alias.
+      --endpoint=                                         Set the Spanner API endpoint (host:port)
+      --host=                                             Host on which Spanner server is located
       --port=                                             Port number for Spanner connection
-      --directed-read=                                    Directed read option
-                                                          (replica_location:replica_type).
-                                                          The replicat_type is optional and
-                                                          either READ_ONLY or READ_WRITE
-      --set=                                              Set system variables e.g.
-                                                          --set=name1=value1
+      --directed-read=                                    Directed read option (replica_location:replica_type). The
+                                                          replica_type is optional and either READ_ONLY or READ_WRITE
+      --set=                                              Set system variables e.g. --set=name1=value1
                                                           --set=name2=value2
-      --param=                                            Set query parameters, it can be
-                                                          literal or type(EXPLAIN/DESCRIBE
-                                                          only) e.g.
-                                                          --param="p1='string_value'"
+      --param=                                            Set query parameters, it can be literal or
+                                                          type(EXPLAIN/DESCRIBE only) e.g. --param="p1='string_value'"
                                                           --param=p2=FLOAT64
-      --proto-descriptor-file=                            Path of a file that contains a
-                                                          protobuf-serialized
-                                                          google.protobuf.FileDescriptorSet
-                                                          message.
-      --insecure                                          Skip TLS verification and permit
-                                                          plaintext gRPC. --skip-tls-verify
-                                                          is an alias.
-      --embedded-emulator                                 Use embedded Cloud Spanner
-                                                          Emulator. --project, --instance,
-                                                          --database, --endpoint,
-                                                          --insecure will be automatically
+      --proto-descriptor-file=                            Path of a file that contains a protobuf-serialized
+                                                          google.protobuf.FileDescriptorSet message.
+      --insecure                                          Skip TLS verification and permit plaintext gRPC.
+                                                          --skip-tls-verify is an alias.
+      --embedded-emulator                                 Use embedded Cloud Spanner Emulator. --project, --instance,
+                                                          --database, --endpoint, --insecure will be automatically
                                                           configured.
-      --emulator-image=                                   container image for
-                                                          --embedded-emulator
-      --emulator-platform=                                Container platform (e.g.
-                                                          linux/amd64, linux/arm64) for
+      --emulator-image=                                   container image for --embedded-emulator
+      --emulator-platform=                                Container platform (e.g. linux/amd64, linux/arm64) for
                                                           embedded emulator
-      --sample-database=                                  Initialize emulator with built-in
-                                                          sample (e.g. fingraph, singers,
-                                                          banking) or path to metadata.json
-                                                          file. Requires
+      --sample-database=                                  Initialize emulator with built-in sample (e.g. fingraph,
+                                                          singers, banking) or path to metadata.json file. Requires
                                                           --embedded-emulator.
-      --list-samples                                      List available sample databases
-                                                          and exit
-      --output-template=                                  Filepath of output template.
-                                                          (EXPERIMENTAL)
+      --list-samples                                      List available sample databases and exit
+      --output-template=                                  Filepath of output template. (EXPERIMENTAL)
       --log-level=
       --log-grpc                                          Show gRPC logs
-      --query-mode=[NORMAL|PLAN|PROFILE]                  Mode in which the query must be
-                                                          processed.
+      --query-mode=[NORMAL|PLAN|PROFILE]                  Mode in which the query must be processed.
       --strong                                            Perform a strong query.
-      --read-timestamp=                                   Perform a query at the given
-                                                          timestamp.
+      --read-timestamp=                                   Perform a query at the given timestamp.
       --vertexai-project=                                 Vertex AI project
-      --vertexai-model=                                   Vertex AI model (default:
-                                                          gemini-3-flash-preview)
-      --vertexai-location=                                Vertex AI location (default:
-                                                          global)
-      --database-dialect=[POSTGRESQL|GOOGLE_STANDARD_SQL] The SQL dialect of the Cloud
-                                                          Spanner Database.
+      --vertexai-model=                                   Vertex AI model (default: gemini-3-flash-preview)
+      --vertexai-location=                                Vertex AI location (default: global)
+      --database-dialect=[POSTGRESQL|GOOGLE_STANDARD_SQL] The SQL dialect of the Cloud Spanner Database.
       --impersonate-service-account=                      Impersonate service account email
       --version                                           Show version string.
       --enable-partitioned-dml                            Partitioned DML as default
-                                                          (AUTOCOMMIT_DML_MODE=PARTITIONED_-
-
-                                                          NON_ATOMIC)
-      --timeout=                                          Statement timeout (e.g., '10s',
-                                                          '5m', '1h') (default: 10m)
-      --async                                             Return immediately, without
-                                                          waiting for the operation in
+                                                          (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
+      --timeout=                                          Statement timeout (e.g., '10s', '5m', '1h') (default: 10m)
+      --async                                             Return immediately, without waiting for the operation in
                                                           progress to complete
-      --try-partition-query                               Test whether the query can be
-                                                          executed as partition query
+      --try-partition-query                               Test whether the query can be executed as partition query
                                                           without execution
       --mcp                                               Run as MCP server
       --skip-system-command                               Do not allow system commands
-      --system-command=[ON|OFF]                           Enable or disable system commands
-                                                          (ON/OFF) (default: ON)
-      --tee=                                              Append a copy of output to the
-                                                          specified file (both screen and
-                                                          file)
-  -o, --output=                                           Redirect output to file (file
-                                                          only, no screen output)
+      --system-command=[ON|OFF]                           Enable or disable system commands (ON/OFF) (default: ON)
+      --tee=                                              Append a copy of output to the specified file (both screen
+                                                          and file)
+  -o, --output=                                           Redirect output to file (file only, no screen output)
       --skip-column-names                                 Suppress column headers in output
-      --streaming=[AUTO|TRUE|FALSE]                       Streaming output mode: AUTO
-                                                          (format-dependent default), TRUE
-                                                          (always stream), FALSE (never
-                                                          stream) (default: AUTO)
-      --color=[AUTO|TRUE|FALSE]                           ANSI styling in output: AUTO
-                                                          (styled if TTY), TRUE (always
-                                                          styled), FALSE (never styled)
-                                                          (default: AUTO)
-  -q, --quiet                                             Suppress result lines like 'rows
-                                                          in set' for clean output
+      --streaming=[AUTO|TRUE|FALSE]                       Streaming output mode: AUTO (format-dependent default), TRUE
+                                                          (always stream), FALSE (never stream) (default: AUTO)
+      --color=[AUTO|TRUE|FALSE]                           ANSI styling in output: AUTO (styled if TTY), TRUE (always
+                                                          styled), FALSE (never styled) (default: AUTO)
+  -q, --quiet                                             Suppress result lines like 'rows in set' for clean output
 
 Help Options:
   -h, --help                                              Show this help message

--- a/README.md
+++ b/README.md
@@ -115,62 +115,130 @@ Usage:
   spanner-mycli [OPTIONS]
 
 spanner:
-  -p, --project=                                          (required) GCP Project ID. [$SPANNER_PROJECT_ID]
-  -i, --instance=                                         (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
-  -d, --database=                                         Cloud Spanner Database ID. Optional when --detached is used. [$SPANNER_DATABASE_ID]
-      --detached                                          Start in detached mode, ignoring database env var/flag
-  -e, --execute=                                          Execute SQL statement and quit. --sql is an alias.
-  -f, --file=                                             Execute SQL statement from file and quit. --source is an alias.
-  -t, --table                                             Display output in table format for batch mode.
+  -p, --project=                                          (required) GCP Project ID.
+                                                          [$SPANNER_PROJECT_ID]
+  -i, --instance=                                         (required) Cloud Spanner Instance
+                                                          ID [$SPANNER_INSTANCE_ID]
+  -d, --database=                                         Cloud Spanner Database ID.
+                                                          Optional when --detached is used.
+                                                          [$SPANNER_DATABASE_ID]
+      --detached                                          Start in detached mode, ignoring
+                                                          database env var/flag
+  -e, --execute=                                          Execute SQL statement and quit.
+                                                          --sql is an alias.
+  -f, --file=                                             Execute SQL statement from file
+                                                          and quit. --source is an alias.
+  -t, --table                                             Display output in table format
+                                                          for batch mode.
       --html                                              Display output in HTML format.
       --xml                                               Display output in XML format.
       --csv                                               Display output in CSV format.
-      --format=                                           Output format (table, tab, vertical, html, xml, csv)
+      --format=                                           Output format (table, tab,
+                                                          vertical, html, xml, csv, jsonl)
   -v, --verbose                                           Display verbose output.
       --credential=                                       Use the specific credential file
-      --prompt=                                           Set the prompt to the specified format (default: spanner%t> )
-      --prompt2=                                          Set the prompt2 to the specified format (default: %P%R> )
-      --history=                                          Set the history file to the specified path (default: /tmp/spanner_mycli_readline.tmp)
-      --priority=                                         Set default request priority (HIGH|MEDIUM|LOW)
-      --role=                                             Use the specific database role. --database-role is an alias.
-      --endpoint=                                         Set the Spanner API endpoint (host:port)
-      --host=                                             Host on which Spanner server is located
+      --prompt=                                           Set the prompt to the specified
+                                                          format (default: spanner%t> )
+      --prompt2=                                          Set the prompt2 to the specified
+                                                          format (default: %P%R> )
+      --history=                                          Set the history file to the
+                                                          specified path (default:
+                                                          /tmp/spanner_mycli_readline.tmp)
+      --priority=                                         Set default request priority
+                                                          (HIGH|MEDIUM|LOW)
+      --role=                                             Use the specific database role.
+                                                          --database-role is an alias.
+      --endpoint=                                         Set the Spanner API endpoint
+                                                          (host:port)
+      --host=                                             Host on which Spanner server is
+                                                          located
       --port=                                             Port number for Spanner connection
-      --directed-read=                                    Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE
-      --set=                                              Set system variables e.g. --set=name1=value1 --set=name2=value2
-      --param=                                            Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param="p1='string_value'" --param=p2=FLOAT64
-      --proto-descriptor-file=                            Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message.
-      --insecure                                          Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias.
-      --embedded-emulator                                 Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured.
-      --emulator-image=                                   container image for --embedded-emulator
-      --emulator-platform=                                Container platform (e.g. linux/amd64, linux/arm64) for embedded emulator
-      --sample-database=                                  Initialize emulator with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator.
-      --list-samples                                      List available sample databases and exit
-      --output-template=                                  Filepath of output template. (EXPERIMENTAL)
+      --directed-read=                                    Directed read option
+                                                          (replica_location:replica_type).
+                                                          The replicat_type is optional and
+                                                          either READ_ONLY or READ_WRITE
+      --set=                                              Set system variables e.g.
+                                                          --set=name1=value1
+                                                          --set=name2=value2
+      --param=                                            Set query parameters, it can be
+                                                          literal or type(EXPLAIN/DESCRIBE
+                                                          only) e.g.
+                                                          --param="p1='string_value'"
+                                                          --param=p2=FLOAT64
+      --proto-descriptor-file=                            Path of a file that contains a
+                                                          protobuf-serialized
+                                                          google.protobuf.FileDescriptorSet
+                                                          message.
+      --insecure                                          Skip TLS verification and permit
+                                                          plaintext gRPC. --skip-tls-verify
+                                                          is an alias.
+      --embedded-emulator                                 Use embedded Cloud Spanner
+                                                          Emulator. --project, --instance,
+                                                          --database, --endpoint,
+                                                          --insecure will be automatically
+                                                          configured.
+      --emulator-image=                                   container image for
+                                                          --embedded-emulator
+      --emulator-platform=                                Container platform (e.g.
+                                                          linux/amd64, linux/arm64) for
+                                                          embedded emulator
+      --sample-database=                                  Initialize emulator with built-in
+                                                          sample (e.g. fingraph, singers,
+                                                          banking) or path to metadata.json
+                                                          file. Requires
+                                                          --embedded-emulator.
+      --list-samples                                      List available sample databases
+                                                          and exit
+      --output-template=                                  Filepath of output template.
+                                                          (EXPERIMENTAL)
       --log-level=
       --log-grpc                                          Show gRPC logs
-      --query-mode=[NORMAL|PLAN|PROFILE]                  Mode in which the query must be processed.
+      --query-mode=[NORMAL|PLAN|PROFILE]                  Mode in which the query must be
+                                                          processed.
       --strong                                            Perform a strong query.
-      --read-timestamp=                                   Perform a query at the given timestamp.
+      --read-timestamp=                                   Perform a query at the given
+                                                          timestamp.
       --vertexai-project=                                 Vertex AI project
-      --vertexai-model=                                   Vertex AI model (default: gemini-3-flash-preview)
-      --vertexai-location=                                Vertex AI location (default: global)
-      --database-dialect=[POSTGRESQL|GOOGLE_STANDARD_SQL] The SQL dialect of the Cloud Spanner Database.
+      --vertexai-model=                                   Vertex AI model (default:
+                                                          gemini-3-flash-preview)
+      --vertexai-location=                                Vertex AI location (default:
+                                                          global)
+      --database-dialect=[POSTGRESQL|GOOGLE_STANDARD_SQL] The SQL dialect of the Cloud
+                                                          Spanner Database.
       --impersonate-service-account=                      Impersonate service account email
       --version                                           Show version string.
-      --enable-partitioned-dml                            Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
-      --timeout=                                          Statement timeout (e.g., '10s', '5m', '1h') (default: 10m)
-      --async                                             Return immediately, without waiting for the operation in progress to complete
-      --try-partition-query                               Test whether the query can be executed as partition query without execution
+      --enable-partitioned-dml                            Partitioned DML as default
+                                                          (AUTOCOMMIT_DML_MODE=PARTITIONED_-
+
+                                                          NON_ATOMIC)
+      --timeout=                                          Statement timeout (e.g., '10s',
+                                                          '5m', '1h') (default: 10m)
+      --async                                             Return immediately, without
+                                                          waiting for the operation in
+                                                          progress to complete
+      --try-partition-query                               Test whether the query can be
+                                                          executed as partition query
+                                                          without execution
       --mcp                                               Run as MCP server
       --skip-system-command                               Do not allow system commands
-      --system-command=[ON|OFF]                           Enable or disable system commands (ON/OFF) (default: ON)
-      --tee=                                              Append a copy of output to the specified file (both screen and file)
-  -o, --output=                                           Redirect output to file (file only, no screen output)
+      --system-command=[ON|OFF]                           Enable or disable system commands
+                                                          (ON/OFF) (default: ON)
+      --tee=                                              Append a copy of output to the
+                                                          specified file (both screen and
+                                                          file)
+  -o, --output=                                           Redirect output to file (file
+                                                          only, no screen output)
       --skip-column-names                                 Suppress column headers in output
-      --streaming=[AUTO|TRUE|FALSE]                       Streaming output mode: AUTO (format-dependent default), TRUE (always stream), FALSE (never stream) (default: AUTO)
-      --color=[AUTO|TRUE|FALSE]                           ANSI styling in output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled) (default: AUTO)
-  -q, --quiet                                             Suppress result lines like 'rows in set' for clean output
+      --streaming=[AUTO|TRUE|FALSE]                       Streaming output mode: AUTO
+                                                          (format-dependent default), TRUE
+                                                          (always stream), FALSE (never
+                                                          stream) (default: AUTO)
+      --color=[AUTO|TRUE|FALSE]                           ANSI styling in output: AUTO
+                                                          (styled if TTY), TRUE (always
+                                                          styled), FALSE (never styled)
+                                                          (default: AUTO)
+  -q, --quiet                                             Suppress result lines like 'rows
+                                                          in set' for clean output
 
 Help Options:
   -h, --help                                              Show this help message

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/apstndb/github-schema-go v0.0.0-20250623031417-7b63713e7a90 // indirect
 	github.com/apstndb/go-jq-yamlformat v0.0.0-20250724144043-044ee62273ff // indirect
 	github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba // indirect
-	github.com/apstndb/ptyhelp v0.1.0 // indirect
+	github.com/apstndb/ptyhelp v0.2.1 // indirect
 	github.com/apstndb/treeprint v0.0.0-20250529153958-e82576b37da6 // indirect
 	github.com/aymanbagabas/go-pty v0.2.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2487,6 +2487,8 @@ github.com/apstndb/memebridge v0.5.0 h1:WaWD0Wp3Yw1BZwyvT4bIf2XsXAA+vq9ZNxUKXXV/
 github.com/apstndb/memebridge v0.5.0/go.mod h1:fPrWYKcg5/eaavD6RovT9qeq8K7bDhgLKOcGhqg6zo4=
 github.com/apstndb/ptyhelp v0.1.0 h1:WDV+Wsl9A4SJxW04Tl/qgS7+R7zWVs2iooRVnwmAE/0=
 github.com/apstndb/ptyhelp v0.1.0/go.mod h1:VI4NWnhDSERhK66XstA0Ju0K8EuKbz8TX87iH/lNCm0=
+github.com/apstndb/ptyhelp v0.2.1 h1:vGqYJiIBNS3opPA3JLCKsdKIZzomz2zFkO1PVuM+WLs=
+github.com/apstndb/ptyhelp v0.2.1/go.mod h1:qQr/aibVk0BK/dweEW7mcaT0jAH9NeRHP2in6MIgEcA=
 github.com/apstndb/spanemuboost v0.3.4 h1:0sP11pSdCJv+pOods08pmjE7zCwqOoSef14h1NCjpe4=
 github.com/apstndb/spanemuboost v0.3.4/go.mod h1:uNXjl80HX4S8hK68HCobxRrNEBLhzE+EVxkwOGuwdRM=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l0QJZRVSRwBXTxaMMAjrmF0kQDjXlCM0bwTCo5Gs=

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -73,7 +73,7 @@ type spannerOptions struct {
 	HTML                      bool              `long:"html" description:"Display output in HTML format." default-mask:"-"`
 	XML                       bool              `long:"xml" description:"Display output in XML format." default-mask:"-"`
 	CSV                       bool              `long:"csv" description:"Display output in CSV format." default-mask:"-"`
-	Format                    string            `long:"format" description:"Output format (table, tab, vertical, html, xml, csv)" default-mask:"-"`
+	Format                    string            `long:"format" description:"Output format (table, tab, vertical, html, xml, csv, jsonl)" default-mask:"-"`
 	Verbose                   bool              `long:"verbose" short:"v" description:"Display verbose output." default-mask:"-"`
 	Credential                string            `long:"credential" description:"Use the specific credential file" default-mask:"-"`
 	Prompt                    *string           `long:"prompt" description:"Set the prompt to the specified format" default-mask:"spanner%t> "`

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -84,7 +84,7 @@ type spannerOptions struct {
 	Endpoint                  string            `long:"endpoint" description:"Set the Spanner API endpoint (host:port)" default-mask:"-"`
 	Host                      string            `long:"host" description:"Host on which Spanner server is located" default-mask:"-"`
 	Port                      int               `long:"port" description:"Port number for Spanner connection" default-mask:"-"`
-	DirectedRead              string            `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE" default-mask:"-"`
+	DirectedRead              string            `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replica_type is optional and either READ_ONLY or READ_WRITE" default-mask:"-"`
 	SQL                       string            `long:"sql" hidden:"true" description:"Hidden alias of --execute for gcloud spanner databases execute-sql compatibility" default-mask:"-"`
 	Set                       map[string]string `long:"set" key-value-delimiter:"=" description:"Set system variables e.g. --set=name1=value1 --set=name2=value2" default-mask:"-"`
 	Param                     map[string]string `long:"param" key-value-delimiter:"=" description:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64" default-mask:"-"`


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `make docs-update` and fails if `README.md` changes
- refresh the checked-in README help block so the new workflow passes from the current main baseline

## Test Plan
- [x] `make check`
- [x] `make docs-update`
