### PR TITLE
Fix Kong help output and TOML config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ Flags:
       --vertexai-model=VERTEXAI-MODEL          Vertex AI model (default: gemini-3-flash-preview)
       --vertexai-location=VERTEXAI-LOCATION    Vertex AI location (default: global)
       --database-dialect=STRING                The SQL dialect of the Cloud Spanner Database. Allowed values:
-                                               POSTGRESQL, GOOGLE_STANDARD_SQL.
+                                               POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this
+                                               flag to leave it unset.
       --impersonate-service-account=STRING     Impersonate service account email
   -h, --help                                   Show this help message and exit.
       --version                                Show version string.
@@ -722,6 +723,7 @@ This tool supports a TOML configuration file called `.spanner_mycli.toml`.
 The config files are loaded from `~/.spanner_mycli.toml` and `./.spanner_mycli.toml`.
 In the config file, you can set default option values for command line options.
 TOML keys follow hyphen-separated flag names, for example `vertexai-project` for `--vertexai-project`.
+This follows `kong-toml`'s key mapping and validation; underscore variants such as `vertexai_project` are rejected as unknown configuration keys.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Flags:
                                                execution
       --mcp                                    Run as MCP server
       --skip-system-command                    Do not allow system commands
-      --system-command=ON                      Enable or disable system commands (ON/OFF). Default: ON.
+      --system-command=ON|OFF                  Enable or disable system commands (ON/OFF). Default: ON.
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
   -o, --output=STRING                          Redirect output to file (file only, no screen output)
       --skip-column-names                      Suppress column headers in output

--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ Flags:
       --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
       --log-level=STRING
       --log-grpc                               Show gRPC logs
-      --query-mode=STRING                      Mode in which the query must be processed. Allowed values: NORMAL, PLAN,
+      --query-mode=QUERY-MODE                  Mode in which the query must be processed. Allowed values: NORMAL, PLAN,
                                                PROFILE.
       --strong                                 Perform a strong query.
       --read-timestamp=STRING                  Perform a query at the given timestamp.
       --vertexai-project=STRING                Vertex AI project
       --vertexai-model=VERTEXAI-MODEL          Vertex AI model (default: gemini-3-flash-preview)
       --vertexai-location=VERTEXAI-LOCATION    Vertex AI location (default: global)
-      --database-dialect=STRING                The SQL dialect of the Cloud Spanner Database. Allowed values:
+      --database-dialect=DATABASE-DIALECT      The SQL dialect of the Cloud Spanner Database. Allowed values:
                                                POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this
                                                flag to leave it unset.
       --impersonate-service-account=STRING     Impersonate service account email
@@ -177,7 +177,7 @@ Flags:
                                                execution
       --mcp                                    Run as MCP server
       --skip-system-command                    Do not allow system commands
-      --system-command=SYSTEM-COMMAND          Enable or disable system commands (ON/OFF). Default: ON.
+      --system-command=ON                      Enable or disable system commands (ON/OFF). Default: ON.
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
   -o, --output=STRING                          Redirect output to file (file only, no screen output)
       --skip-column-names                      Suppress column headers in output

--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ Flags:
       --format=STRING                          Output format (table, tab, vertical, html, xml, csv, jsonl)
   -v, --verbose                                Display verbose output.
       --credential=STRING                      Use the specific credential file
-      --prompt=PROMPT                          Set the prompt to the specified format
-      --prompt2=PROMPT2                        Set the prompt2 to the specified format
-      --history=HISTORY                        Set the history file to the specified path
+      --prompt=PROMPT                          Set the prompt to the specified format (default: spanner%t> )
+      --prompt2=PROMPT2                        Set the prompt2 to the specified format (default: %P%R> )
+      --history=HISTORY                        Set the history file to the specified path (default:
+                                               /tmp/spanner_mycli_readline.tmp)
       --priority=STRING                        Set default request priority (HIGH|MEDIUM|LOW)
       --role=STRING                            Use the specific database role. --database-role is an alias.
       --endpoint=STRING                        Set the Spanner API endpoint (host:port)
@@ -155,13 +156,15 @@ Flags:
       --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
       --log-level=STRING
       --log-grpc                               Show gRPC logs
-      --query-mode=STRING                      Mode in which the query must be processed.
+      --query-mode=STRING                      Mode in which the query must be processed. Allowed values: NORMAL, PLAN,
+                                               PROFILE.
       --strong                                 Perform a strong query.
       --read-timestamp=STRING                  Perform a query at the given timestamp.
       --vertexai-project=STRING                Vertex AI project
-      --vertexai-model=VERTEXAI-MODEL          Vertex AI model
-      --vertexai-location=VERTEXAI-LOCATION    Vertex AI location
-      --database-dialect=STRING                The SQL dialect of the Cloud Spanner Database.
+      --vertexai-model=VERTEXAI-MODEL          Vertex AI model (default: gemini-3-flash-preview)
+      --vertexai-location=VERTEXAI-LOCATION    Vertex AI location (default: global)
+      --database-dialect=STRING                The SQL dialect of the Cloud Spanner Database. Allowed values:
+                                               POSTGRESQL, GOOGLE_STANDARD_SQL.
       --impersonate-service-account=STRING     Impersonate service account email
   -h, --help                                   Show this help message and exit.
       --version                                Show version string.
@@ -173,7 +176,7 @@ Flags:
                                                execution
       --mcp                                    Run as MCP server
       --skip-system-command                    Do not allow system commands
-      --system-command=SYSTEM-COMMAND          Enable or disable system commands (ON/OFF)
+      --system-command=SYSTEM-COMMAND          Enable or disable system commands (ON/OFF). Default: ON.
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
   -o, --output=STRING                          Redirect output to file (file only, no screen output)
       --skip-column-names                      Suppress column headers in output
@@ -718,7 +721,7 @@ spanner> SELECT """
 This tool supports a TOML configuration file called `.spanner_mycli.toml`.
 The config files are loaded from `~/.spanner_mycli.toml` and `./.spanner_mycli.toml`.
 In the config file, you can set default option values for command line options.
-Hyphenated flags use underscore TOML keys, for example `vertexai_project` for `--vertexai-project`.
+TOML keys follow hyphen-separated flag names, for example `vertexai-project` for `--vertexai-project`.
 
 Example:
 
@@ -1983,10 +1986,10 @@ spanner> PARTITION SELECT * FROM Singers;
 
 ### GenAI support
 
-You can use `GEMINI` statement by setting `vertexai_project` in config file.
+You can use `GEMINI` statement by setting `vertexai-project` in config file.
 
 ```toml
-vertexai_project = "example-project"
+vertexai-project = "example-project"
 ```
 
 Built-in Spanner reference docs are always available. Setting `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` enables dynamic documentation lookup via the Developer Knowledge API for more comprehensive coverage.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Flags:
       --format=STRING                          Output format (table, tab, vertical, html, xml, csv, jsonl)
   -v, --verbose                                Display verbose output.
       --credential=STRING                      Use the specific credential file
-      --prompt=PROMPT                          Set the prompt to the specified format (default: spanner%t> )
-      --prompt2=PROMPT2                        Set the prompt2 to the specified format (default: %P%R> )
+      --prompt=PROMPT                          Set the prompt to the specified format (default: "spanner%t> ")
+      --prompt2=PROMPT2                        Set the prompt2 to the specified format (default: "%P%R> ")
       --history=HISTORY                        Set the history file to the specified path (default:
                                                /tmp/spanner_mycli_readline.tmp)
       --priority=STRING                        Set default request priority (HIGH|MEDIUM|LOW)
@@ -722,8 +722,8 @@ spanner> SELECT """
 This tool supports a TOML configuration file called `.spanner_mycli.toml`.
 The config files are loaded from `~/.spanner_mycli.toml` and `./.spanner_mycli.toml`.
 In the config file, you can set default option values for command line options.
-TOML keys follow hyphen-separated flag names, for example `vertexai-project` for `--vertexai-project`.
-This follows `kong-toml`'s key mapping and validation; underscore variants such as `vertexai_project` are rejected as unknown configuration keys.
+TOML keys normally follow hyphen-separated flag names, for example `vertexai-project` for `--vertexai-project`.
+For convenience, matching snake_case aliases such as `vertexai_project` are accepted too.
 
 Example:
 
@@ -1988,10 +1988,10 @@ spanner> PARTITION SELECT * FROM Singers;
 
 ### GenAI support
 
-You can use `GEMINI` statement by setting `vertexai-project` in config file.
+You can use `GEMINI` statement by setting `vertexai_project` in config file.
 
 ```toml
-vertexai-project = "example-project"
+vertexai_project = "example-project"
 ```
 
 Built-in Spanner reference docs are always available. Setting `DEVELOPERKNOWLEDGE_API_KEY` or `GOOGLE_API_KEY` enables dynamic documentation lookup via the Developer Knowledge API for more comprehensive coverage.

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -86,6 +86,15 @@ func (v showVersionFlag) BeforeReset(app *kong.Kong, vars kong.Vars) error {
 	return versionRequestedError{}
 }
 
