### PR TITLE
Overwrite redirected output files instead of appending

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Flags:
       --skip-system-command                    Do not allow system commands
       --system-command=ON|OFF                  Enable or disable system commands (ON/OFF). Default: ON.
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
-  -o, --output=STRING                          Redirect output to file (overwrites existing file, no screen output)
+  -o, --output=STRING                          Redirect query/data output to file (overwrites existing file)
       --skip-column-names                      Suppress column headers in output
       --streaming="AUTO"                       Streaming output mode: AUTO (format-dependent default), TRUE (always
                                                stream), FALSE (never stream)
@@ -379,28 +379,28 @@ spanner> SELECT * FROM keys;  -- This won't be logged (screen only)
 spanner> \T another.log       -- Start tee to a different file
 ```
 
-#### Output redirect (file only)
+#### Output redirect (query/data output to file)
 
 ##### Using --output option
 
 ```bash
-# Redirect all output to file (overwrites existing file, no screen output)
+# Redirect query/data output to file (overwrites existing file)
 $ spanner-mycli --output backup.sql -p myproject -i myinstance -d mydb -e 'DUMP DATABASE;'
 
-# Useful for clean SQL exports without progress messages on screen
+# Useful for clean SQL exports while leaving progress and errors on screen
 $ spanner-mycli --output export.sql -p myproject -i myinstance -d mydb
 ```
 
 ##### Using \o meta-command (PostgreSQL-style)
 
 ```sql
-spanner> \o backup.sql        -- Redirect output to file only (overwrite if it exists)
+spanner> \o backup.sql        -- Redirect query/data output to file (overwrite if it exists)
 spanner> DUMP DATABASE;       -- SQL goes to file, progress shows on screen
 spanner> \o                   -- Disable redirect (return to screen output)
 spanner> SELECT * FROM users; -- This shows on screen only
 
 -- Alternative using \O (symmetric with \T/\t pattern)
-spanner> \o export.sql        -- Redirect output to file only (overwrite if it exists)
+spanner> \o export.sql        -- Redirect query/data output to file (overwrite if it exists)
 spanner> SELECT * FROM keys;  -- Output goes to file only
 spanner> \O                   -- Disable redirect using \O
 ```
@@ -631,7 +631,7 @@ Meta commands are special commands that start with a backslash (`\`) and are pro
 | `\u <database>` | Switch to a different database | `\u mydb` |
 | `\T <filename>` | Start tee logging to file (both screen and file) | `\T output.txt` |
 | `\t` | Stop tee logging | `\t` |
-| `\o <filename>` | Redirect output to file only (overwrite existing file, no screen) | `\o backup.sql` |
+| `\o <filename>` | Redirect query/data output to file (overwrite existing file) | `\o backup.sql` |
 | `\o` | Disable output redirect (return to screen) | `\o` |
 | `\O` | Disable output redirect (alternative to `\o`) | `\O` |
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Flags:
       --skip-system-command                    Do not allow system commands
       --system-command=ON|OFF                  Enable or disable system commands (ON/OFF). Default: ON.
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
-  -o, --output=STRING                          Redirect output to file (file only, no screen output)
+  -o, --output=STRING                          Redirect output to file (overwrites existing file, no screen output)
       --skip-column-names                      Suppress column headers in output
       --streaming="AUTO"                       Streaming output mode: AUTO (format-dependent default), TRUE (always
                                                stream), FALSE (never stream)
@@ -384,7 +384,7 @@ spanner> \T another.log       -- Start tee to a different file
 ##### Using --output option
 
 ```bash
-# Redirect all output to file (no screen output)
+# Redirect all output to file (overwrites existing file, no screen output)
 $ spanner-mycli --output backup.sql -p myproject -i myinstance -d mydb -e 'DUMP DATABASE;'
 
 # Useful for clean SQL exports without progress messages on screen
@@ -394,13 +394,13 @@ $ spanner-mycli --output export.sql -p myproject -i myinstance -d mydb
 ##### Using \o meta-command (PostgreSQL-style)
 
 ```sql
-spanner> \o backup.sql        -- Redirect output to file only
+spanner> \o backup.sql        -- Redirect output to file only (overwrite if it exists)
 spanner> DUMP DATABASE;       -- SQL goes to file, progress shows on screen
 spanner> \o                   -- Disable redirect (return to screen output)
 spanner> SELECT * FROM users; -- This shows on screen only
 
 -- Alternative using \O (symmetric with \T/\t pattern)
-spanner> \o export.sql        -- Redirect output to file only
+spanner> \o export.sql        -- Redirect output to file only (overwrite if it exists)
 spanner> SELECT * FROM keys;  -- Output goes to file only
 spanner> \O                   -- Disable redirect using \O
 ```
