### PR TITLE
Fix spanner client leak on admin client setup failure

### DIFF
--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -268,6 +268,24 @@ func logGrpcClientOptions() []option.ClientOption {
 }
 
 func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
+	return newSessionWithFactories(
+		ctx,
+		sysVars,
+		spanner.NewClientWithConfig,
+		adminapi.NewDatabaseAdminClient,
+		func(client *spanner.Client) { client.Close() },
+		opts...,
+	)
+}
+
+func newSessionWithFactories(
+	ctx context.Context,
+	sysVars *systemVariables,
+	clientFactory func(context.Context, string, spanner.ClientConfig, ...option.ClientOption) (*spanner.Client, error),
+	adminClientFactory func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error),
+	closeClient func(*spanner.Client),
+	opts ...option.ClientOption,
+) (*Session, error) {
 	dbPath := sysVars.DatabasePath()
 	clientConfig := defaultClientConfig
 	clientConfig.DatabaseRole = sysVars.Connection.Role
@@ -282,13 +300,14 @@ func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.Cl
 	}
 
 	opts = append(opts, defaultClientOpts...)
-	client, err := spanner.NewClientWithConfig(ctx, dbPath, clientConfig, opts...)
+	client, err := clientFactory(ctx, dbPath, clientConfig, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	adminClient, err := adminapi.NewDatabaseAdminClient(ctx, opts...)
+	adminClient, err := adminClientFactory(ctx, opts...)
 	if err != nil {
+		closeClient(client)
 		return nil, err
 	}
 

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -1,12 +1,16 @@
 package mycli
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"testing"
 
+	"cloud.google.com/go/spanner"
+	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/option"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -122,5 +126,41 @@ func TestSession_FailStatementIfReadOnly(t *testing.T) {
 	err = s.failStatementIfReadOnly()
 	if err != nil {
 		t.Errorf("failStatementIfReadOnly should not return an error when ReadOnly is false")
+	}
+}
+
+func TestNewSessionClosesClientWhenAdminClientCreationFails(t *testing.T) {
+	expectedErr := errors.New("admin client creation failed")
+	fakeClient := &spanner.Client{}
+
+	var closedClient *spanner.Client
+
+	session, err := newSessionWithFactories(
+		context.Background(),
+		&systemVariables{
+			Connection: ConnectionVars{
+				Project:  "test-project",
+				Instance: "test-instance",
+				Database: "test-database",
+			},
+		},
+		func(context.Context, string, spanner.ClientConfig, ...option.ClientOption) (*spanner.Client, error) {
+			return fakeClient, nil
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return nil, expectedErr
+		},
+		func(client *spanner.Client) {
+			closedClient = client
+		},
+	)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("newSessionWithFactories() error = %v, want %v", err, expectedErr)
+	}
+	if session != nil {
+		t.Fatalf("newSessionWithFactories() session = %#v, want nil", session)
+	}
+	if closedClient != fakeClient {
+		t.Fatalf("newSessionWithFactories() closed client = %p, want %p", closedClient, fakeClient)
 	}
 }

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -130,6 +130,8 @@ func TestSession_FailStatementIfReadOnly(t *testing.T) {
 }
 
 func TestNewSessionClosesClientWhenAdminClientCreationFails(t *testing.T) {
+	t.Parallel()
+
 	expectedErr := errors.New("admin client creation failed")
 	fakeClient := &spanner.Client{}
 


### PR DESCRIPTION
Fixes #594

## Summary
- close the already-created `spanner.Client` if `NewDatabaseAdminClient` fails
- keep the production path unchanged by routing `NewSession` through a small injectable helper
- add a regression test for the cleanup-on-error path

## Validation
- `go test ./internal/mycli -run 'TestNewSessionClosesClientWhenAdminClientCreationFails|TestSession_FailStatementIfReadOnly|TestSession_TransactionMode'`\n- `golangci-lint run ./...`\n- `make fmt-check`\n\n## Notes\n- local `make check` is currently blocked by the host Docker setup (`bridge` network missing), which causes existing integration tests to fail before lint/format checks run.