+// caseInsensitiveEnumValue preserves case-insensitive CLI input while still
+// allowing Kong enum validation to run on the normalized uppercase value.
+type caseInsensitiveEnumValue string
+
+func (v *caseInsensitiveEnumValue) UnmarshalText(text []byte) error {
+	*v = caseInsensitiveEnumValue(strings.ToUpper(string(text)))
+	return nil
+}
+
 type spannerOptions struct {
 	ProjectId           string            `name:"project" short:"p" help:"(required) GCP Project ID ($SPANNER_PROJECT_ID)."`
 	InstanceId          string            `name:"instance" short:"i" help:"(required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)"`
@@ -127,24 +136,24 @@ type spannerOptions struct {
 	// Kong only accepts enum validation on optional flags when they are modeled as
 	// pointers. Keeping these as *string preserves "unset" semantics while still
 	// letting Kong validate and document the allowed values natively.
-	QueryMode                 *string         `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE." enum:"NORMAL,PLAN,PROFILE"`
-	Strong                    bool            `name:"strong" help:"Perform a strong query."`
-	ReadTimestamp             string          `name:"read-timestamp" help:"Perform a query at the given timestamp."`
-	VertexAIProject           string          `name:"vertexai-project" help:"Vertex AI project"`
-	VertexAIModel             *string         `name:"vertexai-model" help:"Vertex AI model (default: ${defaultVertexAIModel})"`
-	VertexAILocation          *string         `name:"vertexai-location" help:"Vertex AI location (default: ${defaultVertexAILocation})"`
-	DatabaseDialect           *string         `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset." enum:"POSTGRESQL,GOOGLE_STANDARD_SQL,DATABASE_DIALECT_UNSPECIFIED"`
-	ImpersonateServiceAccount string          `name:"impersonate-service-account" help:"Impersonate service account email"`
-	Help                      showHelpFlag    `name:"help" short:"h" help:"Show this help message and exit."`
-	Version                   showVersionFlag `name:"version" help:"Show version string."`
-	StatementHelp             bool            `name:"statement-help" hidden:"" help:"Show statement help."`
-	DatabaseRole              string          `name:"database-role" hidden:"" help:"Hidden alias of --role for gcloud spanner databases execute-sql compatibility"`
-	DeploymentEndpoint        string          `name:"deployment-endpoint" hidden:"" help:"Hidden alias of --endpoint for Google Cloud Spanner CLI compatibility"`
-	EnablePartitionedDML      bool            `name:"enable-partitioned-dml" help:"Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)"`
-	Timeout                   string          `name:"timeout" help:"Statement timeout (e.g., '10s', '5m', '1h')" default:"10m"`
-	Async                     bool            `name:"async" help:"Return immediately, without waiting for the operation in progress to complete"`
-	TryPartitionQuery         bool            `name:"try-partition-query" help:"Test whether the query can be executed as partition query without execution"`
-	MCP                       bool            `name:"mcp" help:"Run as MCP server"`
+	QueryMode                 *caseInsensitiveEnumValue `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE." enum:"NORMAL,PLAN,PROFILE"`
+	Strong                    bool                      `name:"strong" help:"Perform a strong query."`
+	ReadTimestamp             string                    `name:"read-timestamp" help:"Perform a query at the given timestamp."`
+	VertexAIProject           string                    `name:"vertexai-project" help:"Vertex AI project"`
+	VertexAIModel             *string                   `name:"vertexai-model" help:"Vertex AI model (default: ${defaultVertexAIModel})"`
+	VertexAILocation          *string                   `name:"vertexai-location" help:"Vertex AI location (default: ${defaultVertexAILocation})"`
+	DatabaseDialect           *caseInsensitiveEnumValue `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset." enum:"POSTGRESQL,GOOGLE_STANDARD_SQL,DATABASE_DIALECT_UNSPECIFIED"`
+	ImpersonateServiceAccount string                    `name:"impersonate-service-account" help:"Impersonate service account email"`
+	Help                      showHelpFlag              `name:"help" short:"h" help:"Show this help message and exit."`
+	Version                   showVersionFlag           `name:"version" help:"Show version string."`
+	StatementHelp             bool                      `name:"statement-help" hidden:"" help:"Show statement help."`
+	DatabaseRole              string                    `name:"database-role" hidden:"" help:"Hidden alias of --role for gcloud spanner databases execute-sql compatibility"`
+	DeploymentEndpoint        string                    `name:"deployment-endpoint" hidden:"" help:"Hidden alias of --endpoint for Google Cloud Spanner CLI compatibility"`
+	EnablePartitionedDML      bool                      `name:"enable-partitioned-dml" help:"Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)"`
+	Timeout                   string                    `name:"timeout" help:"Statement timeout (e.g., '10s', '5m', '1h')" default:"10m"`
+	Async                     bool                      `name:"async" help:"Return immediately, without waiting for the operation in progress to complete"`
+	TryPartitionQuery         bool                      `name:"try-partition-query" help:"Test whether the query can be executed as partition query without execution"`
+	MCP                       bool                      `name:"mcp" help:"Run as MCP server"`
 	// SkipSystemCommand is kept for compatibility with official Spanner CLI.
 	// The official implementation uses --skip-system-command to disable shell commands,
 	// so we maintain the same flag name and behavior for consistency.
@@ -542,11 +551,11 @@ func initializeSystemVariables(opts *spannerOptions) (*systemVariables, error) {
 	lo.Must0(sysVars.SetFromSimple("CLI_ANALYZE_COLUMNS", DefaultAnalyzeColumns))
 
 	if err := applyOptionMappings(sysVars, []optionMapping{
-		{"CLI_DATABASE_DIALECT", lo.FromPtr(opts.DatabaseDialect), "--database-dialect"},
+		{"CLI_DATABASE_DIALECT", string(lo.FromPtr(opts.DatabaseDialect)), "--database-dialect"},
 		{"AUTOCOMMIT_DML_MODE", lo.Ternary(opts.EnablePartitionedDML, "PARTITIONED_NON_ATOMIC", ""), "--enable-partitioned-dml"},
 		{"STATEMENT_TIMEOUT", opts.Timeout, "--timeout"},
 		{"RPC_PRIORITY", cmp.Or(opts.Priority, "MEDIUM"), "--priority"},
-		{"CLI_QUERY_MODE", lo.FromPtr(opts.QueryMode), "--query-mode"},
+		{"CLI_QUERY_MODE", string(lo.FromPtr(opts.QueryMode)), "--query-mode"},
 		{"CLI_TRY_PARTITION_QUERY", lo.Ternary(opts.TryPartitionQuery, "TRUE", ""), "--try-partition-query"},
 		{"CLI_STREAMING", lo.Ternary(opts.Streaming != "" && opts.Streaming != "AUTO", opts.Streaming, ""), "--streaming"},
 		{"CLI_STYLED_OUTPUT", lo.Ternary(opts.Color != "" && opts.Color != "AUTO", opts.Color, ""), "--color"},
@@ -611,9 +620,7 @@ func newFlagParser(gopts *globalOptions, installFrom string, configFiles []strin
 		kong.Vars{
 			"version":                 getVersion(),
 			"installFrom":             installFrom,
-			"defaultPrompt":           defaultPrompt,
 			"defaultPromptQuoted":     strconv.Quote(defaultPrompt),
-			"defaultPrompt2":          defaultPrompt2,
 			"defaultPrompt2Quoted":    strconv.Quote(defaultPrompt2),
 			"defaultHistoryFile":      defaultHistoryFile,
 			"defaultVertexAIModel":    defaultVertexAIModel,

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -88,61 +88,65 @@ func (v showVersionFlag) BeforeReset(app *kong.Kong, vars kong.Vars) error {
 }
 
 type spannerOptions struct {
-	ProjectId                 string            `name:"project" short:"p" help:"(required) GCP Project ID ($SPANNER_PROJECT_ID)."`
-	InstanceId                string            `name:"instance" short:"i" help:"(required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)"`
-	DatabaseId                string            `name:"database" short:"d" help:"Cloud Spanner Database ID. Optional when --detached is used ($SPANNER_DATABASE_ID)."`
-	Detached                  bool              `name:"detached" help:"Start in detached mode, ignoring database env var/flag"`
-	Execute                   string            `name:"execute" short:"e" help:"Execute SQL statement and quit. --sql is an alias."`
-	File                      string            `name:"file" short:"f" help:"Execute SQL statement from file and quit. --source is an alias."`
-	Source                    string            `name:"source" hidden:"" help:"Hidden alias of --file for Google Cloud Spanner CLI compatibility"`
-	Table                     bool              `name:"table" short:"t" help:"Display output in table format for batch mode."`
-	HTML                      bool              `name:"html" help:"Display output in HTML format."`
-	XML                       bool              `name:"xml" help:"Display output in XML format."`
-	CSV                       bool              `name:"csv" help:"Display output in CSV format."`
-	Format                    string            `name:"format" help:"Output format (table, tab, vertical, html, xml, csv, jsonl)"`
-	Verbose                   bool              `name:"verbose" short:"v" help:"Display verbose output."`
-	Credential                string            `name:"credential" help:"Use the specific credential file"`
-	Prompt                    *string           `name:"prompt" help:"Set the prompt to the specified format"`
-	Prompt2                   *string           `name:"prompt2" help:"Set the prompt2 to the specified format"`
-	HistoryFile               *string           `name:"history" help:"Set the history file to the specified path"`
-	Priority                  string            `name:"priority" help:"Set default request priority (HIGH|MEDIUM|LOW)"`
-	Role                      string            `name:"role" help:"Use the specific database role. --database-role is an alias."`
-	Endpoint                  string            `name:"endpoint" help:"Set the Spanner API endpoint (host:port)"`
-	Host                      string            `name:"host" help:"Host on which Spanner server is located"`
-	Port                      int               `name:"port" help:"Port number for Spanner connection"`
-	DirectedRead              string            `name:"directed-read" help:"Directed read option (replica_location:replica_type). The replica_type is optional and either READ_ONLY or READ_WRITE"`
-	SQL                       string            `name:"sql" hidden:"" help:"Hidden alias of --execute for gcloud spanner databases execute-sql compatibility"`
-	Set                       map[string]string `name:"set" mapsep:"none" help:"Set system variables e.g. --set=name1=value1 --set=name2=value2"`
-	Param                     map[string]string `name:"param" mapsep:"none" help:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64"`
-	ProtoDescriptorFile       string            `name:"proto-descriptor-file" help:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message."`
-	Insecure                  *bool             `name:"insecure" help:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias."`
-	SkipTlsVerify             *bool             `name:"skip-tls-verify" hidden:"" help:"Hidden alias of --insecure from original spanner-cli"`
-	EmbeddedEmulator          bool              `name:"embedded-emulator" help:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
-	EmulatorImage             string            `name:"emulator-image" help:"container image for --embedded-emulator"`
-	EmulatorPlatform          string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded emulator"`
-	SampleDatabase            string            `name:"sample-database" help:"Initialize emulator with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator."`
-	ListSamples               bool              `name:"list-samples" help:"List available sample databases and exit"`
-	OutputTemplate            string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
-	LogLevel                  string            `name:"log-level"`
-	LogGrpc                   bool              `name:"log-grpc" help:"Show gRPC logs"`
-	QueryMode                 string            `name:"query-mode" help:"Mode in which the query must be processed."`
-	Strong                    bool              `name:"strong" help:"Perform a strong query."`
-	ReadTimestamp             string            `name:"read-timestamp" help:"Perform a query at the given timestamp."`
-	VertexAIProject           string            `name:"vertexai-project" help:"Vertex AI project"`
-	VertexAIModel             *string           `name:"vertexai-model" help:"Vertex AI model"`
-	VertexAILocation          *string           `name:"vertexai-location" help:"Vertex AI location"`
-	DatabaseDialect           string            `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database."`
-	ImpersonateServiceAccount string            `name:"impersonate-service-account" help:"Impersonate service account email"`
-	Help                      showHelpFlag      `name:"help" short:"h" help:"Show this help message and exit."`
-	Version                   showVersionFlag   `name:"version" help:"Show version string."`
-	StatementHelp             bool              `name:"statement-help" hidden:"" help:"Show statement help."`
-	DatabaseRole              string            `name:"database-role" hidden:"" help:"Hidden alias of --role for gcloud spanner databases execute-sql compatibility"`
-	DeploymentEndpoint        string            `name:"deployment-endpoint" hidden:"" help:"Hidden alias of --endpoint for Google Cloud Spanner CLI compatibility"`
-	EnablePartitionedDML      bool              `name:"enable-partitioned-dml" help:"Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)"`
-	Timeout                   string            `name:"timeout" help:"Statement timeout (e.g., '10s', '5m', '1h')" default:"10m"`
-	Async                     bool              `name:"async" help:"Return immediately, without waiting for the operation in progress to complete"`
-	TryPartitionQuery         bool              `name:"try-partition-query" help:"Test whether the query can be executed as partition query without execution"`
-	MCP                       bool              `name:"mcp" help:"Run as MCP server"`
+	ProjectId           string            `name:"project" short:"p" help:"(required) GCP Project ID ($SPANNER_PROJECT_ID)."`
+	InstanceId          string            `name:"instance" short:"i" help:"(required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)"`
+	DatabaseId          string            `name:"database" short:"d" help:"Cloud Spanner Database ID. Optional when --detached is used ($SPANNER_DATABASE_ID)."`
+	Detached            bool              `name:"detached" help:"Start in detached mode, ignoring database env var/flag"`
+	Execute             string            `name:"execute" short:"e" help:"Execute SQL statement and quit. --sql is an alias."`
+	File                string            `name:"file" short:"f" help:"Execute SQL statement from file and quit. --source is an alias."`
+	Source              string            `name:"source" hidden:"" help:"Hidden alias of --file for Google Cloud Spanner CLI compatibility"`
+	Table               bool              `name:"table" short:"t" help:"Display output in table format for batch mode."`
+	HTML                bool              `name:"html" help:"Display output in HTML format."`
+	XML                 bool              `name:"xml" help:"Display output in XML format."`
+	CSV                 bool              `name:"csv" help:"Display output in CSV format."`
+	Format              string            `name:"format" help:"Output format (table, tab, vertical, html, xml, csv, jsonl)"`
+	Verbose             bool              `name:"verbose" short:"v" help:"Display verbose output."`
+	Credential          string            `name:"credential" help:"Use the specific credential file"`
+	Prompt              *string           `name:"prompt" help:"Set the prompt to the specified format (default: ${defaultPrompt})"`
+	Prompt2             *string           `name:"prompt2" help:"Set the prompt2 to the specified format (default: ${defaultPrompt2})"`
+	HistoryFile         *string           `name:"history" help:"Set the history file to the specified path (default: ${defaultHistoryFile})"`
+	Priority            string            `name:"priority" help:"Set default request priority (HIGH|MEDIUM|LOW)"`
+	Role                string            `name:"role" help:"Use the specific database role. --database-role is an alias."`
+	Endpoint            string            `name:"endpoint" help:"Set the Spanner API endpoint (host:port)"`
+	Host                string            `name:"host" help:"Host on which Spanner server is located"`
+	Port                int               `name:"port" help:"Port number for Spanner connection"`
+	DirectedRead        string            `name:"directed-read" help:"Directed read option (replica_location:replica_type). The replica_type is optional and either READ_ONLY or READ_WRITE"`
+	SQL                 string            `name:"sql" hidden:"" help:"Hidden alias of --execute for gcloud spanner databases execute-sql compatibility"`
+	Set                 map[string]string `name:"set" mapsep:"none" help:"Set system variables e.g. --set=name1=value1 --set=name2=value2"`
+	Param               map[string]string `name:"param" mapsep:"none" help:"Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only) e.g. --param=\"p1='string_value'\" --param=p2=FLOAT64"`
+	ProtoDescriptorFile string            `name:"proto-descriptor-file" help:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message."`
+	Insecure            *bool             `name:"insecure" help:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias."`
+	SkipTlsVerify       *bool             `name:"skip-tls-verify" hidden:"" help:"Hidden alias of --insecure from original spanner-cli"`
+	EmbeddedEmulator    bool              `name:"embedded-emulator" help:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
+	EmulatorImage       string            `name:"emulator-image" help:"container image for --embedded-emulator"`
+	EmulatorPlatform    string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded emulator"`
+	SampleDatabase      string            `name:"sample-database" help:"Initialize emulator with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator."`
+	ListSamples         bool              `name:"list-samples" help:"List available sample databases and exit"`
+	OutputTemplate      string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
+	LogLevel            string            `name:"log-level"`
+	LogGrpc             bool              `name:"log-grpc" help:"Show gRPC logs"`
+	// QueryMode and DatabaseDialect intentionally stay as plain strings here.
+	// Kong only validates enum tags for required or defaulted values, but these
+	// options are optional and should remain unset unless the user provides them.
+	// Validation still happens later via system-variable initialization.
+	QueryMode                 string          `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE."`
+	Strong                    bool            `name:"strong" help:"Perform a strong query."`
+	ReadTimestamp             string          `name:"read-timestamp" help:"Perform a query at the given timestamp."`
+	VertexAIProject           string          `name:"vertexai-project" help:"Vertex AI project"`
+	VertexAIModel             *string         `name:"vertexai-model" help:"Vertex AI model (default: ${defaultVertexAIModel})"`
+	VertexAILocation          *string         `name:"vertexai-location" help:"Vertex AI location (default: ${defaultVertexAILocation})"`
+	DatabaseDialect           string          `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL."`
+	ImpersonateServiceAccount string          `name:"impersonate-service-account" help:"Impersonate service account email"`
+	Help                      showHelpFlag    `name:"help" short:"h" help:"Show this help message and exit."`
+	Version                   showVersionFlag `name:"version" help:"Show version string."`
+	StatementHelp             bool            `name:"statement-help" hidden:"" help:"Show statement help."`
+	DatabaseRole              string          `name:"database-role" hidden:"" help:"Hidden alias of --role for gcloud spanner databases execute-sql compatibility"`
+	DeploymentEndpoint        string          `name:"deployment-endpoint" hidden:"" help:"Hidden alias of --endpoint for Google Cloud Spanner CLI compatibility"`
+	EnablePartitionedDML      bool            `name:"enable-partitioned-dml" help:"Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)"`
+	Timeout                   string          `name:"timeout" help:"Statement timeout (e.g., '10s', '5m', '1h')" default:"10m"`
+	Async                     bool            `name:"async" help:"Return immediately, without waiting for the operation in progress to complete"`
+	TryPartitionQuery         bool            `name:"try-partition-query" help:"Test whether the query can be executed as partition query without execution"`
+	MCP                       bool            `name:"mcp" help:"Run as MCP server"`
 	// SkipSystemCommand is kept for compatibility with official Spanner CLI.
 	// The official implementation uses --skip-system-command to disable shell commands,
 	// so we maintain the same flag name and behavior for consistency.
@@ -150,7 +154,7 @@ type spannerOptions struct {
 	// SystemCommand provides an alternative way to control system command execution.
 	// It accepts ON/OFF values and is maintained for compatibility with Google Cloud Spanner CLI.
 	// When both --skip-system-command and --system-command are used, --skip-system-command takes precedence.
-	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF)" enum:"ON,OFF"`
+	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF"`
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
 	Output          string  `name:"output" short:"o" help:"Redirect output to file (file only, no screen output)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`
@@ -607,8 +611,13 @@ func newFlagParser(gopts *globalOptions, installFrom string, configFiles []strin
 		kong.NoDefaultHelp(),
 		kong.Writers(stdout, stderr),
 		kong.Vars{
-			"version":     getVersion(),
-			"installFrom": installFrom,
+			"version":                 getVersion(),
+			"installFrom":             installFrom,
+			"defaultPrompt":           defaultPrompt,
+			"defaultPrompt2":          defaultPrompt2,
+			"defaultHistoryFile":      defaultHistoryFile,
+			"defaultVertexAIModel":    defaultVertexAIModel,
+			"defaultVertexAILocation": defaultVertexAILocation,
 		},
 	}
 

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -32,7 +32,6 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/alecthomas/kong"
-	kongtoml "github.com/alecthomas/kong-toml"
 	"github.com/apstndb/spanemuboost"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
@@ -102,8 +101,8 @@ type spannerOptions struct {
 	Format              string            `name:"format" help:"Output format (table, tab, vertical, html, xml, csv, jsonl)"`
 	Verbose             bool              `name:"verbose" short:"v" help:"Display verbose output."`
 	Credential          string            `name:"credential" help:"Use the specific credential file"`
-	Prompt              *string           `name:"prompt" help:"Set the prompt to the specified format (default: ${defaultPrompt})"`
-	Prompt2             *string           `name:"prompt2" help:"Set the prompt2 to the specified format (default: ${defaultPrompt2})"`
+	Prompt              *string           `name:"prompt" help:"Set the prompt to the specified format (default: ${defaultPromptQuoted})"`
+	Prompt2             *string           `name:"prompt2" help:"Set the prompt2 to the specified format (default: ${defaultPrompt2Quoted})"`
 	HistoryFile         *string           `name:"history" help:"Set the history file to the specified path (default: ${defaultHistoryFile})"`
 	Priority            string            `name:"priority" help:"Set default request priority (HIGH|MEDIUM|LOW)"`
 	Role                string            `name:"role" help:"Use the specific database role. --database-role is an alias."`
@@ -614,7 +613,9 @@ func newFlagParser(gopts *globalOptions, installFrom string, configFiles []strin
 			"version":                 getVersion(),
 			"installFrom":             installFrom,
 			"defaultPrompt":           defaultPrompt,
+			"defaultPromptQuoted":     strconv.Quote(defaultPrompt),
 			"defaultPrompt2":          defaultPrompt2,
+			"defaultPrompt2Quoted":    strconv.Quote(defaultPrompt2),
 			"defaultHistoryFile":      defaultHistoryFile,
 			"defaultVertexAIModel":    defaultVertexAIModel,
 			"defaultVertexAILocation": defaultVertexAILocation,
@@ -622,9 +623,9 @@ func newFlagParser(gopts *globalOptions, installFrom string, configFiles []strin
 	}
 
 	if len(configFiles) > 0 {
-		// kong-toml normalizes configuration to hyphen-separated keys and its
-		// validator rejects unknown underscore variants such as vertexai_project.
-		options = append(options, kong.Configuration(kongtoml.Loader, configFiles...))
+		// Keep kong-toml's normal hyphenated lookup while also accepting
+		// snake_case aliases such as vertexai_project for user convenience.
+		options = append(options, kong.Configuration(underscoreCompatibleTOMLLoader, configFiles...))
 	}
 	// Context.Resolve keeps the last non-nil resolver result, so appending the
 	// SPANNER_* resolver after TOML preserves CLI > env > config precedence.

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -86,8 +86,8 @@ func (v showVersionFlag) BeforeReset(app *kong.Kong, vars kong.Vars) error {
 	return versionRequestedError{}
 }
 
-// caseInsensitiveEnumValue preserves case-insensitive CLI input while still
-// allowing Kong enum validation to run on the normalized uppercase value.
+// caseInsensitiveEnumValue accepts case-insensitive CLI input and normalizes
+// it to uppercase so Kong enum validation runs on the normalized value.
 type caseInsensitiveEnumValue string
 
 func (v *caseInsensitiveEnumValue) UnmarshalText(text []byte) error {

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -135,7 +135,7 @@ type spannerOptions struct {
 	VertexAIProject           string          `name:"vertexai-project" help:"Vertex AI project"`
 	VertexAIModel             *string         `name:"vertexai-model" help:"Vertex AI model (default: ${defaultVertexAIModel})"`
 	VertexAILocation          *string         `name:"vertexai-location" help:"Vertex AI location (default: ${defaultVertexAILocation})"`
-	DatabaseDialect           string          `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL."`
+	DatabaseDialect           string          `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset."`
 	ImpersonateServiceAccount string          `name:"impersonate-service-account" help:"Impersonate service account email"`
 	Help                      showHelpFlag    `name:"help" short:"h" help:"Show this help message and exit."`
 	Version                   showVersionFlag `name:"version" help:"Show version string."`
@@ -622,6 +622,8 @@ func newFlagParser(gopts *globalOptions, installFrom string, configFiles []strin
 	}
 
 	if len(configFiles) > 0 {
+		// kong-toml normalizes configuration to hyphen-separated keys and its
+		// validator rejects unknown underscore variants such as vertexai_project.
 		options = append(options, kong.Configuration(kongtoml.Loader, configFiles...))
 	}
 	// Context.Resolve keeps the last non-nil resolver result, so appending the

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -124,17 +124,16 @@ type spannerOptions struct {
 	OutputTemplate      string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
 	LogLevel            string            `name:"log-level"`
 	LogGrpc             bool              `name:"log-grpc" help:"Show gRPC logs"`
-	// QueryMode and DatabaseDialect intentionally stay as plain strings here.
-	// Kong only validates enum tags for required or defaulted values, but these
-	// options are optional and should remain unset unless the user provides them.
-	// Validation still happens later via system-variable initialization.
-	QueryMode                 string          `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE."`
+	// Kong only accepts enum validation on optional flags when they are modeled as
+	// pointers. Keeping these as *string preserves "unset" semantics while still
+	// letting Kong validate and document the allowed values natively.
+	QueryMode                 *string         `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE." enum:"NORMAL,PLAN,PROFILE"`
 	Strong                    bool            `name:"strong" help:"Perform a strong query."`
 	ReadTimestamp             string          `name:"read-timestamp" help:"Perform a query at the given timestamp."`
 	VertexAIProject           string          `name:"vertexai-project" help:"Vertex AI project"`
 	VertexAIModel             *string         `name:"vertexai-model" help:"Vertex AI model (default: ${defaultVertexAIModel})"`
 	VertexAILocation          *string         `name:"vertexai-location" help:"Vertex AI location (default: ${defaultVertexAILocation})"`
-	DatabaseDialect           string          `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset."`
+	DatabaseDialect           *string         `name:"database-dialect" help:"The SQL dialect of the Cloud Spanner Database. Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset." enum:"POSTGRESQL,GOOGLE_STANDARD_SQL,DATABASE_DIALECT_UNSPECIFIED"`
 	ImpersonateServiceAccount string          `name:"impersonate-service-account" help:"Impersonate service account email"`
 	Help                      showHelpFlag    `name:"help" short:"h" help:"Show this help message and exit."`
 	Version                   showVersionFlag `name:"version" help:"Show version string."`
@@ -150,10 +149,10 @@ type spannerOptions struct {
 	// The official implementation uses --skip-system-command to disable shell commands,
 	// so we maintain the same flag name and behavior for consistency.
 	SkipSystemCommand bool `name:"skip-system-command" help:"Do not allow system commands"`
-	// SystemCommand provides an alternative way to control system command execution.
-	// It accepts ON/OFF values and is maintained for compatibility with Google Cloud Spanner CLI.
-	// When both --skip-system-command and --system-command are used, --skip-system-command takes precedence.
-	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF"`
+	// SystemCommand provides an alternative way to control system command
+	// execution. Kong's default keeps the documented ON value aligned with the
+	// effective default, while --skip-system-command still takes precedence.
+	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF" default:"ON"`
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
 	Output          string  `name:"output" short:"o" help:"Redirect output to file (file only, no screen output)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`
@@ -543,11 +542,11 @@ func initializeSystemVariables(opts *spannerOptions) (*systemVariables, error) {
 	lo.Must0(sysVars.SetFromSimple("CLI_ANALYZE_COLUMNS", DefaultAnalyzeColumns))
 
 	if err := applyOptionMappings(sysVars, []optionMapping{
-		{"CLI_DATABASE_DIALECT", opts.DatabaseDialect, "--database-dialect"},
+		{"CLI_DATABASE_DIALECT", lo.FromPtr(opts.DatabaseDialect), "--database-dialect"},
 		{"AUTOCOMMIT_DML_MODE", lo.Ternary(opts.EnablePartitionedDML, "PARTITIONED_NON_ATOMIC", ""), "--enable-partitioned-dml"},
 		{"STATEMENT_TIMEOUT", opts.Timeout, "--timeout"},
 		{"RPC_PRIORITY", cmp.Or(opts.Priority, "MEDIUM"), "--priority"},
-		{"CLI_QUERY_MODE", opts.QueryMode, "--query-mode"},
+		{"CLI_QUERY_MODE", lo.FromPtr(opts.QueryMode), "--query-mode"},
 		{"CLI_TRY_PARTITION_QUERY", lo.Ternary(opts.TryPartitionQuery, "TRUE", ""), "--try-partition-query"},
 		{"CLI_STREAMING", lo.Ternary(opts.Streaming != "" && opts.Streaming != "AUTO", opts.Streaming, ""), "--streaming"},
 		{"CLI_STYLED_OUTPUT", lo.Ternary(opts.Color != "" && opts.Color != "AUTO", opts.Color, ""), "--color"},

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -161,7 +161,7 @@ type spannerOptions struct {
 	// SystemCommand provides an alternative way to control system command
 	// execution. Kong's default keeps the documented ON value aligned with the
 	// effective default, while --skip-system-command still takes precedence.
-	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF" default:"ON"`
+	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF" default:"ON" placeholder:"ON|OFF"`
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
 	Output          string  `name:"output" short:"o" help:"Redirect output to file (file only, no screen output)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -66,12 +66,14 @@ func (r *underscoreCompatibleTOMLResolver) Resolve(kctx *kong.Context, parent *k
 func (r *underscoreCompatibleTOMLResolver) Validate(app *kong.Application) error {
 	configKeys := map[string]bool{}
 	flattenTOMLTree("", r.tree, configKeys)
-	_ = kong.Visit(app, func(node kong.Visitable, next kong.Next) error {
+	if err := kong.Visit(app, func(node kong.Visitable, next kong.Next) error {
 		if flag, ok := node.(*kong.Flag); ok {
 			deleteMatchingConfigKeys(configKeys, flag.Name)
 		}
 		return next(nil)
-	})
+	}); err != nil {
+		return err
+	}
 	if len(configKeys) > 0 {
 		keys := slices.Collect(maps.Keys(configKeys))
 		slices.Sort(keys)

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -30,18 +30,18 @@ import (
 // underscoreCompatibleTOMLLoader keeps kong-toml's hyphenated key model while
 // also accepting snake_case aliases for user-facing configuration keys.
 func underscoreCompatibleTOMLLoader(r io.Reader) (kong.Resolver, error) {
-	tree, err := toml.LoadReader(r)
-	if err != nil {
-		return nil, err
-	}
-	normalizedTree, err := normalizeTOMLValue(tree.ToMap())
-	if err != nil {
-		return nil, err
-	}
-
 	var filename string
 	if named, ok := r.(interface{ Name() string }); ok {
 		filename = named.Name()
+	}
+
+	tree, err := toml.LoadReader(r)
+	if err != nil {
+		return nil, formatConfigError(filename, err)
+	}
+	normalizedTree, err := normalizeTOMLValue(tree.ToMap())
+	if err != nil {
+		return nil, formatConfigError(filename, err)
 	}
 	return &underscoreCompatibleTOMLResolver{
 		filename: filename,
@@ -76,9 +76,16 @@ func (r *underscoreCompatibleTOMLResolver) Validate(app *kong.Application) error
 	if len(configKeys) > 0 {
 		keys := slices.Collect(maps.Keys(configKeys))
 		slices.Sort(keys)
-		return fmt.Errorf("%s: unknown configuration keys: %s", r.filename, strings.Join(keys, ", "))
+		return formatConfigError(r.filename, fmt.Errorf("unknown configuration keys: %s", strings.Join(keys, ", ")))
 	}
 	return nil
+}
+
+func formatConfigError(filename string, err error) error {
+	if filename == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", filename, err)
 }
 
 func (r *underscoreCompatibleTOMLResolver) findValue(parent *kong.Path, flag *kong.Flag) (any, bool) {

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -1,0 +1,163 @@
+//
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package mycli
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/pelletier/go-toml"
+)
+
+// underscoreCompatibleTOMLLoader keeps kong-toml's hyphenated key model while
+// also accepting snake_case aliases for user-facing configuration keys.
+func underscoreCompatibleTOMLLoader(r io.Reader) (kong.Resolver, error) {
+	tree, err := toml.LoadReader(r)
+	if err != nil {
+		return nil, err
+	}
+	normalizedTree, err := normalizeTOMLValue(tree.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	var filename string
+	if named, ok := r.(interface{ Name() string }); ok {
+		filename = named.Name()
+	}
+	return &underscoreCompatibleTOMLResolver{
+		filename: filename,
+		tree:     normalizedTree.(map[string]any),
+	}, nil
+}
+
+// underscoreCompatibleTOMLResolver is a lightly adapted copy of kong-toml's
+// resolver so validation/lookup operate on the normalized alias map.
+type underscoreCompatibleTOMLResolver struct {
+	filename string
+	tree     map[string]any
+}
+
+func (r *underscoreCompatibleTOMLResolver) Resolve(kctx *kong.Context, parent *kong.Path, flag *kong.Flag) (any, error) {
+	value, ok := r.findValue(parent, flag)
+	if !ok {
+		return nil, nil
+	}
+	return value, nil
+}
+
+func (r *underscoreCompatibleTOMLResolver) Validate(app *kong.Application) error {
+	configKeys := map[string]bool{}
+	flattenNormalizedTOMLTree("", r.tree, configKeys)
+	_ = kong.Visit(app, func(node kong.Visitable, next kong.Next) error {
+		if flag, ok := node.(*kong.Flag); ok {
+			delete(configKeys, flag.Name)
+		}
+		return next(nil)
+	})
+	if len(configKeys) > 0 {
+		keys := slices.Collect(maps.Keys(configKeys))
+		slices.Sort(keys)
+		return fmt.Errorf("%s: unknown configuration keys: %s", r.filename, strings.Join(keys, ", "))
+	}
+	return nil
+}
+
+func (r *underscoreCompatibleTOMLResolver) findValue(parent *kong.Path, flag *kong.Flag) (any, bool) {
+	keys := []string{
+		strings.Join(append(strings.Split(parent.Node().Path(), "-"), flag.Name), "-"),
+		flag.Name,
+	}
+	return r.findValueFromKeys(keys)
+}
+
+func (r *underscoreCompatibleTOMLResolver) findValueFromKeys(keys []string) (any, bool) {
+	for _, key := range keys {
+		parts := strings.Split(key, "-")
+		if value, ok := r.findValueParts(parts[0], parts[1:], r.tree); ok {
+			return value, ok
+		}
+	}
+	return nil, false
+}
+
+func (r *underscoreCompatibleTOMLResolver) findValueParts(prefix string, suffix []string, tree map[string]any) (any, bool) {
+	if value, ok := tree[prefix]; ok {
+		if len(suffix) == 0 {
+			return value, true
+		}
+		if branch, ok := value.(map[string]any); ok {
+			return r.findValueParts(suffix[0], suffix[1:], branch)
+		}
+	}
+	if len(suffix) > 0 {
+		return r.findValueParts(prefix+"-"+suffix[0], suffix[1:], tree)
+	}
+	return nil, false
+}
+
+func flattenNormalizedTOMLTree(prefix string, tree any, flags map[string]bool) {
+	switch tree := tree.(type) {
+	case map[string]any:
+		for key, value := range tree {
+			if prefix == "" {
+				flattenNormalizedTOMLTree(key, value, flags)
+			} else {
+				flattenNormalizedTOMLTree(prefix+"-"+key, value, flags)
+			}
+		}
+	default:
+		flags[prefix] = true
+	}
+}
+
+func normalizeTOMLValue(value any) (any, error) {
+	switch value := value.(type) {
+	case map[string]any:
+		normalized := make(map[string]any, len(value))
+		rawKeys := map[string]string{}
+		for rawKey, rawValue := range value {
+			normalizedKey := strings.ReplaceAll(rawKey, "_", "-")
+			if previous, exists := rawKeys[normalizedKey]; exists {
+				return nil, fmt.Errorf("duplicate configuration keys after underscore normalization: %s, %s", previous, rawKey)
+			}
+			normalizedValue, err := normalizeTOMLValue(rawValue)
+			if err != nil {
+				return nil, err
+			}
+			rawKeys[normalizedKey] = rawKey
+			normalized[normalizedKey] = normalizedValue
+		}
+		return normalized, nil
+	case []any:
+		normalized := make([]any, len(value))
+		for i, entry := range value {
+			normalizedEntry, err := normalizeTOMLValue(entry)
+			if err != nil {
+				return nil, err
+			}
+			normalized[i] = normalizedEntry
+		}
+		return normalized, nil
+	default:
+		return value, nil
+	}
+}

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -131,6 +131,10 @@ func (r *underscoreCompatibleTOMLResolver) findValueParts(prefix string, suffix 
 func flattenTOMLTree(prefix string, tree any, flags map[string]bool) {
 	switch tree := tree.(type) {
 	case map[string]any:
+		if prefix != "" && len(tree) == 0 {
+			flags[prefix] = true
+			return
+		}
 		for key, value := range tree {
 			if prefix == "" {
 				flattenTOMLTree(key, value, flags)

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -66,14 +66,7 @@ func (r *underscoreCompatibleTOMLResolver) Resolve(kctx *kong.Context, parent *k
 func (r *underscoreCompatibleTOMLResolver) Validate(app *kong.Application) error {
 	configKeys := map[string]bool{}
 	flattenTOMLTree("", r.tree, configKeys)
-	if err := kong.Visit(app, func(node kong.Visitable, next kong.Next) error {
-		if flag, ok := node.(*kong.Flag); ok {
-			deleteMatchingConfigKeys(configKeys, flag)
-		}
-		return next(nil)
-	}); err != nil {
-		return err
-	}
+	deleteMatchingNodeConfigKeys(configKeys, app.Node)
 	if len(configKeys) > 0 {
 		keys := slices.Collect(maps.Keys(configKeys))
 		slices.Sort(keys)
@@ -149,15 +142,31 @@ func flattenTOMLTree(prefix string, tree any, flags map[string]bool) {
 	}
 }
 
-func deleteMatchingConfigKeys(configKeys map[string]bool, flag *kong.Flag) {
-	for _, prefix := range []string{flag.Name, strings.ReplaceAll(flag.Name, "-", "_")} {
-		delete(configKeys, prefix)
-		if !flag.IsMap() {
-			continue
-		}
-		for key := range configKeys {
-			if strings.HasPrefix(key, prefix+"-") {
-				delete(configKeys, key)
+func deleteMatchingNodeConfigKeys(configKeys map[string]bool, node *kong.Node) {
+	path := node.Path()
+	for _, flag := range node.Flags {
+		deleteMatchingConfigKeys(configKeys, flag, path)
+	}
+	for _, child := range node.Children {
+		deleteMatchingNodeConfigKeys(configKeys, child)
+	}
+}
+
+func deleteMatchingConfigKeys(configKeys map[string]bool, flag *kong.Flag, nodePath string) {
+	prefixes := []string{flag.Name}
+	if nodePath != "" {
+		prefixes = append(prefixes, nodePath+"-"+flag.Name)
+	}
+	for _, prefix := range prefixes {
+		for _, prefix := range []string{prefix, strings.ReplaceAll(prefix, "-", "_")} {
+			delete(configKeys, prefix)
+			if !flag.IsMap() {
+				continue
+			}
+			for key := range configKeys {
+				if strings.HasPrefix(key, prefix+"-") {
+					delete(configKeys, key)
+				}
 			}
 		}
 	}

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -39,13 +39,9 @@ func underscoreCompatibleTOMLLoader(r io.Reader) (kong.Resolver, error) {
 	if err != nil {
 		return nil, formatConfigError(filename, err)
 	}
-	normalizedTree, err := normalizeTOMLValue(tree.ToMap())
-	if err != nil {
-		return nil, formatConfigError(filename, err)
-	}
 	return &underscoreCompatibleTOMLResolver{
 		filename: filename,
-		tree:     normalizedTree.(map[string]any),
+		tree:     tree.ToMap(),
 	}, nil
 }
 
@@ -57,7 +53,10 @@ type underscoreCompatibleTOMLResolver struct {
 }
 
 func (r *underscoreCompatibleTOMLResolver) Resolve(kctx *kong.Context, parent *kong.Path, flag *kong.Flag) (any, error) {
-	value, ok := r.findValue(parent, flag)
+	value, ok, err := r.findValue(parent, flag)
+	if err != nil {
+		return nil, formatConfigError(r.filename, err)
+	}
 	if !ok {
 		return nil, nil
 	}
@@ -66,10 +65,10 @@ func (r *underscoreCompatibleTOMLResolver) Resolve(kctx *kong.Context, parent *k
 
 func (r *underscoreCompatibleTOMLResolver) Validate(app *kong.Application) error {
 	configKeys := map[string]bool{}
-	flattenNormalizedTOMLTree("", r.tree, configKeys)
+	flattenTOMLTree("", r.tree, configKeys)
 	_ = kong.Visit(app, func(node kong.Visitable, next kong.Next) error {
 		if flag, ok := node.(*kong.Flag); ok {
-			delete(configKeys, flag.Name)
+			deleteMatchingConfigKeys(configKeys, flag.Name)
 		}
 		return next(nil)
 	})
@@ -88,7 +87,7 @@ func formatConfigError(filename string, err error) error {
 	return fmt.Errorf("%s: %w", filename, err)
 }
 
-func (r *underscoreCompatibleTOMLResolver) findValue(parent *kong.Path, flag *kong.Flag) (any, bool) {
+func (r *underscoreCompatibleTOMLResolver) findValue(parent *kong.Path, flag *kong.Flag) (any, bool, error) {
 	keys := []string{
 		strings.Join(append(strings.Split(parent.Node().Path(), "-"), flag.Name), "-"),
 		flag.Name,
@@ -96,20 +95,28 @@ func (r *underscoreCompatibleTOMLResolver) findValue(parent *kong.Path, flag *ko
 	return r.findValueFromKeys(keys)
 }
 
-func (r *underscoreCompatibleTOMLResolver) findValueFromKeys(keys []string) (any, bool) {
+func (r *underscoreCompatibleTOMLResolver) findValueFromKeys(keys []string) (any, bool, error) {
 	for _, key := range keys {
 		parts := strings.Split(key, "-")
-		if value, ok := r.findValueParts(parts[0], parts[1:], r.tree); ok {
-			return value, ok
+		value, ok, err := r.findValueParts(parts[0], parts[1:], r.tree)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return value, ok, nil
 		}
 	}
-	return nil, false
+	return nil, false, nil
 }
 
-func (r *underscoreCompatibleTOMLResolver) findValueParts(prefix string, suffix []string, tree map[string]any) (any, bool) {
-	if value, ok := tree[prefix]; ok {
+func (r *underscoreCompatibleTOMLResolver) findValueParts(prefix string, suffix []string, tree map[string]any) (any, bool, error) {
+	value, ok, err := findAliasValue(tree, prefix)
+	if err != nil {
+		return nil, false, err
+	}
+	if ok {
 		if len(suffix) == 0 {
-			return value, true
+			return value, true, nil
 		}
 		if branch, ok := value.(map[string]any); ok {
 			return r.findValueParts(suffix[0], suffix[1:], branch)
@@ -118,17 +125,17 @@ func (r *underscoreCompatibleTOMLResolver) findValueParts(prefix string, suffix 
 	if len(suffix) > 0 {
 		return r.findValueParts(prefix+"-"+suffix[0], suffix[1:], tree)
 	}
-	return nil, false
+	return nil, false, nil
 }
 
-func flattenNormalizedTOMLTree(prefix string, tree any, flags map[string]bool) {
+func flattenTOMLTree(prefix string, tree any, flags map[string]bool) {
 	switch tree := tree.(type) {
 	case map[string]any:
 		for key, value := range tree {
 			if prefix == "" {
-				flattenNormalizedTOMLTree(key, value, flags)
+				flattenTOMLTree(key, value, flags)
 			} else {
-				flattenNormalizedTOMLTree(prefix+"-"+key, value, flags)
+				flattenTOMLTree(prefix+"-"+key, value, flags)
 			}
 		}
 	default:
@@ -136,35 +143,40 @@ func flattenNormalizedTOMLTree(prefix string, tree any, flags map[string]bool) {
 	}
 }
 
-func normalizeTOMLValue(value any) (any, error) {
-	switch value := value.(type) {
-	case map[string]any:
-		normalized := make(map[string]any, len(value))
-		rawKeys := map[string]string{}
-		for rawKey, rawValue := range value {
-			normalizedKey := strings.ReplaceAll(rawKey, "_", "-")
-			if previous, exists := rawKeys[normalizedKey]; exists {
-				return nil, fmt.Errorf("duplicate configuration keys after underscore normalization: %s, %s", previous, rawKey)
+func deleteMatchingConfigKeys(configKeys map[string]bool, flagName string) {
+	for _, prefix := range []string{flagName, strings.ReplaceAll(flagName, "-", "_")} {
+		delete(configKeys, prefix)
+		for key := range configKeys {
+			if strings.HasPrefix(key, prefix+"-") {
+				delete(configKeys, key)
 			}
-			normalizedValue, err := normalizeTOMLValue(rawValue)
-			if err != nil {
-				return nil, err
-			}
-			rawKeys[normalizedKey] = rawKey
-			normalized[normalizedKey] = normalizedValue
 		}
-		return normalized, nil
-	case []any:
-		normalized := make([]any, len(value))
-		for i, entry := range value {
-			normalizedEntry, err := normalizeTOMLValue(entry)
-			if err != nil {
-				return nil, err
-			}
-			normalized[i] = normalizedEntry
-		}
-		return normalized, nil
-	default:
-		return value, nil
 	}
+}
+
+func findAliasValue(tree map[string]any, key string) (any, bool, error) {
+	candidates := []string{key}
+	if underscored := strings.ReplaceAll(key, "-", "_"); underscored != key {
+		candidates = append(candidates, underscored)
+	}
+
+	var (
+		foundKey   string
+		foundValue any
+	)
+	for _, candidate := range candidates {
+		value, ok := tree[candidate]
+		if !ok {
+			continue
+		}
+		if foundKey != "" {
+			return nil, false, fmt.Errorf("duplicate configuration keys for %q: %s, %s", key, foundKey, candidate)
+		}
+		foundKey = candidate
+		foundValue = value
+	}
+	if foundKey == "" {
+		return nil, false, nil
+	}
+	return foundValue, true, nil
 }

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -68,7 +68,7 @@ func (r *underscoreCompatibleTOMLResolver) Validate(app *kong.Application) error
 	flattenTOMLTree("", r.tree, configKeys)
 	if err := kong.Visit(app, func(node kong.Visitable, next kong.Next) error {
 		if flag, ok := node.(*kong.Flag); ok {
-			deleteMatchingConfigKeys(configKeys, flag.Name)
+			deleteMatchingConfigKeys(configKeys, flag)
 		}
 		return next(nil)
 	}); err != nil {
@@ -149,9 +149,12 @@ func flattenTOMLTree(prefix string, tree any, flags map[string]bool) {
 	}
 }
 
-func deleteMatchingConfigKeys(configKeys map[string]bool, flagName string) {
-	for _, prefix := range []string{flagName, strings.ReplaceAll(flagName, "-", "_")} {
+func deleteMatchingConfigKeys(configKeys map[string]bool, flag *kong.Flag) {
+	for _, prefix := range []string{flag.Name, strings.ReplaceAll(flag.Name, "-", "_")} {
 		delete(configKeys, prefix)
+		if !flag.IsMap() {
+			continue
+		}
 		for key := range configKeys {
 			if strings.HasPrefix(key, prefix+"-") {
 				delete(configKeys, key)

--- a/internal/mycli/kong_toml_loader.go
+++ b/internal/mycli/kong_toml_loader.go
@@ -83,10 +83,12 @@ func formatConfigError(filename string, err error) error {
 }
 
 func (r *underscoreCompatibleTOMLResolver) findValue(parent *kong.Path, flag *kong.Flag) (any, bool, error) {
-	keys := []string{
-		strings.Join(append(strings.Split(parent.Node().Path(), "-"), flag.Name), "-"),
-		flag.Name,
+	parentPath := parent.Node().Path()
+	keys := make([]string, 0, 2)
+	if parentPath != "" {
+		keys = append(keys, strings.Join(append(strings.Split(parentPath, "-"), flag.Name), "-"))
 	}
+	keys = append(keys, flag.Name)
 	return r.findValueFromKeys(keys)
 }
 
@@ -158,13 +160,13 @@ func deleteMatchingConfigKeys(configKeys map[string]bool, flag *kong.Flag, nodeP
 		prefixes = append(prefixes, nodePath+"-"+flag.Name)
 	}
 	for _, prefix := range prefixes {
-		for _, prefix := range []string{prefix, strings.ReplaceAll(prefix, "-", "_")} {
-			delete(configKeys, prefix)
+		for _, candidatePrefix := range []string{prefix, strings.ReplaceAll(prefix, "-", "_")} {
+			delete(configKeys, candidatePrefix)
 			if !flag.IsMap() {
 				continue
 			}
 			for key := range configKeys {
-				if strings.HasPrefix(key, prefix+"-") {
+				if strings.HasPrefix(key, candidatePrefix+"-") {
 					delete(configKeys, key)
 				}
 			}

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1842,7 +1842,7 @@ func TestHelpAndVersionFlags(t *testing.T) {
 	}
 }
 
-func TestHelpOutputDocumentsDefaultsAndConfigKeys(t *testing.T) {
+func TestHelpOutputDocumentsDefaultsAndAllowedValues(t *testing.T) {
 	t.Parallel()
 
 	var stdout bytes.Buffer

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1995,6 +1995,29 @@ CLI_FORMAT = "VERTICAL"
 		}
 	})
 
+	t.Run("nested typo under scalar flag is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		configFile := filepath.Join(t.TempDir(), configFileName)
+		if err := os.WriteFile(configFile, []byte(`project = "p"
+instance = "i"
+database = "d"
+
+[vertexai]
+project-id = "example-project"
+`), 0o644); err != nil {
+			t.Fatalf("Failed to create config file: %v", err)
+		}
+
+		_, err := parseTestFlags(nil, configFile)
+		if err == nil {
+			t.Fatal("parseTestFlags() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "unknown configuration keys: vertexai-project-id") {
+			t.Fatalf("parseTestFlags() error = %v, want nested scalar typo error", err)
+		}
+	})
+
 	t.Run("unknown empty table is rejected", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/alecthomas/kong"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/creack/pty"
 	"github.com/google/go-cmp/cmp"
@@ -78,6 +79,20 @@ func assertEqual[T comparable](t *testing.T, fieldName string, got T, want *T) {
 	t.Helper()
 	if want != nil && got != *want {
 		t.Errorf("%s = %v, want %v", fieldName, got, *want)
+	}
+}
+
+func assertStringPtrEqual(t *testing.T, fieldName string, got, want *string) {
+	t.Helper()
+	if want == nil {
+		return
+	}
+	if got == nil {
+		t.Errorf("%s = nil, want %q", fieldName, *want)
+		return
+	}
+	if *got != *want {
+		t.Errorf("%s = %q, want %q", fieldName, *got, *want)
 	}
 }
 
@@ -219,8 +234,8 @@ func verifySpannerOptions(t *testing.T, got *spannerOptions, want *spannerOption
 		return
 	}
 	assertEqual(t, "Priority", got.Priority, want.Priority)
-	assertEqual(t, "QueryMode", got.QueryMode, want.QueryMode)
-	assertEqual(t, "DatabaseDialect", got.DatabaseDialect, want.DatabaseDialect)
+	assertStringPtrEqual(t, "QueryMode", got.QueryMode, want.QueryMode)
+	assertStringPtrEqual(t, "DatabaseDialect", got.DatabaseDialect, want.DatabaseDialect)
 	assertEqual(t, "DirectedRead", got.DirectedRead, want.DirectedRead)
 	assertEqual(t, "ReadTimestamp", got.ReadTimestamp, want.ReadTimestamp)
 	assertEqual(t, "Timeout", got.Timeout, want.Timeout)
@@ -416,12 +431,12 @@ func TestParseFlagsValidation(t *testing.T) {
 		{
 			name:        "invalid query-mode value",
 			args:        withRequiredFlags("--query-mode", "INVALID"),
-			errContains: "invalid value of --query-mode",
+			errContains: "--query-mode must be one of",
 		},
 		{
 			name:        "invalid database-dialect value",
 			args:        withRequiredFlags("--database-dialect", "INVALID"),
-			errContains: "invalid value of --database-dialect",
+			errContains: "--database-dialect must be one of",
 		},
 
 		// Format validation
@@ -1937,6 +1952,19 @@ vertexai_project = "other-project"
 			t.Fatalf("parseTestFlags() error = %v, want duplicate alias error", err)
 		}
 	})
+}
+
+func TestKongOptionalEnumUsesPointerSemantics(t *testing.T) {
+	t.Parallel()
+
+	type opts struct {
+		QueryMode       *string `name:"query-mode" enum:"NORMAL,PLAN,PROFILE"`
+		DatabaseDialect *string `name:"database-dialect" enum:"POSTGRESQL,GOOGLE_STANDARD_SQL,DATABASE_DIALECT_UNSPECIFIED"`
+	}
+
+	if _, err := kong.New(&opts{}); err != nil {
+		t.Fatalf("kong.New() error = %v, want nil", err)
+	}
 }
 
 // TestComplexFlagInteractions tests complex interactions between multiple flags

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1884,6 +1884,7 @@ func TestHelpOutputDocumentsDefaultsAndAllowedValues(t *testing.T) {
 
 	helpOutput := normalizeWhitespace(stdout.String())
 	for _, want := range []string{
+		"--system-command=ON|OFF",
 		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt)),
 		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt2)),
 		fmt.Sprintf("default: %s", defaultHistoryFile),

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1853,13 +1853,13 @@ func TestHelpOutputDocumentsDefaultsAndConfigKeys(t *testing.T) {
 
 	helpOutput := normalizeWhitespace(stdout.String())
 	for _, want := range []string{
-		"default: spanner%t> ",
-		"default: %P%R> ",
-		"default: /tmp/spanner_mycli_readline.tmp",
+		fmt.Sprintf("default: %s", defaultPrompt),
+		fmt.Sprintf("default: %s", defaultPrompt2),
+		fmt.Sprintf("default: %s", defaultHistoryFile),
 		"Allowed values: NORMAL, PLAN, PROFILE.",
-		"default: gemini-3-flash-preview",
-		"default: global",
-		"Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL.",
+		fmt.Sprintf("default: %s", defaultVertexAIModel),
+		fmt.Sprintf("default: %s", defaultVertexAILocation),
+		"Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset.",
 		"Default: ON.",
 	} {
 		if !strings.Contains(helpOutput, want) {
@@ -1893,7 +1893,7 @@ vertexai-project = "example-project"
 		}
 	})
 
-	t.Run("underscore key is rejected", func(t *testing.T) {
+	t.Run("underscore key is rejected by kong-toml validation", func(t *testing.T) {
 		t.Parallel()
 
 		configFile := filepath.Join(t.TempDir(), configFileName)

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -2042,6 +2042,40 @@ database = "d"
 	})
 }
 
+func TestTOMLConfigValidationTracksNestedFlagPaths(t *testing.T) {
+	t.Parallel()
+
+	type runCommand struct {
+		Timeout string `name:"timeout"`
+	}
+	type opts struct {
+		Run runCommand `cmd:"" name:"run"`
+	}
+
+	configFile := filepath.Join(t.TempDir(), configFileName)
+	if err := os.WriteFile(configFile, []byte(`[run]
+timeout = "10s"
+`), 0o644); err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+
+	var parsed opts
+	parser, err := kong.New(&parsed,
+		kong.Name("nested-config-test"),
+		kong.NoDefaultHelp(),
+		kong.Configuration(underscoreCompatibleTOMLLoader, configFile),
+	)
+	if err != nil {
+		t.Fatalf("kong.New() error = %v", err)
+	}
+	if _, err := parser.Parse([]string{"run"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := parsed.Run.Timeout; got != "10s" {
+		t.Fatalf("Run.Timeout = %q, want %q", got, "10s")
+	}
+}
+
 func TestKongOptionalEnumPreservesUnsetAndLowercaseInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1946,6 +1946,28 @@ vertexai_project = "example-project"
 		}
 	})
 
+	t.Run("duplicate hyphen and underscore aliases are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		configFile := filepath.Join(t.TempDir(), configFileName)
+		if err := os.WriteFile(configFile, []byte(`project = "p"
+instance = "i"
+database = "d"
+vertexai-project = "example-project"
+vertexai_project = "other-project"
+`), 0o644); err != nil {
+			t.Fatalf("Failed to create config file: %v", err)
+		}
+
+		_, err := parseTestFlags(nil, configFile)
+		if err == nil {
+			t.Fatal("parseTestFlags() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), `duplicate configuration keys for "vertexai-project": vertexai-project, vertexai_project`) {
+			t.Fatalf("parseTestFlags() error = %v, want duplicate alias error", err)
+		}
+	})
+
 	t.Run("map-valued set keys preserve underscores", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -63,6 +63,10 @@ func contains(s, substr string) bool {
 	return len(substr) > 0 && len(s) >= len(substr) && bytes.Contains([]byte(s), []byte(substr))
 }
 
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
 // ptr returns a pointer to the given string
 func ptr(s string) *string {
 	return &s
@@ -1836,6 +1840,79 @@ func TestHelpAndVersionFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHelpOutputDocumentsDefaultsAndConfigKeys(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	_, _, err := parseFlagsArgs([]string{"--help"}, "built from source", nil, &stdout, io.Discard)
+	if !isHelpRequested(err) {
+		t.Fatalf("Expected help to be written, but got err = %v", err)
+	}
+
+	helpOutput := normalizeWhitespace(stdout.String())
+	for _, want := range []string{
+		"default: spanner%t> ",
+		"default: %P%R> ",
+		"default: /tmp/spanner_mycli_readline.tmp",
+		"Allowed values: NORMAL, PLAN, PROFILE.",
+		"default: gemini-3-flash-preview",
+		"default: global",
+		"Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL.",
+		"Default: ON.",
+	} {
+		if !strings.Contains(helpOutput, want) {
+			t.Errorf("help output does not contain %q", want)
+		}
+	}
+}
+
+func TestTOMLConfigKeyStyle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hyphenated key is accepted", func(t *testing.T) {
+		t.Parallel()
+
+		configFile := filepath.Join(t.TempDir(), configFileName)
+		if err := os.WriteFile(configFile, []byte(`project = "p"
+instance = "i"
+database = "d"
+vertexai-project = "example-project"
+`), 0o644); err != nil {
+			t.Fatalf("Failed to create config file: %v", err)
+		}
+
+		gopts, err := parseTestFlags(nil, configFile)
+		if err != nil {
+			t.Fatalf("parseTestFlags() error = %v", err)
+		}
+		sysVars := initSysVarsOrFail(t, &gopts.Spanner)
+		if got := sysVars.Feature.VertexAIProject; got != "example-project" {
+			t.Fatalf("VertexAIProject = %q, want %q", got, "example-project")
+		}
+	})
+
+	t.Run("underscore key is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		configFile := filepath.Join(t.TempDir(), configFileName)
+		if err := os.WriteFile(configFile, []byte(`project = "p"
+instance = "i"
+database = "d"
+vertexai_project = "example-project"
+`), 0o644); err != nil {
+			t.Fatalf("Failed to create config file: %v", err)
+		}
+
+		_, err := parseTestFlags(nil, configFile)
+		if err == nil {
+			t.Fatal("parseTestFlags() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "unknown configuration keys: vertexai_project") {
+			t.Fatalf("parseTestFlags() error = %v, want unknown configuration key error", err)
+		}
+	})
 }
 
 // TestComplexFlagInteractions tests complex interactions between multiple flags

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -82,7 +82,7 @@ func assertEqual[T comparable](t *testing.T, fieldName string, got T, want *T) {
 	}
 }
 
-func assertStringPtrEqual(t *testing.T, fieldName string, got, want *string) {
+func assertStringPtrEqual[T ~string](t *testing.T, fieldName string, got *T, want *string) {
 	t.Helper()
 	if want == nil {
 		return
@@ -91,8 +91,8 @@ func assertStringPtrEqual(t *testing.T, fieldName string, got, want *string) {
 		t.Errorf("%s = nil, want %q", fieldName, *want)
 		return
 	}
-	if *got != *want {
-		t.Errorf("%s = %q, want %q", fieldName, *got, *want)
+	if string(*got) != *want {
+		t.Errorf("%s = %q, want %q", fieldName, string(*got), *want)
 	}
 }
 
@@ -589,29 +589,44 @@ func TestParseFlagsValidation(t *testing.T) {
 		})
 	}
 
-	for _, mode := range []string{"NORMAL", "PLAN", "PROFILE"} {
+	for _, tc := range []struct {
+		arg  string
+		want string
+	}{
+		{arg: "NORMAL", want: "NORMAL"},
+		{arg: "PLAN", want: "PLAN"},
+		{arg: "PROFILE", want: "PROFILE"},
+		{arg: "plan", want: "PLAN"},
+	} {
 		tests = append(tests, struct {
 			name        string
 			args        []string
 			errContains string
 			want        *spannerOptionsExpectations
 		}{
-			name: fmt.Sprintf("valid query-mode %s", mode),
-			args: withRequiredFlags("--query-mode", mode),
-			want: &spannerOptionsExpectations{QueryMode: &mode},
+			name: fmt.Sprintf("valid query-mode %s", tc.arg),
+			args: withRequiredFlags("--query-mode", tc.arg),
+			want: &spannerOptionsExpectations{QueryMode: ptr(tc.want)},
 		})
 	}
 
-	for _, dialect := range []string{"POSTGRESQL", "GOOGLE_STANDARD_SQL"} {
+	for _, tc := range []struct {
+		arg  string
+		want string
+	}{
+		{arg: "POSTGRESQL", want: "POSTGRESQL"},
+		{arg: "GOOGLE_STANDARD_SQL", want: "GOOGLE_STANDARD_SQL"},
+		{arg: "postgresql", want: "POSTGRESQL"},
+	} {
 		tests = append(tests, struct {
 			name        string
 			args        []string
 			errContains string
 			want        *spannerOptionsExpectations
 		}{
-			name: fmt.Sprintf("valid database-dialect %s", dialect),
-			args: withRequiredFlags("--database-dialect", dialect),
-			want: &spannerOptionsExpectations{DatabaseDialect: &dialect},
+			name: fmt.Sprintf("valid database-dialect %s", tc.arg),
+			args: withRequiredFlags("--database-dialect", tc.arg),
+			want: &spannerOptionsExpectations{DatabaseDialect: ptr(tc.want)},
 		})
 	}
 
@@ -1957,18 +1972,71 @@ CLI_FORMAT = "VERTICAL"
 			t.Fatalf("CLIFormat = %v, want %v", got, enums.DisplayModeVertical)
 		}
 	})
+
+	t.Run("unknown empty table is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		configFile := filepath.Join(t.TempDir(), configFileName)
+		if err := os.WriteFile(configFile, []byte(`project = "p"
+instance = "i"
+database = "d"
+
+[typo]
+`), 0o644); err != nil {
+			t.Fatalf("Failed to create config file: %v", err)
+		}
+
+		_, err := parseTestFlags(nil, configFile)
+		if err == nil {
+			t.Fatal("parseTestFlags() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "unknown configuration keys: typo") {
+			t.Fatalf("parseTestFlags() error = %v, want unknown empty table error", err)
+		}
+	})
 }
 
-func TestKongOptionalEnumUsesPointerSemantics(t *testing.T) {
+func TestKongOptionalEnumPreservesUnsetAndLowercaseInput(t *testing.T) {
 	t.Parallel()
 
 	type opts struct {
-		QueryMode       *string `name:"query-mode" enum:"NORMAL,PLAN,PROFILE"`
-		DatabaseDialect *string `name:"database-dialect" enum:"POSTGRESQL,GOOGLE_STANDARD_SQL,DATABASE_DIALECT_UNSPECIFIED"`
+		QueryMode *caseInsensitiveEnumValue `name:"query-mode" enum:"NORMAL,PLAN,PROFILE"`
 	}
 
-	if _, err := kong.New(&opts{}); err != nil {
+	var unset opts
+	parser, err := kong.New(&unset)
+	if err != nil {
 		t.Fatalf("kong.New() error = %v, want nil", err)
+	}
+	if _, err := parser.Parse(nil); err != nil {
+		t.Fatalf("Parse(nil) error = %v", err)
+	}
+	if unset.QueryMode != nil {
+		t.Fatalf("QueryMode = %v, want nil", *unset.QueryMode)
+	}
+
+	var set opts
+	parser, err = kong.New(&set)
+	if err != nil {
+		t.Fatalf("kong.New() error = %v, want nil", err)
+	}
+	if _, err := parser.Parse([]string{"--query-mode", "plan"}); err != nil {
+		t.Fatalf("Parse(lowercase) error = %v", err)
+	}
+	if set.QueryMode == nil || string(*set.QueryMode) != "PLAN" {
+		t.Fatalf("QueryMode = %v, want PLAN", set.QueryMode)
+	}
+}
+
+func TestKongOptionalEnumRequiresPointerOrDefault(t *testing.T) {
+	t.Parallel()
+
+	type opts struct {
+		QueryMode caseInsensitiveEnumValue `name:"query-mode" enum:"NORMAL,PLAN,PROFILE"`
+	}
+
+	if _, err := kong.New(&opts{}); err == nil {
+		t.Fatal("kong.New() error = nil, want error")
 	}
 }
 

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1853,8 +1854,8 @@ func TestHelpOutputDocumentsDefaultsAndAllowedValues(t *testing.T) {
 
 	helpOutput := normalizeWhitespace(stdout.String())
 	for _, want := range []string{
-		fmt.Sprintf("default: %s", defaultPrompt),
-		fmt.Sprintf("default: %s", defaultPrompt2),
+		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt)),
+		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt2)),
 		fmt.Sprintf("default: %s", defaultHistoryFile),
 		"Allowed values: NORMAL, PLAN, PROFILE.",
 		fmt.Sprintf("default: %s", defaultVertexAIModel),
@@ -1868,7 +1869,7 @@ func TestHelpOutputDocumentsDefaultsAndAllowedValues(t *testing.T) {
 	}
 }
 
-func TestTOMLConfigKeyStyle(t *testing.T) {
+func TestTOMLConfigKeyAliases(t *testing.T) {
 	t.Parallel()
 
 	t.Run("hyphenated key is accepted", func(t *testing.T) {
@@ -1893,7 +1894,7 @@ vertexai-project = "example-project"
 		}
 	})
 
-	t.Run("underscore key is rejected by kong-toml validation", func(t *testing.T) {
+	t.Run("underscore key alias is accepted", func(t *testing.T) {
 		t.Parallel()
 
 		configFile := filepath.Join(t.TempDir(), configFileName)
@@ -1905,12 +1906,35 @@ vertexai_project = "example-project"
 			t.Fatalf("Failed to create config file: %v", err)
 		}
 
+		gopts, err := parseTestFlags(nil, configFile)
+		if err != nil {
+			t.Fatalf("parseTestFlags() error = %v", err)
+		}
+		sysVars := initSysVarsOrFail(t, &gopts.Spanner)
+		if got := sysVars.Feature.VertexAIProject; got != "example-project" {
+			t.Fatalf("VertexAIProject = %q, want %q", got, "example-project")
+		}
+	})
+
+	t.Run("duplicate hyphen and underscore aliases are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		configFile := filepath.Join(t.TempDir(), configFileName)
+		if err := os.WriteFile(configFile, []byte(`project = "p"
+instance = "i"
+database = "d"
+vertexai-project = "example-project"
+vertexai_project = "other-project"
+`), 0o644); err != nil {
+			t.Fatalf("Failed to create config file: %v", err)
+		}
+
 		_, err := parseTestFlags(nil, configFile)
 		if err == nil {
 			t.Fatal("parseTestFlags() error = nil, want error")
 		}
-		if !strings.Contains(err.Error(), "unknown configuration keys: vertexai_project") {
-			t.Fatalf("parseTestFlags() error = %v, want unknown configuration key error", err)
+		if !strings.Contains(err.Error(), "duplicate configuration keys after underscore normalization") {
+			t.Fatalf("parseTestFlags() error = %v, want duplicate alias error", err)
 		}
 	})
 }

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1931,25 +1931,30 @@ vertexai_project = "example-project"
 		}
 	})
 
-	t.Run("duplicate hyphen and underscore aliases are rejected", func(t *testing.T) {
+	t.Run("map-valued set keys preserve underscores", func(t *testing.T) {
 		t.Parallel()
 
 		configFile := filepath.Join(t.TempDir(), configFileName)
 		if err := os.WriteFile(configFile, []byte(`project = "p"
 instance = "i"
 database = "d"
-vertexai-project = "example-project"
-vertexai_project = "other-project"
+
+[set]
+CLI_FORMAT = "VERTICAL"
 `), 0o644); err != nil {
 			t.Fatalf("Failed to create config file: %v", err)
 		}
 
-		_, err := parseTestFlags(nil, configFile)
-		if err == nil {
-			t.Fatal("parseTestFlags() error = nil, want error")
+		gopts, err := parseTestFlags(nil, configFile)
+		if err != nil {
+			t.Fatalf("parseTestFlags() error = %v", err)
 		}
-		if !strings.Contains(err.Error(), "duplicate configuration keys after underscore normalization") {
-			t.Fatalf("parseTestFlags() error = %v, want duplicate alias error", err)
+		if got := gopts.Spanner.Set["CLI_FORMAT"]; got != "VERTICAL" {
+			t.Fatalf("Set[CLI_FORMAT] = %q, want %q", got, "VERTICAL")
+		}
+		sysVars := initSysVarsOrFail(t, &gopts.Spanner)
+		if got := sysVars.Display.CLIFormat; got != enums.DisplayModeVertical {
+			t.Fatalf("CLIFormat = %v, want %v", got, enums.DisplayModeVertical)
 		}
 	})
 }

--- a/internal/mycli/main_test.go
+++ b/internal/mycli/main_test.go
@@ -81,12 +81,12 @@ func Test_initializeSystemVariables(t *testing.T) {
 				SkipTlsVerify:             lo.ToPtr(false), // Insecure takes precedence
 				LogGrpc:                   true,
 				LogLevel:                  "INFO",
-				QueryMode:                 "PLAN",
+				QueryMode:                 lo.ToPtr("PLAN"),
 				Strong:                    true,
 				ReadTimestamp:             "", // Strong takes precedence
 				VertexAIProject:           "vertex-project",
 				VertexAIModel:             lo.ToPtr("gemini-1.0-pro"),
-				DatabaseDialect:           "POSTGRESQL",
+				DatabaseDialect:           lo.ToPtr("POSTGRESQL"),
 				ImpersonateServiceAccount: "test-sa@example.com",
 				EnablePartitionedDML:      true,
 			},

--- a/internal/mycli/main_test.go
+++ b/internal/mycli/main_test.go
@@ -20,6 +20,11 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
+func ptrCaseInsensitiveEnumValue(s string) *caseInsensitiveEnumValue {
+	v := caseInsensitiveEnumValue(s)
+	return &v
+}
+
 func Test_initializeSystemVariables(t *testing.T) {
 	// NOTE: Most test cases below hardcode expected values instead of using newSystemVariablesWithDefaults()
 	// This means they need updating when defaults change (like TablePreviewRows).
@@ -81,12 +86,12 @@ func Test_initializeSystemVariables(t *testing.T) {
 				SkipTlsVerify:             lo.ToPtr(false), // Insecure takes precedence
 				LogGrpc:                   true,
 				LogLevel:                  "INFO",
-				QueryMode:                 lo.ToPtr("PLAN"),
+				QueryMode:                 ptrCaseInsensitiveEnumValue("PLAN"),
 				Strong:                    true,
 				ReadTimestamp:             "", // Strong takes precedence
 				VertexAIProject:           "vertex-project",
 				VertexAIModel:             lo.ToPtr("gemini-1.0-pro"),
-				DatabaseDialect:           lo.ToPtr("POSTGRESQL"),
+				DatabaseDialect:           ptrCaseInsensitiveEnumValue("POSTGRESQL"),
 				ImpersonateServiceAccount: "test-sa@example.com",
 				EnablePartitionedDML:      true,
 			},


### PR DESCRIPTION
Follow-up for #589.

## Summary

- fix README TOML guidance to use hyphenated keys such as `vertexai-project`
- restore missing default and allowed-value information in generated `--help` output
- add tests for help text coverage and TOML key style behavior

## Validation

- `go test ./internal/mycli -run '^(TestHelpAndVersionFlags|TestHelpOutputDocumentsDefaultsAndConfigKeys|TestTOMLConfigKeyStyle)$' -count=1`
- `go test ./internal/mycli -count=1`
- `go test ./...`
- `golangci-lint run`
- `make fmt-check`
- `make docs-update`