@@ -631,7 +631,7 @@ Meta commands are special commands that start with a backslash (`\`) and are pro
 | `\u <database>` | Switch to a different database | `\u mydb` |
 | `\T <filename>` | Start tee logging to file (both screen and file) | `\T output.txt` |
 | `\t` | Stop tee logging | `\t` |
-| `\o <filename>` | Redirect output to file only (no screen) | `\o backup.sql` |
+| `\o <filename>` | Redirect output to file only (overwrite existing file, no screen) | `\o backup.sql` |
 | `\o` | Disable output redirect (return to screen) | `\o` |
 | `\O` | Disable output redirect (alternative to `\o`) | `\O` |
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ spanner> SHOW VARIABLE STATEMENT_TIMEOUT;
 spanner-mycli provides two ways to capture output to files:
 
 1. **Tee functionality**: Append output to a file while still displaying it on the console (like the Unix `tee` command)
-2. **Output redirect**: Send output only to a file, with no screen output (like shell redirection `>`)
+2. **Output redirect**: Send query and result output to a file while prompts, progress, and errors stay on their normal screen streams
 
 Both features are available through command-line options and interactive meta-commands.
 

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -197,9 +197,9 @@ spanner> SELECT * FROM sensitive_data;  -- This will only show on screen
 
 ### Output Redirect (`\o` and `\O`) - PostgreSQL-style
 
-The `\o` meta command provides output redirection (file only, no screen output), complementing the `--output` command-line option.
+The `\o` meta command provides output redirection (file only, no screen output), complementing the `--output` command-line option. Unlike tee logging, output redirection starts from a clean file each time and overwrites any existing file content.
 
-- `\o <filename>` - Redirect output to the specified file only (no screen output)
+- `\o <filename>` - Redirect output to the specified file only (overwrite existing file, no screen output)
 - `\o` - Disable output redirect (return to screen output)
 - `\O` - Disable output redirect (alternative syntax, symmetric with `\T`/`\t`)
 

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -197,7 +197,7 @@ spanner> SELECT * FROM sensitive_data;  -- This will only show on screen
 
 ### Output Redirect (`\o` and `\O`) - PostgreSQL-style
 
-The `\o` meta command redirects query and result output to a file, complementing the `--output` command-line option. Progress messages, prompts, and errors still use the normal screen streams. Unlike tee logging, output redirection starts from a clean file each time and overwrites any existing file content.
+The `\o` meta command redirects query and result output to a file, complementing the `--output` command-line option. Progress messages, prompts, and errors still use the normal screen streams. Unlike tee logging, each time output redirection is enabled it starts from a clean file and overwrites any existing file content.
 
 - `\o <filename>` - Redirect query/data output to the specified file (overwrite existing file)
 - `\o` - Disable output redirect (return to screen output)

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -220,7 +220,7 @@ spanner> \O                   -- Disable using \O (symmetric with \t)
 | Command | Screen Output | File Output | Use Case |
 |---------|--------------|-------------|----------|
 | `\T file` | Yes | Yes | Log queries while working interactively |
-| `\o file` | Progress/errors only | Yes | Export clean SQL while keeping status messages visible |
+| `\o file` | Prompts/progress/errors only | Yes | Export clean SQL while keeping status messages visible |
 | Neither | Yes | No | Normal interactive work |
 
 For detailed information about output functionality (what gets logged, file handling, error handling), see [Output logging and redirection](../README.md#output-logging-and-redirection) in the README.

--- a/docs/meta_commands.md
+++ b/docs/meta_commands.md
@@ -197,9 +197,9 @@ spanner> SELECT * FROM sensitive_data;  -- This will only show on screen
 
 ### Output Redirect (`\o` and `\O`) - PostgreSQL-style
 
-The `\o` meta command provides output redirection (file only, no screen output), complementing the `--output` command-line option. Unlike tee logging, output redirection starts from a clean file each time and overwrites any existing file content.
+The `\o` meta command redirects query and result output to a file, complementing the `--output` command-line option. Progress messages, prompts, and errors still use the normal screen streams. Unlike tee logging, output redirection starts from a clean file each time and overwrites any existing file content.
 
-- `\o <filename>` - Redirect output to the specified file only (overwrite existing file, no screen output)
+- `\o <filename>` - Redirect query/data output to the specified file (overwrite existing file)
 - `\o` - Disable output redirect (return to screen output)
 - `\O` - Disable output redirect (alternative syntax, symmetric with `\T`/`\t`)
 
@@ -220,7 +220,7 @@ spanner> \O                   -- Disable using \O (symmetric with \t)
 | Command | Screen Output | File Output | Use Case |
 |---------|--------------|-------------|----------|
 | `\T file` | Yes | Yes | Log queries while working interactively |
-| `\o file` | No | Yes | Export clean SQL without cluttering screen |
+| `\o file` | Progress/errors only | Yes | Export clean SQL while keeping status messages visible |
 | Neither | Yes | No | Normal interactive work |
 
 For detailed information about output functionality (what gets logged, file handling, error handling), see [Output logging and redirection](../README.md#output-logging-and-redirection) in the README.

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -163,7 +163,7 @@ type spannerOptions struct {
 	// effective default, while --skip-system-command still takes precedence.
 	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF" default:"ON" placeholder:"ON|OFF"`
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
-	Output          string  `name:"output" short:"o" help:"Redirect output to file (file only, no screen output)"`
+	Output          string  `name:"output" short:"o" help:"Redirect output to file (overwrites existing file, no screen output)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`
 	Streaming       string  `name:"streaming" help:"Streaming output mode: AUTO (format-dependent default), TRUE (always stream), FALSE (never stream)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`
 	Color           string  `name:"color" help:"ANSI styling in output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -163,7 +163,7 @@ type spannerOptions struct {
 	// effective default, while --skip-system-command still takes precedence.
 	SystemCommand   *string `name:"system-command" help:"Enable or disable system commands (ON/OFF). Default: ON." enum:"ON,OFF" default:"ON" placeholder:"ON|OFF"`
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
-	Output          string  `name:"output" short:"o" help:"Redirect output to file (overwrites existing file, no screen output)"`
+	Output          string  `name:"output" short:"o" help:"Redirect query/data output to file (overwrites existing file)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`
 	Streaming       string  `name:"streaming" help:"Streaming output mode: AUTO (format-dependent default), TRUE (always stream), FALSE (never stream)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`
 	Color           string  `name:"color" help:"ANSI styling in output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`

--- a/internal/mycli/integration_meta_command_test.go
+++ b/internal/mycli/integration_meta_command_test.go
@@ -587,7 +587,7 @@ SELECT "foo" AS s;`
 
 		// Check that error was printed
 		outputStr := consoleBuf.String()
-		if !strings.Contains(outputStr, "ERROR: tee output to a non-regular file is not supported") {
+		if !strings.Contains(outputStr, "ERROR: output file must be a regular file") {
 			t.Errorf("Expected output to contain error about directory, got: %s", outputStr)
 		}
 	})

--- a/internal/mycli/meta_commands_test.go
+++ b/internal/mycli/meta_commands_test.go
@@ -644,7 +644,7 @@ func TestTeeOutputMetaCommand_Execute(t *testing.T) {
 				return path, func() {}
 			},
 			wantErr:     true,
-			errContains: "non-regular file", // Our validation returns this error
+			errContains: "must be a regular file",
 		},
 	}
 

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -49,10 +49,10 @@ func (s *safeTeeWriter) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
-// openTeeFile validates and opens a file for file output.
+// openOutputFile validates and opens a file for file output.
 // appendMode=true preserves existing content for tee logging, while false starts
 // output redirection from a clean file.
-func openTeeFile(filePath string, appendMode bool) (*os.File, error) {
+func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 	// Check if the file exists and is a regular file before opening.
 	// This prevents blocking on special files like FIFOs.
 	fi, err := os.Stat(filePath)
@@ -165,7 +165,7 @@ func (sm *StreamManager) EnableTee(filePath string, silent bool) error {
 
 	// Open the new tee file while holding the lock to ensure atomicity.
 	appendMode := !silent
-	teeFile, err := openTeeFile(filePath, appendMode)
+	teeFile, err := openOutputFile(filePath, appendMode)
 	if err != nil {
 		return err
 	}

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -49,8 +49,10 @@ func (s *safeTeeWriter) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
-// openTeeFile validates and opens a file for tee output
-func openTeeFile(filePath string) (*os.File, error) {
+// openTeeFile validates and opens a file for tee output.
+// appendMode=true preserves existing content for tee logging, while false starts
+// output redirection from a clean file.
+func openTeeFile(filePath string, appendMode bool) (*os.File, error) {
 	// Check if the file exists and is a regular file before opening.
 	// This prevents blocking on special files like FIFOs.
 	fi, err := os.Stat(filePath)
@@ -73,8 +75,14 @@ func openTeeFile(filePath string) (*os.File, error) {
 		return nil, fmt.Errorf("failed to stat tee file %q: %w", filePath, err)
 	}
 
-	// Open tee file in append mode (creates if doesn't exist)
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	openFlags := os.O_CREATE | os.O_WRONLY
+	if appendMode {
+		openFlags |= os.O_APPEND
+	} else {
+		openFlags |= os.O_TRUNC
+	}
+
+	file, err := os.OpenFile(filePath, openFlags, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +164,7 @@ func (sm *StreamManager) EnableTee(filePath string, silent bool) error {
 	defer sm.mu.Unlock()
 
 	// Open the new tee file while holding the lock to ensure atomicity.
-	teeFile, err := openTeeFile(filePath)
+	teeFile, err := openTeeFile(filePath, !silent)
 	if err != nil {
 		return err
 	}

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -37,8 +37,8 @@ func (s *safeTeeWriter) Write(p []byte) (n int, err error) {
 	if err != nil {
 		// Print warning only once to avoid spamming
 		s.hasWarned = true
-		fmt.Fprintf(s.errStream, "WARNING: Failed to write to tee file: %v\n", err)
-		fmt.Fprintf(s.errStream, "WARNING: Tee logging disabled for remainder of session\n")
+		fmt.Fprintf(s.errStream, "WARNING: Failed to write to output file: %v\n", err)
+		fmt.Fprintf(s.errStream, "WARNING: File output disabled for remainder of session\n")
 		// CRITICAL: We must return success here even though the write failed.
 		// io.MultiWriter will stop writing to ALL writers (including stdout!)
 		// if ANY writer returns an error. By returning success, we ensure
@@ -53,8 +53,8 @@ func (s *safeTeeWriter) Write(p []byte) (n int, err error) {
 // appendMode=true preserves existing content for tee logging, while false starts
 // output redirection from a clean file.
 func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
-	// Check if the file exists and is a regular file before opening.
-	// This prevents blocking on special files like FIFOs.
+	// Check if the path already exists and is a regular file before opening.
+	// This rejects already-existing special files such as FIFOs.
 	fi, err := os.Stat(filePath)
 
 	// Handle three cases:
@@ -65,7 +65,7 @@ func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 	case err == nil:
 		// File exists - ensure it's a regular file
 		if !fi.Mode().IsRegular() {
-			return nil, fmt.Errorf("file output to a non-regular file is not supported: %q", filePath)
+			return nil, fmt.Errorf("output file must be a regular file: %q", filePath)
 		}
 	case os.IsNotExist(err):
 		// File doesn't exist - OpenFile will create it
@@ -87,9 +87,8 @@ func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 		return nil, err
 	}
 
-	// Double-check the file after opening to handle TOCTOU race conditions.
-	// Without this check, a regular file could be replaced with a FIFO
-	// between our initial stat and open calls, causing the CLI to block.
+	// Double-check the opened file to catch paths that changed after the initial
+	// stat but still opened successfully.
 	fi, err = file.Stat()
 	if err != nil {
 		file.Close()
@@ -98,7 +97,7 @@ func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 
 	if !fi.Mode().IsRegular() {
 		file.Close()
-		return nil, fmt.Errorf("file output to a non-regular file is not supported: %q", filePath)
+		return nil, fmt.Errorf("output file must be a regular file: %q", filePath)
 	}
 
 	return file, nil

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -50,8 +50,9 @@ func (s *safeTeeWriter) Write(p []byte) (n int, err error) {
 }
 
 // openOutputFile validates and opens a file for file output.
-// appendMode=true preserves existing content for tee logging, while false starts
-// output redirection from a clean file.
+// appendMode=true preserves existing content for tee logging, while false opens
+// the file without truncating so callers can defer reset until after any
+// previous output file is safely closed.
 func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 	// Check if the path already exists and is a regular file before opening.
 	// This rejects already-existing special files such as FIFOs.
@@ -78,8 +79,6 @@ func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 	openFlags := os.O_CREATE | os.O_WRONLY
 	if appendMode {
 		openFlags |= os.O_APPEND
-	} else {
-		openFlags |= os.O_TRUNC
 	}
 
 	file, err := os.OpenFile(filePath, openFlags, 0o644)
@@ -101,6 +100,16 @@ func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 	}
 
 	return file, nil
+}
+
+func resetOutputFile(file *os.File) error {
+	if err := file.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	return nil
 }
 
 // createTeeWriter creates a MultiWriter that writes to both the original stream and a tee file
@@ -176,6 +185,13 @@ func (sm *StreamManager) EnableTee(filePath string, silent bool) error {
 			// To be safe, close the new file and abort the operation to prevent a leak.
 			_ = teeFile.Close()
 			return fmt.Errorf("failed to switch tee file: could not close previous file %q: %w", sm.teeFile.Name(), err)
+		}
+	}
+
+	if silent {
+		if err := resetOutputFile(teeFile); err != nil {
+			_ = teeFile.Close()
+			return fmt.Errorf("failed to reset output file %q: %w", filePath, err)
 		}
 	}
 

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -3,6 +3,7 @@
 package streamio
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -103,6 +104,9 @@ func openOutputFile(filePath string, appendMode bool) (*os.File, error) {
 }
 
 func resetOutputFile(file *os.File) error {
+	if file == nil {
+		return errors.New("output file is nil")
+	}
 	if err := file.Truncate(0); err != nil {
 		return err
 	}
@@ -139,6 +143,7 @@ type StreamManager struct {
 	teeFile      *os.File      // Tee file when enabled
 	cachedWriter io.Writer     // Cache the writer to ensure consistent behavior
 	silentMode   bool          // When true, output goes only to file (not stdout)
+	resetFile    func(*os.File) error
 }
 
 // NewStreamManager creates a new StreamManager instance
@@ -147,6 +152,7 @@ func NewStreamManager(inStream io.ReadCloser, outStream, errStream io.Writer) *S
 		inStream:  inStream,
 		outStream: outStream,
 		errStream: errStream,
+		resetFile: resetOutputFile,
 	}
 
 	// If outStream is a terminal, keep a reference for terminal operations
@@ -189,8 +195,15 @@ func (sm *StreamManager) EnableTee(filePath string, silent bool) error {
 	}
 
 	if silent {
-		if err := resetOutputFile(teeFile); err != nil {
+		resetFile := sm.resetFile
+		if resetFile == nil {
+			resetFile = resetOutputFile
+		}
+		if err := resetFile(teeFile); err != nil {
 			_ = teeFile.Close()
+			sm.teeFile = nil
+			sm.silentMode = false
+			sm.cachedWriter = nil
 			return fmt.Errorf("failed to reset output file %q: %w", filePath, err)
 		}
 	}

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -184,7 +184,7 @@ func (sm *StreamManager) EnableTee(filePath string, silent bool) error {
 			// If we can't close the old file, we're in a risky state.
 			// To be safe, close the new file and abort the operation to prevent a leak.
 			_ = teeFile.Close()
-			return fmt.Errorf("failed to switch tee file: could not close previous file %q: %w", sm.teeFile.Name(), err)
+			return fmt.Errorf("failed to switch file output: could not close previous output file %q: %w", sm.teeFile.Name(), err)
 		}
 	}
 

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -49,7 +49,7 @@ func (s *safeTeeWriter) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
-// openTeeFile validates and opens a file for tee output.
+// openTeeFile validates and opens a file for file output.
 // appendMode=true preserves existing content for tee logging, while false starts
 // output redirection from a clean file.
 func openTeeFile(filePath string, appendMode bool) (*os.File, error) {
@@ -65,14 +65,14 @@ func openTeeFile(filePath string, appendMode bool) (*os.File, error) {
 	case err == nil:
 		// File exists - ensure it's a regular file
 		if !fi.Mode().IsRegular() {
-			return nil, fmt.Errorf("tee output to a non-regular file is not supported: %q", filePath)
+			return nil, fmt.Errorf("file output to a non-regular file is not supported: %q", filePath)
 		}
 	case os.IsNotExist(err):
 		// File doesn't exist - OpenFile will create it
 		// Continue to OpenFile
 	default:
 		// Unexpected stat error (e.g., permission denied)
-		return nil, fmt.Errorf("failed to stat tee file %q: %w", filePath, err)
+		return nil, fmt.Errorf("failed to stat output file %q: %w", filePath, err)
 	}
 
 	openFlags := os.O_CREATE | os.O_WRONLY
@@ -98,7 +98,7 @@ func openTeeFile(filePath string, appendMode bool) (*os.File, error) {
 
 	if !fi.Mode().IsRegular() {
 		file.Close()
-		return nil, fmt.Errorf("tee output to a non-regular file is not supported: %q", filePath)
+		return nil, fmt.Errorf("file output to a non-regular file is not supported: %q", filePath)
 	}
 
 	return file, nil
@@ -164,7 +164,8 @@ func (sm *StreamManager) EnableTee(filePath string, silent bool) error {
 	defer sm.mu.Unlock()
 
 	// Open the new tee file while holding the lock to ensure atomicity.
-	teeFile, err := openTeeFile(filePath, !silent)
+	appendMode := !silent
+	teeFile, err := openTeeFile(filePath, appendMode)
 	if err != nil {
 		return err
 	}

--- a/internal/mycli/streamio/stream_manager_edge_test.go
+++ b/internal/mycli/streamio/stream_manager_edge_test.go
@@ -59,8 +59,8 @@ func TestStreamManager_DirectoryError(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error when enabling tee with directory path")
 	}
-	if !strings.Contains(err.Error(), "non-regular file") {
-		t.Errorf("Expected 'non-regular file' error, got: %v", err)
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Errorf("Expected regular-file error, got: %v", err)
 	}
 
 	// Verify tee is not enabled
@@ -208,7 +208,7 @@ func TestStreamManager_WriteAfterError(t *testing.T) {
 	}
 
 	// Check warning was printed
-	if !strings.Contains(errOut.String(), "WARNING: Failed to write to tee file") {
+	if !strings.Contains(errOut.String(), "WARNING: Failed to write to output file") {
 		t.Error("Expected warning message not found")
 	}
 

--- a/internal/mycli/streamio/stream_manager_edge_test.go
+++ b/internal/mycli/streamio/stream_manager_edge_test.go
@@ -59,7 +59,7 @@ func TestStreamManager_DirectoryError(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error when enabling tee with directory path")
 	}
-	if !strings.Contains(err.Error(), "regular file") {
+	if !strings.Contains(err.Error(), "must be a regular file") {
 		t.Errorf("Expected regular-file error, got: %v", err)
 	}
 

--- a/internal/mycli/streamio/stream_manager_fifo_test.go
+++ b/internal/mycli/streamio/stream_manager_fifo_test.go
@@ -65,7 +65,7 @@ func TestOpenOutputFile_FIFO(t *testing.T) {
 		if openErr == nil {
 			t.Error("Expected error when opening FIFO, got nil")
 		}
-		if !strings.Contains(openErr.Error(), "regular file") {
+		if !strings.Contains(openErr.Error(), "must be a regular file") {
 			t.Errorf("Expected regular-file error, got: %v", openErr)
 		}
 	case <-time.After(1 * time.Second):
@@ -112,7 +112,7 @@ func TestStreamManager_FIFO(t *testing.T) {
 		if enableErr == nil {
 			t.Error("Expected error when enabling tee to FIFO, got nil")
 		}
-		if !strings.Contains(enableErr.Error(), "regular file") {
+		if !strings.Contains(enableErr.Error(), "must be a regular file") {
 			t.Errorf("Expected regular-file error, got: %v", enableErr)
 		}
 		// Verify that tee is not enabled

--- a/internal/mycli/streamio/stream_manager_fifo_test.go
+++ b/internal/mycli/streamio/stream_manager_fifo_test.go
@@ -50,7 +50,7 @@ func TestOpenTeeFile_FIFO(t *testing.T) {
 	var openErr error
 
 	go func() {
-		_, openErr = openTeeFile(fifoPath)
+		_, openErr = openTeeFile(fifoPath, true)
 		close(done)
 	}()
 

--- a/internal/mycli/streamio/stream_manager_fifo_test.go
+++ b/internal/mycli/streamio/stream_manager_fifo_test.go
@@ -50,7 +50,11 @@ func TestOpenOutputFile_FIFO(t *testing.T) {
 	var openErr error
 
 	go func() {
-		_, openErr = openOutputFile(fifoPath, true)
+		file, err := openOutputFile(fifoPath, true)
+		if file != nil {
+			_ = file.Close()
+		}
+		openErr = err
 		close(done)
 	}()
 

--- a/internal/mycli/streamio/stream_manager_fifo_test.go
+++ b/internal/mycli/streamio/stream_manager_fifo_test.go
@@ -25,7 +25,7 @@ func supportsFIFO() bool {
 	}
 }
 
-func TestOpenTeeFile_FIFO(t *testing.T) {
+func TestOpenOutputFile_FIFO(t *testing.T) {
 	t.Parallel()
 	// Skip test on platforms that don't support FIFOs reliably
 	if !supportsFIFO() {
@@ -61,8 +61,8 @@ func TestOpenTeeFile_FIFO(t *testing.T) {
 		if openErr == nil {
 			t.Error("Expected error when opening FIFO, got nil")
 		}
-		if !strings.Contains(openErr.Error(), "non-regular file") {
-			t.Errorf("Expected 'non-regular file' error, got: %v", openErr)
+		if !strings.Contains(openErr.Error(), "regular file") {
+			t.Errorf("Expected regular-file error, got: %v", openErr)
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("openOutputFile hung when attempting to open FIFO - the protection is not working")
@@ -108,8 +108,8 @@ func TestStreamManager_FIFO(t *testing.T) {
 		if enableErr == nil {
 			t.Error("Expected error when enabling tee to FIFO, got nil")
 		}
-		if !strings.Contains(enableErr.Error(), "non-regular file") {
-			t.Errorf("Expected 'non-regular file' error, got: %v", enableErr)
+		if !strings.Contains(enableErr.Error(), "regular file") {
+			t.Errorf("Expected regular-file error, got: %v", enableErr)
 		}
 		// Verify that tee is not enabled
 		if sm.IsEnabled() {

--- a/internal/mycli/streamio/stream_manager_fifo_test.go
+++ b/internal/mycli/streamio/stream_manager_fifo_test.go
@@ -45,12 +45,12 @@ func TestOpenTeeFile_FIFO(t *testing.T) {
 		t.Skipf("Failed to create FIFO (may not be supported): %v", err)
 	}
 
-	// Test that openTeeFile rejects the FIFO without hanging
+	// Test that openOutputFile rejects the FIFO without hanging
 	done := make(chan struct{})
 	var openErr error
 
 	go func() {
-		_, openErr = openTeeFile(fifoPath, true)
+		_, openErr = openOutputFile(fifoPath, true)
 		close(done)
 	}()
 
@@ -65,7 +65,7 @@ func TestOpenTeeFile_FIFO(t *testing.T) {
 			t.Errorf("Expected 'non-regular file' error, got: %v", openErr)
 		}
 	case <-time.After(1 * time.Second):
-		t.Fatal("openTeeFile hung when attempting to open FIFO - the protection is not working")
+		t.Fatal("openOutputFile hung when attempting to open FIFO - the protection is not working")
 	}
 }
 

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -650,6 +650,37 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		}
 	})
 
+	t.Run("silent mode truncates existing file", func(t *testing.T) {
+		originalOut := &bytes.Buffer{}
+		errOut := &bytes.Buffer{}
+		sm := NewStreamManager(os.Stdin, originalOut, errOut)
+		defer sm.Close()
+
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "output.sql")
+		if err := os.WriteFile(outputFile, []byte("stale dump\n"), 0o644); err != nil {
+			t.Fatalf("Failed to seed output file: %v", err)
+		}
+
+		if err := sm.EnableTee(outputFile, true); err != nil {
+			t.Fatalf("Failed to enable output redirect: %v", err)
+		}
+
+		writer := sm.GetWriter()
+		freshData := "CREATE TABLE Singers (\n"
+		if _, err := writer.Write([]byte(freshData)); err != nil {
+			t.Fatalf("Failed to write redirected output: %v", err)
+		}
+
+		content, err := os.ReadFile(outputFile)
+		if err != nil {
+			t.Fatalf("Failed to read redirected file: %v", err)
+		}
+		if string(content) != freshData {
+			t.Fatalf("Expected redirected output %q, got %q", freshData, string(content))
+		}
+	})
+
 	t.Run("GetWriter vs GetOutStream usage", func(t *testing.T) {
 		originalOut := &bytes.Buffer{}
 		errOut := &bytes.Buffer{}

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -2,6 +2,7 @@ package streamio
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -726,6 +727,55 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		sm.mu.Unlock()
 	})
 
+	t.Run("silent mode reset failure clears output state", func(t *testing.T) {
+		originalOut := &bytes.Buffer{}
+		errOut := &bytes.Buffer{}
+		sm := NewStreamManager(os.Stdin, originalOut, errOut)
+		defer sm.Close()
+
+		tmpDir := t.TempDir()
+		currentFile := filepath.Join(tmpDir, "current.log")
+		if err := sm.EnableTee(currentFile, false); err != nil {
+			t.Fatalf("Failed to enable initial tee: %v", err)
+		}
+
+		outputFile := filepath.Join(tmpDir, "output.sql")
+		seedContent := "stale dump\n"
+		if err := os.WriteFile(outputFile, []byte(seedContent), 0o644); err != nil {
+			t.Fatalf("Failed to seed output file: %v", err)
+		}
+
+		sm.resetFile = func(*os.File) error {
+			return errors.New("boom")
+		}
+
+		err := sm.EnableTee(outputFile, true)
+		if err == nil {
+			t.Fatal("Expected enable output redirect to fail when reset fails")
+		}
+		if !strings.Contains(err.Error(), "failed to reset output file") {
+			t.Fatalf("Expected reset failure error, got %v", err)
+		}
+
+		if sm.IsEnabled() {
+			t.Fatal("Expected output state to be cleared after reset failure")
+		}
+		if sm.IsInSilentTeeMode() {
+			t.Fatal("Expected silent mode to be disabled after reset failure")
+		}
+		if got := sm.GetWriter(); got != originalOut {
+			t.Fatal("Expected writer to fall back to original output after reset failure")
+		}
+
+		content, readErr := os.ReadFile(outputFile)
+		if readErr != nil {
+			t.Fatalf("Failed to read redirected file after reset failure: %v", readErr)
+		}
+		if string(content) != seedContent {
+			t.Fatalf("Expected redirected file to remain %q, got %q", seedContent, string(content))
+		}
+	})
+
 	t.Run("GetWriter vs GetOutStream usage", func(t *testing.T) {
 		originalOut := &bytes.Buffer{}
 		errOut := &bytes.Buffer{}
@@ -768,4 +818,16 @@ func TestStreamManagerSilentMode(t *testing.T) {
 			t.Errorf("Expected file to have only data %q, got %q", dataOutput, string(content))
 		}
 	})
+}
+
+func TestResetOutputFile_Nil(t *testing.T) {
+	t.Parallel()
+
+	err := resetOutputFile(nil)
+	if err == nil {
+		t.Fatal("Expected resetOutputFile(nil) to fail")
+	}
+	if !strings.Contains(err.Error(), "output file is nil") {
+		t.Fatalf("Expected nil-file error, got %v", err)
+	}
 }

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -496,7 +496,7 @@ func TestSafeTeeWriter(t *testing.T) {
 		wg.Wait()
 
 		// Verify only one warning was printed (important for concurrent writes)
-		warningCount := strings.Count(errOut.String(), "WARNING: Failed to write to tee file")
+		warningCount := strings.Count(errOut.String(), "WARNING: Failed to write to output file")
 		if warningCount != 1 {
 			t.Errorf("Expected exactly 1 warning, got %d warnings", warningCount)
 		}
@@ -538,10 +538,10 @@ func TestSafeTeeWriter(t *testing.T) {
 
 		// Check warning was printed
 		errOutput := errBuf.String()
-		if !strings.Contains(errOutput, "WARNING: Failed to write to tee file") {
+		if !strings.Contains(errOutput, "WARNING: Failed to write to output file") {
 			t.Errorf("Expected warning message, got: %s", errOutput)
 		}
-		if !strings.Contains(errOutput, "WARNING: Tee logging disabled for remainder of session") {
+		if !strings.Contains(errOutput, "WARNING: File output disabled for remainder of session") {
 			t.Errorf("Expected disabled message, got: %s", errOutput)
 		}
 

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -659,7 +659,8 @@ func TestStreamManagerSilentMode(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		outputFile := filepath.Join(tmpDir, "output.sql")
-		if err := os.WriteFile(outputFile, []byte("stale dump\n"), 0o644); err != nil {
+		seedContent := "stale dump with trailing bytes that must be removed\n"
+		if err := os.WriteFile(outputFile, []byte(seedContent), 0o644); err != nil {
 			t.Fatalf("Failed to seed output file: %v", err)
 		}
 
@@ -679,6 +680,9 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		}
 		if string(content) != freshData {
 			t.Fatalf("Expected redirected output %q, got %q", freshData, string(content))
+		}
+		if strings.Contains(string(content), "trailing bytes") {
+			t.Fatalf("Expected truncation to remove old tail, got %q", string(content))
 		}
 	})
 

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -709,7 +709,7 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected enable output redirect to fail when closing previous file fails")
 		}
-		if !strings.Contains(err.Error(), "failed to switch tee file") {
+		if !strings.Contains(err.Error(), "failed to switch file output") {
 			t.Fatalf("Expected switch failure error, got %v", err)
 		}
 

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -686,6 +686,17 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		originalOut := &bytes.Buffer{}
 		errOut := &bytes.Buffer{}
 		sm := NewStreamManager(os.Stdin, originalOut, errOut)
+		t.Cleanup(func() {
+			sm.mu.Lock()
+			teeFile := sm.teeFile
+			sm.teeFile = nil
+			sm.silentMode = false
+			sm.cachedWriter = nil
+			sm.mu.Unlock()
+			if teeFile != nil {
+				_ = teeFile.Close()
+			}
+		})
 
 		tmpDir := t.TempDir()
 		currentFile := filepath.Join(tmpDir, "current.log")
@@ -721,10 +732,6 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		if string(content) != seedContent {
 			t.Fatalf("Expected redirected file to remain %q, got %q", seedContent, string(content))
 		}
-
-		sm.mu.Lock()
-		sm.teeFile = nil
-		sm.mu.Unlock()
 	})
 
 	t.Run("silent mode reset failure clears output state", func(t *testing.T) {

--- a/internal/mycli/streamio/stream_manager_test.go
+++ b/internal/mycli/streamio/stream_manager_test.go
@@ -681,6 +681,51 @@ func TestStreamManagerSilentMode(t *testing.T) {
 		}
 	})
 
+	t.Run("silent mode leaves target unchanged when switch fails", func(t *testing.T) {
+		originalOut := &bytes.Buffer{}
+		errOut := &bytes.Buffer{}
+		sm := NewStreamManager(os.Stdin, originalOut, errOut)
+
+		tmpDir := t.TempDir()
+		currentFile := filepath.Join(tmpDir, "current.log")
+		if err := sm.EnableTee(currentFile, false); err != nil {
+			t.Fatalf("Failed to enable initial tee: %v", err)
+		}
+
+		sm.mu.Lock()
+		currentHandle := sm.teeFile
+		sm.mu.Unlock()
+		if err := currentHandle.Close(); err != nil {
+			t.Fatalf("Failed to poison current tee file: %v", err)
+		}
+
+		outputFile := filepath.Join(tmpDir, "output.sql")
+		seedContent := "stale dump\n"
+		if err := os.WriteFile(outputFile, []byte(seedContent), 0o644); err != nil {
+			t.Fatalf("Failed to seed output file: %v", err)
+		}
+
+		err := sm.EnableTee(outputFile, true)
+		if err == nil {
+			t.Fatal("Expected enable output redirect to fail when closing previous file fails")
+		}
+		if !strings.Contains(err.Error(), "failed to switch tee file") {
+			t.Fatalf("Expected switch failure error, got %v", err)
+		}
+
+		content, readErr := os.ReadFile(outputFile)
+		if readErr != nil {
+			t.Fatalf("Failed to read redirected file after failed switch: %v", readErr)
+		}
+		if string(content) != seedContent {
+			t.Fatalf("Expected redirected file to remain %q, got %q", seedContent, string(content))
+		}
+
+		sm.mu.Lock()
+		sm.teeFile = nil
+		sm.mu.Unlock()
+	})
+
 	t.Run("GetWriter vs GetOutStream usage", func(t *testing.T) {
 		originalOut := &bytes.Buffer{}
 		errOut := &bytes.Buffer{}


### PR DESCRIPTION
Fixes #592

## Summary
- preserve append behavior for tee logging only
- make `--output` and `\o` start from a clean file by truncating existing content
- add regression coverage for silent output redirection and update README/meta-command docs

## Validation
- `go test ./internal/mycli/streamio`
- `golangci-lint run ./internal/mycli/...`
- `make docs-update`

## Notes
- local `make check` still hits the known Docker bridge-network issue in integration tests on this host, but the changed package tests and lint are clean.