### PR TITLE
docs(skills): stop requesting gemini summary

### DIFF
--- a/.claude/commands/merge-issue-pr.md
+++ b/.claude/commands/merge-issue-pr.md
@@ -10,17 +10,13 @@ You are completing the PR workflow for issue #$ARGUMENTS in the spanner-mycli re
 ## Your task
 
 1. Find the PR associated with issue #$ARGUMENTS
-2. Check if a Gemini summary exists after the last commit:
-   - Use `gh pr view <PR> --comments` to check for recent summary
-   - Look for a comment starting with "## Summary of Changes" that was posted after the last commit
-   - If no recent summary exists, request one by commenting `/gemini summary`
-3. Wait for reviews and checks to complete using `go tool gh-helper reviews wait <PR>`
-4. Squash merge the PR with a descriptive commit message that includes:
+2. Wait for reviews and checks to complete using `go tool gh-helper reviews wait <PR>`
+3. Squash merge the PR with a descriptive commit message that includes:
    - Clear summary of changes
    - Reference to the issue being fixed
-5. Clean up the phantom worktree for this issue if it exists
+4. Clean up the phantom worktree for this issue if it exists
 
 Important notes:
-- Only request a new Gemini summary if one doesn't exist after the last commit push
+- `/gemini summary` is posted automatically on PR creation. Do not request it manually during merge.
 - Use the squash merge method as enforced by the repository ruleset
 - Include a meaningful commit message that describes the changes made in the PR


### PR DESCRIPTION
## Summary
Update the merge workflow skill so it no longer checks for or requests `/gemini summary` during merge. That summary is posted automatically when the PR is created, so the old step was redundant and misleading.

## Key Changes
- **.claude/commands/merge-issue-pr.md**: Removed the manual summary-check/request step from the merge flow.
- **.claude/commands/merge-issue-pr.md**: Updated the guidance to say `/gemini summary` is automatic on PR creation and should not be requested during merge.

## Test Plan
- [ ] `make check` passes locally (blocked here: testcontainers cannot create containers because Docker network `bridge` is missing in this environment)
