### PR TITLE
feat(omni): add experimental embedded runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,8 +1126,8 @@ Available sample databases:
 
 Usage: spanner-mycli --embedded-emulator --sample-database=<name>
        spanner-mycli --embedded-omni --sample-database=<name>
-       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.json
-       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.json
+       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.(json|yaml|yml)
+       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.(json|yaml|yml)
 
 # Start with the banking sample database
 $ spanner-mycli --embedded-emulator --sample-database=banking

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There are differences between spanner-mycli and spanner-cli that include not onl
   * Query profiles (EARLY EXPERIMENTAL) for rendering sampled query plans using `SHOW QUERY PROFILES` and `SHOW QUERY PROFILE`
 * Respects my minor use cases
   * Protocol Buffers support as `SHOW LOCAL PROTO`, `SHOW REMOTE PROTO`, `SYNC PROTO BUNDLE` statement
-  * Can use embedded emulator (`--embedded-emulator`)
+  * Can use embedded runtime backends (`--embedded-emulator`, `--embedded-omni`)
   * Support [query parameters](#query-parameter-support)
   * Test root-partitionable with [`TRY PARTITIONED QUERY <sql>` command](#test-root-partitionable)
   * Experimental Partitioned Query and Data Boost support.
@@ -148,8 +148,11 @@ Flags:
                                                alias.
       --embedded-emulator                      Use embedded Cloud Spanner Emulator. --project, --instance, --database,
                                                --endpoint, --insecure will be automatically configured.
-      --emulator-image=STRING                  container image for --embedded-emulator
-      --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded emulator
+      --embedded-omni                          Use embedded experimental Spanner Omni. --project, --instance,
+                                               --database, --endpoint, --insecure will be automatically configured.
+      --emulator-image=STRING                  container image for embedded runtime (--embedded-emulator or
+                                               --embedded-omni)
+      --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
       --sample-database=STRING                 Initialize emulator with built-in sample (e.g. fingraph, singers,
                                                banking) or path to metadata.json file. Requires --embedded-emulator.
       --list-samples                           List available sample databases and exit
@@ -1145,6 +1148,18 @@ The sample databases include both embedded samples (fingraph, singers) and sampl
 
 > [!NOTE]
 > The embedded emulator has the same limitations as the standalone emulator. See the warning in the [Using with the Cloud Spanner Emulator](#using-with-the-cloud-spanner-emulator) section above for details.
+
+### Embedded Spanner Omni
+
+spanner-mycli can also launch experimental Spanner Omni via `spanemuboost`.
+
+```bash
+$ spanner-mycli --embedded-omni
+default:default:emulator-database
+> SELECT 1
+```
+
+`--embedded-omni` automatically configures the fixed single-server Omni project and instance defaults, and reuses the backend-provided client options needed for the experimental host. `--sample-database` remains emulator-only.
 
 ### Protocol Buffers support
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ Flags:
       --emulator-image=STRING                  container image for embedded runtime (--embedded-emulator or
                                                --embedded-omni)
       --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
-      --sample-database=STRING                 Initialize embedded runtime with built-in sample (e.g. fingraph, singers,
-                                               banking) or path to metadata.json file. Requires --embedded-emulator or
-                                               --embedded-omni. Cannot be combined with --detached.
+      --sample-database=STRING                 Initialize embedded runtime with built-in sample (e.g. fingraph,
+                                               singers, banking) or path to a metadata file (.json, .yaml, .yml).
+                                               Requires --embedded-emulator or --embedded-omni. Cannot be combined with
+                                               --detached.
       --list-samples                           List available sample databases and exit
       --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
       --log-level=STRING

--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ Flags:
       --emulator-image=STRING                  container image for embedded runtime (--embedded-emulator or
                                                --embedded-omni)
       --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
-      --sample-database=STRING                 Initialize emulator with built-in sample (e.g. fingraph, singers,
-                                               banking) or path to metadata.json file. Requires --embedded-emulator.
+      --sample-database=STRING                 Initialize embedded runtime with built-in sample (e.g. fingraph, singers,
+                                               banking) or path to metadata.json file. Requires --embedded-emulator or
+                                               --embedded-omni.
       --list-samples                           List available sample databases and exit
       --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
       --log-level=STRING
@@ -1107,7 +1108,7 @@ Empty set (8.763167ms)
 
 #### Sample Databases
 
-You can initialize the emulator with Google's official sample databases using the `--sample-database` flag:
+You can initialize the embedded runtime with Google's official sample databases using the `--sample-database` flag:
 
 ```bash
 # List available sample databases
@@ -1123,7 +1124,9 @@ Available sample databases:
   singers        GoogleSQL    Music database used throughout Spanner documentation
 
 Usage: spanner-mycli --embedded-emulator --sample-database=<name>
+       spanner-mycli --embedded-omni --sample-database=<name>
        spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.json
+       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.json
 
 # Start with the banking sample database
 $ spanner-mycli --embedded-emulator --sample-database=banking
@@ -1140,8 +1143,12 @@ emulator-project:emulator-instance:emulator-database
 # Use embedded fingraph sample
 $ spanner-mycli --embedded-emulator --sample-database=fingraph
 
+# Load the same sample on embedded Omni
+$ spanner-mycli --embedded-omni --sample-database=fingraph
+
 # Use custom sample with metadata file
 $ spanner-mycli --embedded-emulator --sample-database=/path/to/mysample.yaml
+$ spanner-mycli --embedded-omni --sample-database=/path/to/mysample.yaml
 ```
 
 The sample databases include both embedded samples (fingraph, singers) and samples downloaded from Google Cloud Storage. You can also create custom samples using metadata files in JSON or YAML format.
@@ -1159,7 +1166,7 @@ default:default:emulator-database
 > SELECT 1
 ```
 
-`--embedded-omni` automatically configures the fixed single-server Omni project and instance defaults, and reuses the backend-provided client options needed for the experimental host. `--sample-database` remains emulator-only.
+`--embedded-omni` automatically configures the fixed single-server Omni project and instance defaults, reuses the backend-provided client options needed for the experimental host, and can load the same sample databases as the embedded emulator path.
 
 ### Protocol Buffers support
 

--- a/README.md
+++ b/README.md
@@ -1126,8 +1126,9 @@ Available sample databases:
 
 Usage: spanner-mycli --embedded-emulator --sample-database=<name>
        spanner-mycli --embedded-omni --sample-database=<name>
-       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.(json|yaml|yml)
-       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.(json|yaml|yml)
+       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.yaml
+       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.yaml
+       Sample metadata files may use .json, .yaml, or .yml.
 
 # Start with the banking sample database
 $ spanner-mycli --embedded-emulator --sample-database=banking

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Flags:
       --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
       --sample-database=STRING                 Initialize embedded runtime with built-in sample (e.g. fingraph, singers,
                                                banking) or path to metadata.json file. Requires --embedded-emulator or
-                                               --embedded-omni.
+                                               --embedded-omni. Cannot be combined with --detached.
       --list-samples                           List available sample databases and exit
       --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
       --log-level=STRING

--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,7 @@ default:default:emulator-database
 > SELECT 1
 ```
 
-`--embedded-omni` automatically configures the fixed single-server Omni project and instance defaults, reuses the backend-provided client options needed for the experimental host, and can load the same sample databases as the embedded emulator path.
+`--embedded-omni` automatically configures the fixed single-server Omni project and instance defaults, reuses the backend-provided client options needed for the experimental host, and can load the same sample databases as the embedded emulator path. In Spanner Omni terminology, this embedded single-server setup corresponds to a deployment, which is the Omni equivalent of a Google Cloud Spanner instance; see [Spanner Omni key terms](https://docs.cloud.google.com/spanner-omni/key-terms). Before relying on embedded Omni locally, also check the official [Spanner Omni system requirements](https://docs.cloud.google.com/spanner-omni/system-requirements).
 
 ### Protocol Buffers support
 

--- a/internal/mycli/app.go
+++ b/internal/mycli/app.go
@@ -17,7 +17,6 @@
 package mycli
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -34,6 +33,7 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 	"github.com/samber/lo"
 	"golang.org/x/term"
+	"google.golang.org/api/option"
 
 	_ "github.com/apstndb/spanner-mycli/internal/mycli/formatsql" // Register SQL export formatters
 	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
@@ -171,10 +171,11 @@ func run(ctx context.Context, opts *spannerOptions) error {
 		}
 	}
 
-	if opts.EmbeddedEmulator {
-		// Log when user provides custom values with embedded emulator
+	if opts.usesEmbeddedRuntime() {
+		backend := opts.embeddedRuntimeBackend()
+		// Log when user provides custom values with embedded runtime
 		if opts.ProjectId != "" || opts.InstanceId != "" || opts.DatabaseId != "" {
-			attrs := []any{}
+			attrs := []any{"backend", backend}
 			if opts.ProjectId != "" {
 				attrs = append(attrs, "project", opts.ProjectId)
 			}
@@ -184,26 +185,32 @@ func run(ctx context.Context, opts *spannerOptions) error {
 			if opts.DatabaseId != "" {
 				attrs = append(attrs, "database", opts.DatabaseId)
 			}
-			slog.Warn("Using embedded emulator with user-provided values", attrs...)
+			slog.Warn("Using embedded runtime with user-provided values", attrs...)
 		}
 
 		// Use values from sysVars (which includes defaults set in initializeSystemVariables)
-		emulatorOpts := []spanemuboost.Option{
+		runtimeOpts := []spanemuboost.Option{
 			spanemuboost.WithProjectID(sysVars.Connection.Project),
 			spanemuboost.WithInstanceID(sysVars.Connection.Instance),
 			spanemuboost.WithDatabaseID(sysVars.Connection.Database),
-			spanemuboost.WithContainerImage(cmp.Or(opts.EmulatorImage, spanemuboost.DefaultEmulatorImage)),
 			spanemuboost.WithDatabaseDialect(sysVars.Feature.DatabaseDialect),
 		}
+		if opts.EmulatorImage != "" {
+			runtimeOpts = append(runtimeOpts, spanemuboost.WithContainerImage(opts.EmulatorImage))
+		}
 
-		// In detached mode, only create instance without database
+		// Detached mode should not auto-create a database.
 		if opts.Detached {
-			emulatorOpts = append(emulatorOpts, spanemuboost.EnableInstanceAutoConfigOnly())
+			if backend == spanemuboost.BackendOmni {
+				runtimeOpts = append(runtimeOpts, spanemuboost.DisableAutoConfig())
+			} else {
+				runtimeOpts = append(runtimeOpts, spanemuboost.EnableInstanceAutoConfigOnly())
+			}
 		}
 
 		// Add platform customizer if specified
 		if opts.EmulatorPlatform != "" {
-			emulatorOpts = append(emulatorOpts, spanemuboost.WithContainerCustomizers(withPlatform(opts.EmulatorPlatform)))
+			runtimeOpts = append(runtimeOpts, spanemuboost.WithContainerCustomizers(withPlatform(opts.EmulatorPlatform)))
 		}
 
 		// Load sample database if specified
@@ -229,7 +236,7 @@ func run(ctx context.Context, opts *spannerOptions) error {
 			}
 
 			// Use the sample's dialect
-			emulatorOpts = append(emulatorOpts, spanemuboost.WithDatabaseDialect(sample.ParsedDialect))
+			runtimeOpts = append(runtimeOpts, spanemuboost.WithDatabaseDialect(sample.ParsedDialect))
 
 			// Prepare URIs for batch loading
 			var uris []string
@@ -253,7 +260,7 @@ func run(ctx context.Context, opts *spannerOptions) error {
 					if err != nil {
 						return fmt.Errorf("failed to parse %s statements: %w", stmtType, err)
 					}
-					emulatorOpts = append(emulatorOpts, setupFunc(statements))
+					runtimeOpts = append(runtimeOpts, setupFunc(statements))
 				}
 				return nil
 			}
@@ -269,13 +276,13 @@ func run(ctx context.Context, opts *spannerOptions) error {
 			}
 		}
 
-		embeddedRuntime, err := spanemuboost.Run(ctx, spanemuboost.BackendEmulator, emulatorOpts...)
+		embeddedRuntime, err := spanemuboost.Run(ctx, backend, runtimeOpts...)
 		if err != nil {
-			return fmt.Errorf("failed to start Cloud Spanner Emulator: %w", err)
+			return fmt.Errorf("failed to start embedded %s runtime: %w", backend, err)
 		}
 		defer func() {
 			if err := embeddedRuntime.Close(); err != nil {
-				slog.Warn("failed to close emulator container", "error", err)
+				slog.Warn("failed to close embedded runtime", "backend", backend, "error", err)
 			}
 		}()
 		sysVars.Connection.Project = embeddedRuntime.ProjectID()
@@ -302,10 +309,17 @@ func run(ctx context.Context, opts *spannerOptions) error {
 		host, port, err := parseEndpoint(embeddedRuntime.URI())
 		if err != nil {
 			// This should not happen with a valid URI from testcontainers, but handle defensively.
-			return fmt.Errorf("failed to parse emulator endpoint URI %q: %w", embeddedRuntime.URI(), err)
+			return fmt.Errorf("failed to parse embedded runtime endpoint URI %q: %w", embeddedRuntime.URI(), err)
 		}
 		sysVars.Connection.Host, sysVars.Connection.Port = host, port
-		sysVars.Connection.WithoutAuthentication = true
+		switch backend {
+		case spanemuboost.BackendEmulator:
+			sysVars.Connection.WithoutAuthentication = true
+		case spanemuboost.BackendOmni:
+			sysVars.Internal.EmbeddedClientOptions = append([]option.ClientOption(nil), embeddedRuntime.ClientOptions()...)
+			omniClientConfig := spanemuboost.RecommendedOmniClientConfig()
+			sysVars.Internal.EmbeddedClientConfig = &omniClientConfig
+		}
 	}
 
 	// TTY detection has been moved to StreamManager.

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -65,6 +65,11 @@ type versionRequestedError struct{}
 
 func (versionRequestedError) Error() string { return "version requested" }
 
+const (
+	defaultEmbeddedOmniProjectID  = "default"
+	defaultEmbeddedOmniInstanceID = "default"
+)
+
 type showHelpFlag bool
 
 // BeforeReset runs for matched flags in Kong's traced path, which lets help
@@ -126,8 +131,9 @@ type spannerOptions struct {
 	Insecure            *bool             `name:"insecure" help:"Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an alias."`
 	SkipTlsVerify       *bool             `name:"skip-tls-verify" hidden:"" help:"Hidden alias of --insecure from original spanner-cli"`
 	EmbeddedEmulator    bool              `name:"embedded-emulator" help:"Use embedded Cloud Spanner Emulator. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
-	EmulatorImage       string            `name:"emulator-image" help:"container image for --embedded-emulator"`
-	EmulatorPlatform    string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded emulator"`
+	EmbeddedOmni        bool              `name:"embedded-omni" help:"Use embedded experimental Spanner Omni. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
+	EmulatorImage       string            `name:"emulator-image" help:"container image for embedded runtime (--embedded-emulator or --embedded-omni)"`
+	EmulatorPlatform    string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime"`
 	SampleDatabase      string            `name:"sample-database" help:"Initialize emulator with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator."`
 	ListSamples         bool              `name:"list-samples" help:"List available sample databases and exit"`
 	OutputTemplate      string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
@@ -191,6 +197,17 @@ func determineInitialDatabase(opts *spannerOptions) string {
 	return ""
 }
 
+func (opts *spannerOptions) usesEmbeddedRuntime() bool {
+	return opts.EmbeddedEmulator || opts.EmbeddedOmni
+}
+
+func (opts *spannerOptions) embeddedRuntimeBackend() spanemuboost.Backend {
+	if opts.EmbeddedOmni {
+		return spanemuboost.BackendOmni
+	}
+	return spanemuboost.BackendEmulator
+}
+
 // ValidateSpannerOptions validates the spannerOptions struct.
 func ValidateSpannerOptions(opts *spannerOptions) error {
 	if opts.Strong && opts.ReadTimestamp != "" {
@@ -202,11 +219,15 @@ func ValidateSpannerOptions(opts *spannerOptions) error {
 		return fmt.Errorf("invalid combination: --endpoint and (--host or --port) are mutually exclusive")
 	}
 
-	if !opts.EmbeddedEmulator && (opts.ProjectId == "" || opts.InstanceId == "") {
+	if opts.EmbeddedEmulator && opts.EmbeddedOmni {
+		return fmt.Errorf("invalid combination: --embedded-emulator and --embedded-omni are mutually exclusive")
+	}
+
+	if !opts.usesEmbeddedRuntime() && (opts.ProjectId == "" || opts.InstanceId == "") {
 		return fmt.Errorf("missing parameters: -p, -i are required")
 	}
 
-	if !opts.EmbeddedEmulator && !opts.Detached && opts.DatabaseId == "" {
+	if !opts.usesEmbeddedRuntime() && !opts.Detached && opts.DatabaseId == "" {
 		return fmt.Errorf("missing parameter: -d is required (or use --detached for detached mode)")
 	}
 
@@ -518,18 +539,26 @@ func applyFormatAndSetOptions(sysVars *systemVariables, opts *spannerOptions) er
 	return nil
 }
 
-func applyEmbeddedEmulatorDefaults(sysVars *systemVariables, opts *spannerOptions) error {
-	if opts.EmbeddedEmulator {
-		// When using embedded emulator, insecure connection is required
+func applyEmbeddedRuntimeDefaults(sysVars *systemVariables, opts *spannerOptions) error {
+	if opts.usesEmbeddedRuntime() {
+		// When using an embedded runtime, insecure connection is required.
 		sysVars.Connection.Insecure = true
-		// sysVars.Connection.Host/Port and sysVars.Connection.WithoutAuthentication will be set in run() after emulator starts
+		// sysVars.Connection.Host/Port and authentication-related settings are set in run() after the runtime starts.
 
-		// Set default values for embedded emulator if not specified by user
+		// Set default values for embedded runtime if not specified by user.
 		if sysVars.Connection.Project == "" {
-			sysVars.Connection.Project = spanemuboost.DefaultProjectID
+			if opts.EmbeddedOmni {
+				sysVars.Connection.Project = defaultEmbeddedOmniProjectID
+			} else {
+				sysVars.Connection.Project = spanemuboost.DefaultProjectID
+			}
 		}
 		if sysVars.Connection.Instance == "" {
-			sysVars.Connection.Instance = spanemuboost.DefaultInstanceID
+			if opts.EmbeddedOmni {
+				sysVars.Connection.Instance = defaultEmbeddedOmniInstanceID
+			} else {
+				sysVars.Connection.Instance = spanemuboost.DefaultInstanceID
+			}
 		}
 		// For database, respect --detached mode (empty database)
 		if sysVars.Connection.Database == "" && !opts.Detached {
@@ -569,7 +598,7 @@ func initializeSystemVariables(opts *spannerOptions) (*systemVariables, error) {
 		applyProtoDescriptors,
 		applyDirectedRead,
 		applyFormatAndSetOptions,
-		applyEmbeddedEmulatorDefaults,
+		applyEmbeddedRuntimeDefaults,
 	} {
 		if err := apply(sysVars, opts); err != nil {
 			return nil, err

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -134,7 +134,7 @@ type spannerOptions struct {
 	EmbeddedOmni        bool              `name:"embedded-omni" help:"Use embedded experimental Spanner Omni. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
 	EmulatorImage       string            `name:"emulator-image" help:"container image for embedded runtime (--embedded-emulator or --embedded-omni)"`
 	EmulatorPlatform    string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime"`
-	SampleDatabase      string            `name:"sample-database" help:"Initialize emulator with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator."`
+	SampleDatabase      string            `name:"sample-database" help:"Initialize embedded runtime with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator or --embedded-omni."`
 	ListSamples         bool              `name:"list-samples" help:"List available sample databases and exit"`
 	OutputTemplate      string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
 	LogLevel            string            `name:"log-level"`
@@ -245,8 +245,8 @@ func ValidateSpannerOptions(opts *spannerOptions) error {
 		return fmt.Errorf("invalid combination: --execute(-e), --file(-f), --sql, --source are exclusive")
 	}
 	// Validate sample database flags
-	if opts.SampleDatabase != "" && !opts.EmbeddedEmulator {
-		return fmt.Errorf("--sample-database requires --embedded-emulator")
+	if opts.SampleDatabase != "" && !opts.usesEmbeddedRuntime() {
+		return fmt.Errorf("--sample-database requires --embedded-emulator or --embedded-omni")
 	}
 	if opts.ListSamples && opts.SampleDatabase != "" {
 		return fmt.Errorf("--list-samples and --sample-database are mutually exclusive")

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -134,7 +134,7 @@ type spannerOptions struct {
 	EmbeddedOmni        bool              `name:"embedded-omni" help:"Use embedded experimental Spanner Omni. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
 	EmulatorImage       string            `name:"emulator-image" help:"container image for embedded runtime (--embedded-emulator or --embedded-omni)"`
 	EmulatorPlatform    string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime"`
-	SampleDatabase      string            `name:"sample-database" help:"Initialize embedded runtime with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator or --embedded-omni. Cannot be combined with --detached."`
+	SampleDatabase      string            `name:"sample-database" help:"Initialize embedded runtime with built-in sample (e.g. fingraph, singers, banking) or path to a metadata file (.json, .yaml, .yml). Requires --embedded-emulator or --embedded-omni. Cannot be combined with --detached."`
 	ListSamples         bool              `name:"list-samples" help:"List available sample databases and exit"`
 	OutputTemplate      string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
 	LogLevel            string            `name:"log-level"`

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -134,7 +134,7 @@ type spannerOptions struct {
 	EmbeddedOmni        bool              `name:"embedded-omni" help:"Use embedded experimental Spanner Omni. --project, --instance, --database, --endpoint, --insecure will be automatically configured."`
 	EmulatorImage       string            `name:"emulator-image" help:"container image for embedded runtime (--embedded-emulator or --embedded-omni)"`
 	EmulatorPlatform    string            `name:"emulator-platform" help:"Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime"`
-	SampleDatabase      string            `name:"sample-database" help:"Initialize embedded runtime with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator or --embedded-omni."`
+	SampleDatabase      string            `name:"sample-database" help:"Initialize embedded runtime with built-in sample (e.g. fingraph, singers, banking) or path to metadata.json file. Requires --embedded-emulator or --embedded-omni. Cannot be combined with --detached."`
 	ListSamples         bool              `name:"list-samples" help:"List available sample databases and exit"`
 	OutputTemplate      string            `name:"output-template" help:"Filepath of output template. (EXPERIMENTAL)"`
 	LogLevel            string            `name:"log-level"`
@@ -247,6 +247,9 @@ func ValidateSpannerOptions(opts *spannerOptions) error {
 	// Validate sample database flags
 	if opts.SampleDatabase != "" && !opts.usesEmbeddedRuntime() {
 		return fmt.Errorf("--sample-database requires --embedded-emulator or --embedded-omni")
+	}
+	if opts.SampleDatabase != "" && opts.Detached {
+		return fmt.Errorf("--sample-database cannot be used with --detached")
 	}
 	if opts.ListSamples && opts.SampleDatabase != "" {
 		return fmt.Errorf("--list-samples and --sample-database are mutually exclusive")

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -623,9 +623,7 @@ func parseFlagsArgs(args []string, installFrom string, configFiles []string, std
 }
 
 func newGlobalOptions() globalOptions {
-	var gopts globalOptions
-	gopts.Spanner.EmulatorImage = spanemuboost.DefaultEmulatorImage
-	return gopts
+	return globalOptions{}
 }
 
 const configFileName = ".spanner_mycli.toml"

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -367,6 +367,11 @@ func TestParseFlagsCombinations(t *testing.T) {
 			name: "sample database accepts embedded omni",
 			args: []string{"--embedded-omni", "--sample-database", "singers"},
 		},
+		{
+			name:        "sample database rejects detached mode",
+			args:        []string{"--embedded-omni", "--sample-database", "singers", "--detached"},
+			errContains: "--sample-database cannot be used with --detached",
+		},
 
 		// Missing required parameters
 		{

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -364,9 +364,8 @@ func TestParseFlagsCombinations(t *testing.T) {
 			errContains: errMsgEmbeddedModesExclusive,
 		},
 		{
-			name:        "sample database requires embedded emulator",
-			args:        []string{"--embedded-omni", "--sample-database", "singers"},
-			errContains: "--sample-database requires --embedded-emulator",
+			name: "sample database accepts embedded omni",
+			args: []string{"--embedded-omni", "--sample-database", "singers"},
 		},
 
 		// Missing required parameters

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -50,6 +50,7 @@ const (
 	errMsgEndpointHostPortExclusive    = "--endpoint and (--host or --port) are mutually exclusive"
 	errMsgStrongReadTimestampExclusive = "--strong and --read-timestamp are mutually exclusive"
 	errMsgTryPartitionRequiresInput    = "--try-partition-query requires SQL input via --execute(-e), --file(-f), --source, or --sql"
+	errMsgEmbeddedModesExclusive       = "--embedded-emulator and --embedded-omni are mutually exclusive"
 	errMsgMissingProjectInstance       = "missing parameters: -p, -i are required"
 	errMsgMissingDatabase              = "missing parameter: -d is required"
 )
@@ -353,6 +354,20 @@ func TestParseFlagsCombinations(t *testing.T) {
 			name: "embedded-emulator ignores connection params",
 			args: []string{"--embedded-emulator", "--project", "ignored", "--instance", "ignored", "--database", "ignored"},
 		},
+		{
+			name: "embedded-omni without connection params",
+			args: []string{"--embedded-omni"},
+		},
+		{
+			name:        "embedded modes are mutually exclusive",
+			args:        []string{"--embedded-emulator", "--embedded-omni"},
+			errContains: errMsgEmbeddedModesExclusive,
+		},
+		{
+			name:        "sample database requires embedded emulator",
+			args:        []string{"--embedded-omni", "--sample-database", "singers"},
+			errContains: "--sample-database requires --embedded-emulator",
+		},
 
 		// Missing required parameters
 		{
@@ -377,6 +392,10 @@ func TestParseFlagsCombinations(t *testing.T) {
 		{
 			name: "embedded emulator doesn't require project/instance/database",
 			args: []string{"--embedded-emulator"},
+		},
+		{
+			name: "embedded omni doesn't require project/instance/database",
+			args: []string{"--embedded-omni"},
 		},
 
 		// Valid combinations
@@ -928,6 +947,15 @@ func TestFlagSpecialModes(t *testing.T) {
 			wantInsecure: true,
 		},
 		{
+			name:          "embedded omni with no explicit values uses defaults",
+			args:          []string{"--embedded-omni"},
+			wantProject:   "default",
+			wantInstance:  "default",
+			wantDatabase:  "emulator-database",
+			wantInsecure:  true,
+			checkAfterRun: true,
+		},
+		{
 			name: "MCP mode sets verbose",
 			args: []string{
 				"--project", "p", "--instance", "i", "--database", "d",
@@ -1040,11 +1068,11 @@ func TestFlagSpecialModes(t *testing.T) {
 			}
 
 			// Special checks for modes that set values in run()
-			if tt.name == "embedded emulator with no explicit values uses defaults" && tt.checkAfterRun {
+			if (tt.name == "embedded emulator with no explicit values uses defaults" || tt.name == "embedded omni with no explicit values uses defaults") && tt.checkAfterRun {
 				// These would be set in run() after emulator starts
 				// Just verify the flags that trigger this behavior are correct
-				if !gopts.Spanner.EmbeddedEmulator {
-					t.Errorf("EmbeddedEmulator flag not set")
+				if !gopts.Spanner.EmbeddedEmulator && !gopts.Spanner.EmbeddedOmni {
+					t.Errorf("embedded runtime flag not set")
 				}
 			}
 
@@ -2486,6 +2514,12 @@ func TestEmulatorPlatformFlag(t *testing.T) {
 			wantEmbedded: true,
 		},
 		{
+			name:         "embedded-omni with platform",
+			args:         []string{"--embedded-omni", "--emulator-platform", "linux/amd64"},
+			wantPlatform: "linux/amd64",
+			wantEmbedded: false,
+		},
+		{
 			name:         "emulator-platform without embedded-emulator",
 			args:         []string{"--emulator-platform", "linux/amd64"},
 			wantPlatform: "linux/amd64",
@@ -2505,5 +2539,20 @@ func TestEmulatorPlatformFlag(t *testing.T) {
 			}
 			assertEqual(t, "EmbeddedEmulator", gopts.Spanner.EmbeddedEmulator, &tt.wantEmbedded)
 		})
+	}
+}
+
+func TestEmbeddedOmniFlag(t *testing.T) {
+	t.Parallel()
+
+	gopts, err := parseTestFlags([]string{"--embedded-omni"})
+	if err != nil {
+		t.Fatalf("parseTestFlags() error = %v", err)
+	}
+	if !gopts.Spanner.EmbeddedOmni {
+		t.Fatal("EmbeddedOmni flag not set")
+	}
+	if gopts.Spanner.EmbeddedEmulator {
+		t.Fatal("EmbeddedEmulator unexpectedly set")
 	}
 }

--- a/internal/mycli/main_test.go
+++ b/internal/mycli/main_test.go
@@ -578,6 +578,87 @@ func Test_initializeSystemVariables(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "embedded omni with no user values",
+			opts: &spannerOptions{
+				EmbeddedOmni: true,
+			},
+			want: systemVariables{
+				Connection: ConnectionVars{
+					Project:       "default",
+					Instance:      "default",
+					Database:      "emulator-database",
+					Insecure:      true,
+					EnableADCPlus: true,
+				},
+				Display: DisplayVars{
+					Prompt:               defaultPrompt,
+					Prompt2:              defaultPrompt2,
+					HistoryFile:          defaultHistoryFile,
+					CLIFormat:            enums.DisplayModeTable,
+					AnalyzeColumns:       DefaultAnalyzeColumns,
+					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+					TypeStylesRaw:        defaultTypeStyles,
+					OutputTemplateFile:   "",
+					OutputTemplate:       defaultOutputFormat,
+				},
+				Query: QueryVars{
+					RPCPriority:      defaultPriority,
+					TablePreviewRows: 50,
+				},
+				Transaction: TransactionVars{
+					ReturnCommitStats: true,
+				},
+				Feature: FeatureVars{
+					LogLevel:         slog.LevelWarn,
+					VertexAIModel:    defaultVertexAIModel,
+					VertexAILocation: defaultVertexAILocation,
+					FuzzyFinderKey:   "C_T",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "embedded omni with detached mode",
+			opts: &spannerOptions{
+				EmbeddedOmni: true,
+				Detached:     true,
+			},
+			want: systemVariables{
+				Connection: ConnectionVars{
+					Project:       "default",
+					Instance:      "default",
+					Database:      "",
+					Insecure:      true,
+					EnableADCPlus: true,
+				},
+				Display: DisplayVars{
+					Prompt:               defaultPrompt,
+					Prompt2:              defaultPrompt2,
+					HistoryFile:          defaultHistoryFile,
+					CLIFormat:            enums.DisplayModeTable,
+					AnalyzeColumns:       DefaultAnalyzeColumns,
+					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
+					TypeStylesRaw:        defaultTypeStyles,
+					OutputTemplateFile:   "",
+					OutputTemplate:       defaultOutputFormat,
+				},
+				Query: QueryVars{
+					RPCPriority:      defaultPriority,
+					TablePreviewRows: 50,
+				},
+				Transaction: TransactionVars{
+					ReturnCommitStats: true,
+				},
+				Feature: FeatureVars{
+					LogLevel:         slog.LevelWarn,
+					VertexAIModel:    defaultVertexAIModel,
+					VertexAILocation: defaultVertexAILocation,
+					FuzzyFinderKey:   "C_T",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "CLI_ANALYZE_COLUMNS set",
 			opts: &spannerOptions{
 				Set: map[string]string{

--- a/internal/mycli/sample_databases.go
+++ b/internal/mycli/sample_databases.go
@@ -422,7 +422,9 @@ func ListAvailableSamples() string {
 	}
 
 	sb.WriteString("\nUsage: spanner-mycli --embedded-emulator --sample-database=<name>\n")
+	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=<name>\n")
 	sb.WriteString("       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.json\n")
+	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.json\n")
 	return sb.String()
 }
 

--- a/internal/mycli/sample_databases.go
+++ b/internal/mycli/sample_databases.go
@@ -423,8 +423,8 @@ func ListAvailableSamples() string {
 
 	sb.WriteString("\nUsage: spanner-mycli --embedded-emulator --sample-database=<name>\n")
 	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=<name>\n")
-	sb.WriteString("       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.json\n")
-	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.json\n")
+	sb.WriteString("       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.(json|yaml|yml)\n")
+	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.(json|yaml|yml)\n")
 	return sb.String()
 }
 

--- a/internal/mycli/sample_databases.go
+++ b/internal/mycli/sample_databases.go
@@ -423,8 +423,9 @@ func ListAvailableSamples() string {
 
 	sb.WriteString("\nUsage: spanner-mycli --embedded-emulator --sample-database=<name>\n")
 	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=<name>\n")
-	sb.WriteString("       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.(json|yaml|yml)\n")
-	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.(json|yaml|yml)\n")
+	sb.WriteString("       spanner-mycli --embedded-emulator --sample-database=/path/to/metadata.yaml\n")
+	sb.WriteString("       spanner-mycli --embedded-omni --sample-database=/path/to/metadata.yaml\n")
+	sb.WriteString("       Sample metadata files may use .json, .yaml, or .yml.\n")
 	return sb.String()
 }
 

--- a/internal/mycli/sample_databases_test.go
+++ b/internal/mycli/sample_databases_test.go
@@ -49,8 +49,11 @@ func TestListAvailableSamples(t *testing.T) {
 	}
 
 	// Check for usage instruction
-	if !strings.Contains(output, "metadata.(json|yaml|yml)") {
-		t.Error("ListAvailableSamples() missing metadata format instruction")
+	if !strings.Contains(output, "metadata.yaml") {
+		t.Error("ListAvailableSamples() missing concrete metadata example")
+	}
+	if !strings.Contains(output, ".json, .yaml, or .yml") {
+		t.Error("ListAvailableSamples() missing metadata format note")
 	}
 }
 

--- a/internal/mycli/sample_databases_test.go
+++ b/internal/mycli/sample_databases_test.go
@@ -49,8 +49,8 @@ func TestListAvailableSamples(t *testing.T) {
 	}
 
 	// Check for usage instruction
-	if !strings.Contains(output, "metadata.json") {
-		t.Error("ListAvailableSamples() missing metadata.json instruction")
+	if !strings.Contains(output, "metadata.(json|yaml|yml)") {
+		t.Error("ListAvailableSamples() missing metadata format instruction")
 	}
 }
 

--- a/internal/mycli/samples/README.md
+++ b/internal/mycli/samples/README.md
@@ -91,8 +91,8 @@ INSERT INTO Users (UserId, UserName, Email) VALUES
 
 5. Use your custom sample:
 ```bash
-spanner-mycli --embedded-emulator --sample-database=/path/to/mysample/metadata.json
-spanner-mycli --embedded-omni --sample-database=/path/to/mysample/metadata.json
+spanner-mycli --embedded-emulator --sample-database=/path/to/mysample/metadata.(json|yaml|yml)
+spanner-mycli --embedded-omni --sample-database=/path/to/mysample/metadata.(json|yaml|yml)
 ```
 
 ### Advanced Example with Mixed Sources

--- a/internal/mycli/samples/README.md
+++ b/internal/mycli/samples/README.md
@@ -50,6 +50,8 @@ spanner-mycli --list-samples
 # Use a built-in sample
 spanner-mycli --embedded-emulator --sample-database=fingraph
 spanner-mycli --embedded-emulator --sample-database=singers
+spanner-mycli --embedded-omni --sample-database=fingraph
+spanner-mycli --embedded-omni --sample-database=singers
 ```
 
 ### Creating Custom Samples
@@ -90,6 +92,7 @@ INSERT INTO Users (UserId, UserName, Email) VALUES
 5. Use your custom sample:
 ```bash
 spanner-mycli --embedded-emulator --sample-database=/path/to/mysample/metadata.json
+spanner-mycli --embedded-omni --sample-database=/path/to/mysample/metadata.json
 ```
 
 ### Advanced Example with Mixed Sources

--- a/internal/mycli/samples/README.md
+++ b/internal/mycli/samples/README.md
@@ -91,8 +91,8 @@ INSERT INTO Users (UserId, UserName, Email) VALUES
 
 5. Use your custom sample:
 ```bash
-spanner-mycli --embedded-emulator --sample-database=/path/to/mysample/metadata.(json|yaml|yml)
-spanner-mycli --embedded-omni --sample-database=/path/to/mysample/metadata.(json|yaml|yml)
+spanner-mycli --embedded-emulator --sample-database=/path/to/mysample/metadata.yaml
+spanner-mycli --embedded-omni --sample-database=/path/to/mysample/metadata.yaml
 ```
 
 ### Advanced Example with Mixed Sources

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -70,12 +71,14 @@ var defaultClientOpts = []option.ClientOption{
 }
 
 func clientConfigForSystemVariables(sysVars *systemVariables) spanner.ClientConfig {
-	clientConfig := defaultClientConfig
 	if override := sysVars.Internal.EmbeddedClientConfig; override != nil {
-		clientConfig.DisableNativeMetrics = override.DisableNativeMetrics
-		clientConfig.IsExperimentalHost = override.IsExperimentalHost
+		clientConfig := *override
+		if reflect.DeepEqual(clientConfig.SessionPoolConfig, spanner.SessionPoolConfig{}) {
+			clientConfig.SessionPoolConfig = defaultClientConfig.SessionPoolConfig
+		}
+		return clientConfig
 	}
-	return clientConfig
+	return defaultClientConfig
 }
 
 // Use MEDIUM priority not to disturb regular workloads on the database.

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -69,6 +69,15 @@ var defaultClientOpts = []option.ClientOption{
 	option.WithGRPCConnectionPool(1),
 }
 
+func clientConfigForSystemVariables(sysVars *systemVariables) spanner.ClientConfig {
+	clientConfig := defaultClientConfig
+	if override := sysVars.Internal.EmbeddedClientConfig; override != nil {
+		clientConfig.DisableNativeMetrics = override.DisableNativeMetrics
+		clientConfig.IsExperimentalHost = override.IsExperimentalHost
+	}
+	return clientConfig
+}
+
 // Use MEDIUM priority not to disturb regular workloads on the database.
 const defaultPriority = sppb.RequestOptions_PRIORITY_MEDIUM
 
@@ -287,11 +296,11 @@ func newSessionWithFactories(
 	opts ...option.ClientOption,
 ) (*Session, error) {
 	dbPath := sysVars.DatabasePath()
-	clientConfig := defaultClientConfig
+	clientConfig := clientConfigForSystemVariables(sysVars)
 	clientConfig.DatabaseRole = sysVars.Connection.Role
 	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
 
-	if sysVars.Connection.Insecure {
+	if sysVars.Connection.Insecure && len(sysVars.Internal.EmbeddedClientOptions) == 0 {
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	}
 
@@ -326,11 +335,11 @@ func newSessionWithFactories(
 }
 
 func NewAdminSession(ctx context.Context, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
-	clientConfig := defaultClientConfig
+	clientConfig := clientConfigForSystemVariables(sysVars)
 	clientConfig.DatabaseRole = sysVars.Connection.Role
 	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
 
-	if sysVars.Connection.Insecure {
+	if sysVars.Connection.Insecure && len(sysVars.Internal.EmbeddedClientOptions) == 0 {
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	}
 
@@ -958,6 +967,10 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 
 // createClientOptions creates client options based on credential and system variables
 func createClientOptions(ctx context.Context, credential []byte, sysVars *systemVariables) ([]option.ClientOption, error) {
+	if len(sysVars.Internal.EmbeddedClientOptions) > 0 {
+		return append([]option.ClientOption(nil), sysVars.Internal.EmbeddedClientOptions...), nil
+	}
+
 	var opts []option.ClientOption
 	if sysVars.Connection.Host != "" && sysVars.Connection.Port != 0 {
 		// Reconstruct the endpoint, adding brackets back for IPv6 addresses

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -166,3 +166,125 @@ func TestNewSessionClosesClientWhenAdminClientCreationFails(t *testing.T) {
 		t.Fatalf("newSessionWithFactories() closed client = %p, want %p", closedClient, fakeClient)
 	}
 }
+
+func TestCreateClientOptionsUsesEmbeddedClientOptions(t *testing.T) {
+	t.Parallel()
+
+	sysVars := &systemVariables{
+		Connection: ConnectionVars{
+			Host:                  "localhost",
+			Port:                  9010,
+			WithoutAuthentication: true,
+		},
+		Internal: InternalVars{
+			EmbeddedClientOptions: []option.ClientOption{
+				option.WithoutAuthentication(),
+			},
+		},
+	}
+
+	opts, err := createClientOptions(context.Background(), nil, sysVars)
+	if err != nil {
+		t.Fatalf("createClientOptions() error = %v", err)
+	}
+	if len(opts) != 1 {
+		t.Fatalf("createClientOptions() len = %d, want 1", len(opts))
+	}
+}
+
+func TestNewSessionWithFactoriesUsesEmbeddedClientConfig(t *testing.T) {
+	t.Parallel()
+
+	directedRead := &sppb.DirectedReadOptions{}
+	sysVars := &systemVariables{
+		Connection: ConnectionVars{
+			Project:  "test-project",
+			Instance: "test-instance",
+			Database: "test-database",
+			Role:     "test-role",
+		},
+		Query: QueryVars{
+			DirectedRead: directedRead,
+		},
+		Internal: InternalVars{
+			EmbeddedClientConfig: &spanner.ClientConfig{
+				DisableNativeMetrics: true,
+				IsExperimentalHost:   true,
+			},
+		},
+	}
+
+	var gotConfig spanner.ClientConfig
+	session, err := newSessionWithFactories(
+		context.Background(),
+		sysVars,
+		func(_ context.Context, _ string, cfg spanner.ClientConfig, _ ...option.ClientOption) (*spanner.Client, error) {
+			gotConfig = cfg
+			return &spanner.Client{}, nil
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+		func(*spanner.Client) {},
+	)
+	if err != nil {
+		t.Fatalf("newSessionWithFactories() error = %v", err)
+	}
+	if session == nil {
+		t.Fatal("newSessionWithFactories() returned nil session")
+	}
+	if !gotConfig.DisableNativeMetrics {
+		t.Error("DisableNativeMetrics = false, want true")
+	}
+	if !gotConfig.IsExperimentalHost {
+		t.Error("IsExperimentalHost = false, want true")
+	}
+	if gotConfig.DatabaseRole != "test-role" {
+		t.Errorf("DatabaseRole = %q, want %q", gotConfig.DatabaseRole, "test-role")
+	}
+	if diff := cmp.Diff(directedRead, gotConfig.DirectedReadOptions, protocmp.Transform()); diff != "" {
+		t.Errorf("DirectedReadOptions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNewSessionWithFactoriesDoesNotAppendInsecureForEmbeddedOptions(t *testing.T) {
+	t.Parallel()
+
+	sysVars := &systemVariables{
+		Connection: ConnectionVars{
+			Project:  "test-project",
+			Instance: "test-instance",
+			Database: "test-database",
+			Insecure: true,
+		},
+		Internal: InternalVars{
+			EmbeddedClientOptions: []option.ClientOption{
+				option.WithoutAuthentication(),
+			},
+		},
+	}
+
+	var gotOpts []option.ClientOption
+	session, err := newSessionWithFactories(
+		context.Background(),
+		sysVars,
+		func(_ context.Context, _ string, _ spanner.ClientConfig, opts ...option.ClientOption) (*spanner.Client, error) {
+			gotOpts = append([]option.ClientOption(nil), opts...)
+			return &spanner.Client{}, nil
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+		func(*spanner.Client) {},
+		sysVars.Internal.EmbeddedClientOptions...,
+	)
+	if err != nil {
+		t.Fatalf("newSessionWithFactories() error = %v", err)
+	}
+	if session == nil {
+		t.Fatal("newSessionWithFactories() returned nil session")
+	}
+	if len(gotOpts) != len(sysVars.Internal.EmbeddedClientOptions)+len(defaultClientOpts) {
+		t.Fatalf("len(opts) = %d, want %d", len(gotOpts), len(sysVars.Internal.EmbeddedClientOptions)+len(defaultClientOpts))
+	}
+}

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -247,11 +247,11 @@ func TestNewSessionWithFactoriesUsesEmbeddedClientConfig(t *testing.T) {
 	if gotConfig.UserAgent != "embedded-omni-test" {
 		t.Errorf("UserAgent = %q, want %q", gotConfig.UserAgent, "embedded-omni-test")
 	}
-	if gotConfig.SessionPoolConfig.MinOpened != defaultClientConfig.SessionPoolConfig.MinOpened {
-		t.Errorf("SessionPoolConfig.MinOpened = %d, want %d", gotConfig.SessionPoolConfig.MinOpened, defaultClientConfig.SessionPoolConfig.MinOpened)
+	if gotConfig.MinOpened != defaultClientConfig.MinOpened {
+		t.Errorf("SessionPoolConfig.MinOpened = %d, want %d", gotConfig.MinOpened, defaultClientConfig.MinOpened)
 	}
-	if gotConfig.SessionPoolConfig.MaxOpened != defaultClientConfig.SessionPoolConfig.MaxOpened {
-		t.Errorf("SessionPoolConfig.MaxOpened = %d, want %d", gotConfig.SessionPoolConfig.MaxOpened, defaultClientConfig.SessionPoolConfig.MaxOpened)
+	if gotConfig.MaxOpened != defaultClientConfig.MaxOpened {
+		t.Errorf("SessionPoolConfig.MaxOpened = %d, want %d", gotConfig.MaxOpened, defaultClientConfig.MaxOpened)
 	}
 	if gotConfig.DatabaseRole != "test-role" {
 		t.Errorf("DatabaseRole = %q, want %q", gotConfig.DatabaseRole, "test-role")

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -210,6 +210,8 @@ func TestNewSessionWithFactoriesUsesEmbeddedClientConfig(t *testing.T) {
 			EmbeddedClientConfig: &spanner.ClientConfig{
 				DisableNativeMetrics: true,
 				IsExperimentalHost:   true,
+				DisableRouteToLeader: true,
+				UserAgent:            "embedded-omni-test",
 			},
 		},
 	}
@@ -238,6 +240,18 @@ func TestNewSessionWithFactoriesUsesEmbeddedClientConfig(t *testing.T) {
 	}
 	if !gotConfig.IsExperimentalHost {
 		t.Error("IsExperimentalHost = false, want true")
+	}
+	if !gotConfig.DisableRouteToLeader {
+		t.Error("DisableRouteToLeader = false, want true")
+	}
+	if gotConfig.UserAgent != "embedded-omni-test" {
+		t.Errorf("UserAgent = %q, want %q", gotConfig.UserAgent, "embedded-omni-test")
+	}
+	if gotConfig.SessionPoolConfig.MinOpened != defaultClientConfig.SessionPoolConfig.MinOpened {
+		t.Errorf("SessionPoolConfig.MinOpened = %d, want %d", gotConfig.SessionPoolConfig.MinOpened, defaultClientConfig.SessionPoolConfig.MinOpened)
+	}
+	if gotConfig.SessionPoolConfig.MaxOpened != defaultClientConfig.SessionPoolConfig.MaxOpened {
+		t.Errorf("SessionPoolConfig.MaxOpened = %d, want %d", gotConfig.SessionPoolConfig.MaxOpened, defaultClientConfig.SessionPoolConfig.MaxOpened)
 	}
 	if gotConfig.DatabaseRole != "test-role" {
 		t.Errorf("DatabaseRole = %q, want %q", gotConfig.DatabaseRole, "test-role")

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -35,6 +35,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/api/option"
 
 	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
 )
@@ -155,9 +156,11 @@ type FeatureVars struct {
 
 // InternalVars holds internal state not directly exposed as system variables.
 type InternalVars struct {
-	ProtoDescriptorFile []string // CLI_PROTO_DESCRIPTOR_FILE
-	ProtoDescriptor     *descriptorpb.FileDescriptorSet
-	LastQueryCache      *LastQueryCache
+	ProtoDescriptorFile   []string // CLI_PROTO_DESCRIPTOR_FILE
+	ProtoDescriptor       *descriptorpb.FileDescriptorSet
+	LastQueryCache        *LastQueryCache
+	EmbeddedClientOptions []option.ClientOption
+	EmbeddedClientConfig  *spanner.ClientConfig
 }
 
 // systemVariables holds configuration state for spanner-mycli sessions.


### PR DESCRIPTION
## Summary

- add experimental `--embedded-omni` support alongside `--embedded-emulator`
- wire embedded runtime backend client options/config through session creation
- document embedded Omni usage and refresh generated CLI help

## Details

- add embedded runtime backend selection and validation for emulator vs Omni
- use Omni-specific fixed defaults for project/instance and support sample database bootstrapping on embedded Omni
- preserve backend-aware container image defaults from `spanemuboost`
- reuse embedded runtime client options for Omni and apply the recommended experimental host client config
- add regression coverage for flag parsing, system variable defaults, and embedded client option/config propagation

Fixes #603
