### PR TITLE
chore(deps): upgrade spanvalue to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/apstndb/spanemuboost v0.4.0
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.3
-	github.com/apstndb/spantype v0.3.9
-	github.com/apstndb/spanvalue v0.1.9
+	github.com/apstndb/spantype v0.3.11
+	github.com/apstndb/spanvalue v0.2.1
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24
@@ -43,7 +43,7 @@ require (
 	github.com/nyaosorg/go-readline-ny v1.14.1
 	github.com/olekukonko/tablewriter v1.1.3
 	github.com/pelletier/go-toml v1.9.5
-	github.com/samber/lo v1.51.0
+	github.com/samber/lo v1.53.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/afero v1.14.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -2499,10 +2499,10 @@ github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6/go.mod h1:Enpmw/D11tME865ROYDQzoHSIo9V8uCgWdu+fxA7n2M=
 github.com/apstndb/spannerplan v0.1.3 h1:nFzTEvRL4yMzQeFdtWp3V0VaUidNA/o3T7HyIYIGk/U=
 github.com/apstndb/spannerplan v0.1.3/go.mod h1:iPN9r9R2AknoFnBFqA232cUO+2ZkHpk4Q1qeSAU9xEM=
-github.com/apstndb/spantype v0.3.9 h1:RGBzu9PoQgyzHINp5DL5qOcCxDhhbc/gxedp0o8cLLY=
-github.com/apstndb/spantype v0.3.9/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.1.9 h1:/KImo9AXexYkB9oL8vQSU3urrJ+nwEDtp7Vd0pZB6qE=
-github.com/apstndb/spanvalue v0.1.9/go.mod h1:5bsrzbQvYj8MqXkdtMOmo+60dh7w8axlNw18fpPKxQo=
+github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
+github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
+github.com/apstndb/spanvalue v0.2.1 h1:DcC5MBCcnZ2refpv0y2NPM+IQJBb7XtBwx6756A11HM=
+github.com/apstndb/spanvalue v0.2.1/go.mod h1:wyP0oOBwmPVnid/uebb/Xn4p86V+fVl6gTpsI/zpYkQ=
 github.com/apstndb/treeprint v0.0.0-20250529153958-e82576b37da6 h1:aTufxpgGiMiSQ/yoJzWsX7G7DCpvGOaDFtEYiE7QNmA=
 github.com/apstndb/treeprint v0.0.0-20250529153958-e82576b37da6/go.mod h1:kIPoI1ZQRmOP9hVdFSFjPGwOPVEOSpAEIFgG09dK+7Y=
 github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
@@ -3044,8 +3044,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
-github.com/samber/lo v1.51.0 h1:kysRYLbHy/MB7kQZf5DSN50JHmMsNEdeY24VzJFu7wI=
-github.com/samber/lo v1.51.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQccx6w=

--- a/internal/mycli/decoder/decoder_test.go
+++ b/internal/mycli/decoder/decoder_test.go
@@ -341,7 +341,7 @@ func TestDecodeColumn(t *testing.T) {
 		// TODO: Use NullUUID when available. See https://github.com/googleapis/google-cloud-go/pull/11345.
 		{
 			desc:  "UUID",
-			value: gcvctor.StringBasedValue(sppb.TypeCode_UUID, "bd667006-c4a7-49de-814f-e2a2ec65abca"),
+			value: gcvctor.StringBasedValueFromCode(sppb.TypeCode_UUID, "bd667006-c4a7-49de-814f-e2a2ec65abca"),
 			want:  "bd667006-c4a7-49de-814f-e2a2ec65abca",
 		},
 
@@ -354,7 +354,7 @@ func TestDecodeColumn(t *testing.T) {
 		},
 		{
 			desc:  "null proto",
-			value: gcvctor.TypedNull(typector.FQNToProtoType("examples.spanner.music.SingerInfo")),
+			value: gcvctor.NullOf(typector.FQNToProtoType("examples.spanner.music.SingerInfo")),
 			want:  "NULL",
 		},
 		{
@@ -370,7 +370,7 @@ func TestDecodeColumn(t *testing.T) {
 		},
 		{
 			desc:  "null array proto",
-			value: gcvctor.TypedNull(typector.ElemTypeToArrayType(typector.FQNToProtoType("examples.spanner.music.SingerInfo"))),
+			value: gcvctor.NullOf(typector.ElemTypeToArrayType(typector.FQNToProtoType("examples.spanner.music.SingerInfo"))),
 			want:  "NULL",
 		},
 

--- a/internal/mycli/decoder/jsonvalue_test.go
+++ b/internal/mycli/decoder/jsonvalue_test.go
@@ -38,12 +38,12 @@ func TestJSONFormatConfig(t *testing.T) {
 		wantJSON string
 	}{
 		{name: "INT64 as number", gcv: gcvctor.Int64Value(42), wantJSON: "42"},
-		{name: "NULL", gcv: gcvctor.SimpleTypedNull(sppb.TypeCode_STRING), wantJSON: "null"},
+		{name: "NULL", gcv: gcvctor.NullFromCode(sppb.TypeCode_STRING), wantJSON: "null"},
 		{name: "STRING quoted", gcv: gcvctor.StringValue("hello"), wantJSON: `"hello"`},
 		{name: "BOOL", gcv: gcvctor.BoolValue(true), wantJSON: "true"},
 		{name: "JSON pass-through", gcv: lo.Must(gcvctor.JSONValue(map[string]string{"k": "v"})), wantJSON: `{"k":"v"}`},
 		{name: "ARRAY of INT64", gcv: lo.Must(gcvctor.ArrayValue(gcvctor.Int64Value(1), gcvctor.Int64Value(2))), wantJSON: "[1,2]"},
-		{name: "STRUCT", gcv: lo.Must(gcvctor.StructValue([]string{"name", "age"}, []spanner.GenericColumnValue{gcvctor.StringValue("Alice"), gcvctor.Int64Value(30)})), wantJSON: `{"name":"Alice","age":30}`},
+		{name: "STRUCT", gcv: lo.Must(gcvctor.StructValueOf([]string{"name", "age"}, []spanner.GenericColumnValue{gcvctor.StringValue("Alice"), gcvctor.Int64Value(30)})), wantJSON: `{"name":"Alice","age":30}`},
 	}
 
 	for _, tt := range tests {

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -64,7 +64,7 @@ func prepareFormatConfig(sql string, sysVars *systemVariables) (*spanvalue.Forma
 	case format.SQLLiteralValues:
 		// Use SQL literal formatting for modes that declared SQLLiteralValues
 		// LiteralFormatConfig formats values as valid Spanner SQL literals
-		fc := spanvalue.LiteralFormatConfig
+		fc := spanvalue.LiteralFormatConfig()
 
 		// Auto-detect table name if not explicitly set
 		if sysVars.Display.SQLTableName == "" {

--- a/internal/mycli/integration_sql_export_test.go
+++ b/internal/mycli/integration_sql_export_test.go
@@ -59,10 +59,10 @@ func TestSQLExportIntegration(t *testing.T) {
 				},
 				{
 					gcvctor.Int64Value(3),
-					gcvctor.SimpleTypedNull(sppb.TypeCode_STRING),
+					gcvctor.NullFromCode(sppb.TypeCode_STRING),
 					gcvctor.Float64Value(300),
 					gcvctor.BoolValue(true),
-					gcvctor.SimpleTypedNull(sppb.TypeCode_TIMESTAMP),
+					gcvctor.NullFromCode(sppb.TypeCode_TIMESTAMP),
 				},
 			},
 		},
@@ -337,7 +337,7 @@ CREATE TABLE ComplexDest (
 			// BYTES
 			gcvctor.BytesValue([]byte("hello")),
 			// NUMERIC - Spanner normalizes and returns "123.456" even though we insert with trailing zeros
-			gcvctor.StringBasedValue(sppb.TypeCode_NUMERIC, "123.456"),
+			gcvctor.StringBasedValueFromCode(sppb.TypeCode_NUMERIC, "123.456"),
 		},
 		{
 			gcvctor.Int64Value(2),
@@ -358,9 +358,9 @@ CREATE TABLE ComplexDest (
 				return v
 			}(),
 			// NULL BYTES
-			gcvctor.SimpleTypedNull(sppb.TypeCode_BYTES),
+			gcvctor.NullFromCode(sppb.TypeCode_BYTES),
 			// NULL NUMERIC
-			gcvctor.SimpleTypedNull(sppb.TypeCode_NUMERIC),
+			gcvctor.NullFromCode(sppb.TypeCode_NUMERIC),
 		},
 	}
 

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -838,7 +838,7 @@ func generateParams(paramsNodeMap map[string]ast.Node, includeType bool) (map[st
 			if err != nil {
 				return nil, err
 			}
-			result[k] = gcvctor.TypedNull(typ)
+			result[k] = gcvctor.NullOf(typ)
 		case ast.Expr:
 			expr, err := memebridge.MemefishExprToGCV(v)
 			if err != nil {


### PR DESCRIPTION
## Summary
Upgrade `github.com/apstndb/spanvalue` to `v0.2.1` and align the local call sites with the newer API surface without taking on the broader `v0.3.x` migration yet.

## Key Changes
- **go.mod / go.sum**: bump `spanvalue` to `v0.2.1`, `spantype` to `v0.3.11`, and refresh transitive dependency selections.
- **internal/mycli/execute_sql.go**: switch SQL literal formatting to the new `spanvalue.LiteralFormatConfig()` constructor API.
- **internal/mycli/statements.go**: replace deprecated `gcvctor.TypedNull` usage with `gcvctor.NullOf`.
- **internal/mycli/decoder/decoder_test.go**: update decoder coverage to the non-deprecated `gcvctor` helpers.
- **internal/mycli/decoder/jsonvalue_test.go**: replace deprecated null/struct helper usage in JSON formatting tests.
- **internal/mycli/integration_sql_export_test.go**: update SQL export fixtures to the non-deprecated `gcvctor` helpers.

## Development Insights

### Discoveries
- `spanvalue v0.2.1` is a practical compatibility step, but `v0.3.x` still needs a separate migration because `memebridge` continues to depend on `gcvctor` aliases that are removed in `spanvalue v0.3.0-beta.1`.
- Moving to `v0.2.1` now reduces local deprecated API usage and keeps the follow-up `v0.3.x` PR narrower.

## Test Plan
- [ ] `make check` passes locally *(blocked in this environment because testcontainers cannot create the Docker `bridge` network)*
- [x] `go test -short ./...`
- [x] `golangci-lint run`
- [x] `make fmt-check`