### PR TITLE
chore(deps): upgrade spanvalue to v0.3.0 and memebridge to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,12 @@ require (
 	github.com/apstndb/go-tabwrap v0.1.2
 	github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
-	github.com/apstndb/memebridge v0.5.0
+	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.4.0
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.3
 	github.com/apstndb/spantype v0.3.11
-	github.com/apstndb/spanvalue v0.2.1
+	github.com/apstndb/spanvalue v0.3.0
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -2489,8 +2489,8 @@ github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae h1:dM4EYL52u6aQh
 github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae/go.mod h1:xW+J2790w/YgZZf3y5ff+/iO+dQoJQDGPrNkSLKQ9xc=
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82 h1:l54uIOgcH4r0lTg8xKRhehV71v8m4J+76zpjTGcRqsY=
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82/go.mod h1:PbqzTjsPq7Xhn8D7Vk8g/em15kd8vvEL1Y2xkI9CgGs=
-github.com/apstndb/memebridge v0.5.0 h1:WaWD0Wp3Yw1BZwyvT4bIf2XsXAA+vq9ZNxUKXXV/vZQ=
-github.com/apstndb/memebridge v0.5.0/go.mod h1:fPrWYKcg5/eaavD6RovT9qeq8K7bDhgLKOcGhqg6zo4=
+github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGvElI=
+github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
 github.com/apstndb/ptyhelp v0.2.1 h1:vGqYJiIBNS3opPA3JLCKsdKIZzomz2zFkO1PVuM+WLs=
 github.com/apstndb/ptyhelp v0.2.1/go.mod h1:qQr/aibVk0BK/dweEW7mcaT0jAH9NeRHP2in6MIgEcA=
 github.com/apstndb/spanemuboost v0.4.0 h1:PSr0bjmQlMn7iocJygIM4j8fTTDsvwsZdFsr9TwNXsE=
@@ -2501,8 +2501,8 @@ github.com/apstndb/spannerplan v0.1.3 h1:nFzTEvRL4yMzQeFdtWp3V0VaUidNA/o3T7HyIYI
 github.com/apstndb/spannerplan v0.1.3/go.mod h1:iPN9r9R2AknoFnBFqA232cUO+2ZkHpk4Q1qeSAU9xEM=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.2.1 h1:DcC5MBCcnZ2refpv0y2NPM+IQJBb7XtBwx6756A11HM=
-github.com/apstndb/spanvalue v0.2.1/go.mod h1:wyP0oOBwmPVnid/uebb/Xn4p86V+fVl6gTpsI/zpYkQ=
+github.com/apstndb/spanvalue v0.3.0 h1:MsHW+ZhHXdHmeoVjG/qw785mGvyKJ7GBz3cUPYEIDI4=
+github.com/apstndb/spanvalue v0.3.0/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
 github.com/apstndb/treeprint v0.0.0-20250529153958-e82576b37da6 h1:aTufxpgGiMiSQ/yoJzWsX7G7DCpvGOaDFtEYiE7QNmA=
 github.com/apstndb/treeprint v0.0.0-20250529153958-e82576b37da6/go.mod h1:kIPoI1ZQRmOP9hVdFSFjPGwOPVEOSpAEIFgG09dK+7Y=
 github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -528,9 +528,10 @@ func (s *TruncateTableStatement) Execute(ctx context.Context, session *Session) 
 		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-only transaction`)
 	}
 
-	target := spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, s.Table)
+	dialect := session.systemVariables.Feature.DatabaseDialect
+	target := spanvalue.QuoteIdentifier(dialect, s.Table)
 	if s.Schema != "" {
-		target = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, s.Schema) + "." + target
+		target = spanvalue.QuoteIdentifier(dialect, s.Schema) + "." + target
 	}
 
 	return executePDML(ctx, session, fmt.Sprintf("DELETE FROM %s WHERE true", target))

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apstndb/lox"
 	"github.com/apstndb/memebridge"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/cloudspannerecosystem/memefish/token"
@@ -527,12 +528,12 @@ func (s *TruncateTableStatement) Execute(ctx context.Context, session *Session) 
 		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-only transaction`)
 	}
 
-	var schemaPart string
+	target := spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, s.Table)
 	if s.Schema != "" {
-		schemaPart = fmt.Sprintf("`%s`.", s.Schema)
+		target = spanvalue.QuoteIdentifier(databasepb.DatabaseDialect_GOOGLE_STANDARD_SQL, s.Schema) + "." + target
 	}
 
-	return executePDML(ctx, session, fmt.Sprintf("DELETE FROM %s`%s` WHERE true", schemaPart, s.Table))
+	return executePDML(ctx, session, fmt.Sprintf("DELETE FROM %s WHERE true", target))
 }
 
 // EXPLAIN, EXPLAIN ANALYZE and DESCRIBE related statements are defined in statements_explain.go

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -72,16 +72,16 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 }
 
 // buildSelectQueryWithColumns creates a SELECT query with explicit column list.
-// Identifiers are quoted via spanvalue's GoogleSQL-aware helpers so reserved words
-// and qualified table names are rendered correctly.
-func buildSelectQueryWithColumns(columns []string, tableName string) string {
+// Identifiers are quoted via spanvalue's dialect-aware helpers so reserved words
+// and qualified table names are rendered correctly for the current database.
+func buildSelectQueryWithColumns(dialect dbadminpb.DatabaseDialect, columns []string, tableName string) string {
 	quotedColumns := make([]string, len(columns))
 	for i, col := range columns {
-		quotedColumns[i] = spanvalue.QuoteIdentifier(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, col)
+		quotedColumns[i] = spanvalue.QuoteIdentifier(dialect, col)
 	}
 	return fmt.Sprintf("SELECT %s FROM %s",
 		strings.Join(quotedColumns, ", "),
-		spanvalue.QuoteQualifiedIdentifier(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, tableName),
+		spanvalue.QuoteQualifiedIdentifier(dialect, tableName),
 	)
 }
 
@@ -197,7 +197,7 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 			}
 
 			// Build SELECT query with explicit column list
-			selectQuery := buildSelectQueryWithColumns(columns, table)
+			selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, columns, table)
 
 			// Execute query using the transaction variant since we're already within a transaction
 			dataResult, err := executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
@@ -291,7 +291,7 @@ func executeDumpStreaming(ctx context.Context, session *Session, mode dumpMode, 
 			}
 
 			// Build SELECT query with explicit column list
-			selectQuery := buildSelectQueryWithColumns(columns, table)
+			selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, columns, table)
 
 			// Write table comment
 			fmt.Fprintf(out, "-- Data for table %s\n", table)

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -11,6 +11,7 @@ import (
 	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/formatsql"
+	"github.com/apstndb/spanvalue"
 )
 
 // DumpDatabaseStatement represents DUMP DATABASE statement
@@ -71,14 +72,17 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 }
 
 // buildSelectQueryWithColumns creates a SELECT query with explicit column list.
-// Column names are quoted with backticks to handle reserved words.
-// Returns a SQL query string in the format: SELECT `col1`, `col2` FROM `tableName`
+// Identifiers are quoted via spanvalue's GoogleSQL-aware helpers so reserved words
+// and qualified table names are rendered correctly.
 func buildSelectQueryWithColumns(columns []string, tableName string) string {
 	quotedColumns := make([]string, len(columns))
 	for i, col := range columns {
-		quotedColumns[i] = fmt.Sprintf("`%s`", col)
+		quotedColumns[i] = spanvalue.QuoteIdentifier(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, col)
 	}
-	return fmt.Sprintf("SELECT %s FROM `%s`", strings.Join(quotedColumns, ", "), tableName)
+	return fmt.Sprintf("SELECT %s FROM %s",
+		strings.Join(quotedColumns, ", "),
+		spanvalue.QuoteQualifiedIdentifier(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, tableName),
+	)
 }
 
 // getWritableColumnsWithTxn queries INFORMATION_SCHEMA to get only columns that can accept INSERT values.

--- a/internal/mycli/statements_dump_test.go
+++ b/internal/mycli/statements_dump_test.go
@@ -1,6 +1,10 @@
 package mycli
 
-import "testing"
+import (
+	"testing"
+
+	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+)
 
 func TestBuildSelectQueryWithColumns(t *testing.T) {
 	t.Parallel()
@@ -33,7 +37,7 @@ func TestBuildSelectQueryWithColumns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := buildSelectQueryWithColumns(tt.columns, tt.table); got != tt.wantSQL {
+			if got := buildSelectQueryWithColumns(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, tt.columns, tt.table); got != tt.wantSQL {
 				t.Fatalf("buildSelectQueryWithColumns() = %q, want %q", got, tt.wantSQL)
 			}
 		})

--- a/internal/mycli/statements_dump_test.go
+++ b/internal/mycli/statements_dump_test.go
@@ -1,0 +1,41 @@
+package mycli
+
+import "testing"
+
+func TestBuildSelectQueryWithColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		columns []string
+		table   string
+		wantSQL string
+	}{
+		{
+			name:    "simple identifiers stay quoted",
+			columns: []string{"UserId", "FirstName"},
+			table:   "Users",
+			wantSQL: "SELECT `UserId`, `FirstName` FROM `Users`",
+		},
+		{
+			name:    "reserved identifiers are quoted",
+			columns: []string{"Order", "Value"},
+			table:   "Order",
+			wantSQL: "SELECT `Order`, `Value` FROM `Order`",
+		},
+		{
+			name:    "schema qualified table is quoted segment by segment",
+			columns: []string{"UserId", "From"},
+			table:   "select.Order",
+			wantSQL: "SELECT `UserId`, `From` FROM `select`.`Order`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildSelectQueryWithColumns(tt.columns, tt.table); got != tt.wantSQL {
+				t.Fatalf("buildSelectQueryWithColumns() = %q, want %q", got, tt.wantSQL)
+			}
+		})
+	}
+}

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -255,22 +255,11 @@ func convertToColumnsValues(gcv spanner.GenericColumnValue) ([]string, [][]spann
 }
 
 func parseLiteralExpr(expr ast.Expr) ([]string, [][]spanner.GenericColumnValue, error) {
-	switch e := expr.(type) {
-	case *ast.ParenExpr:
-		gcv, err := memebridge.MemefishExprToGCV(e)
-		if err != nil {
-			return nil, nil, fmt.Errorf("expression is not a supported literal, expr: %v, err: %w", e.SQL(), err)
-		}
-		return convertToColumnsValues(gcv)
-	case *ast.TypedStructLiteral, *ast.TupleStructLiteral, *ast.TypelessStructLiteral, *ast.ArrayLiteral:
-		gcv, err := memebridge.MemefishExprToGCV(e)
-		if err != nil {
-			return nil, nil, fmt.Errorf("expression is not a supported literal, expr: %v, err: %w", e.SQL(), err)
-		}
-		return convertToColumnsValues(gcv)
-	default:
-		return nil, nil, fmt.Errorf("unsupported expr as literals: %v", expr.SQL())
+	gcv, err := memebridge.MemefishExprToGCV(expr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("expression is not a supported literal, expr: %v, err: %w", expr.SQL(), err)
 	}
+	return convertToColumnsValues(gcv)
 }
 
 func parseLiteralString(s string) ([]string, [][]spanner.GenericColumnValue, error) {

--- a/internal/mycli/statements_mutations_test.go
+++ b/internal/mycli/statements_mutations_test.go
@@ -50,6 +50,10 @@ func TestParseMutation(t *testing.T) {
 			sliceOf(spanner.Delete("t", spanner.KeyRange{Start: spanner.Key{int64(1)}, End: spanner.Key{int64(10)}, Kind: spanner.ClosedClosed})),
 		},
 		{
+			"DELETE ClosedClosed with CAST", "DELETE", "t", "KEY_RANGE(start_closed=>CAST(1 AS INT64), end_closed=>CAST(10 AS INT64))",
+			sliceOf(spanner.Delete("t", spanner.KeyRange{Start: spanner.Key{int64(1)}, End: spanner.Key{int64(10)}, Kind: spanner.ClosedClosed})),
+		},
+		{
 			"DELETE ClosedOpen", "DELETE", "t", "KEY_RANGE(start_closed=>(1), end_open=>(10))",
 			sliceOf(spanner.Delete("t", spanner.KeyRange{Start: spanner.Key{int64(1)}, End: spanner.Key{int64(10)}, Kind: spanner.ClosedOpen})),
 		},
@@ -63,6 +67,10 @@ func TestParseMutation(t *testing.T) {
 		},
 		{
 			"INSERT typeless struct", "INSERT", "t", "STRUCT(1 AS n)",
+			sliceOf(spanner.Insert("t", []string{"n"}, []any{int64GCV})),
+		},
+		{
+			"INSERT typeless struct with CAST", "INSERT", "t", "STRUCT(CAST(1 AS INT64) AS n)",
 			sliceOf(spanner.Insert("t", []string{"n"}, []any{int64GCV})),
 		},
 		{

--- a/internal/mycli/statements_schema.go
+++ b/internal/mycli/statements_schema.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"cloud.google.com/go/spanner"
-	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
 	"github.com/apstndb/spanvalue"
@@ -58,7 +57,7 @@ type ShowTablesStatement struct {
 func (s *ShowTablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	alias := fmt.Sprintf("Tables_in_%s", session.systemVariables.Connection.Database)
 	stmt := spanner.Statement{
-		SQL:    fmt.Sprintf("SELECT t.TABLE_NAME AS %s FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_CATALOG = '' and t.TABLE_SCHEMA = @schema", spanvalue.QuoteIdentifier(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, alias)),
+		SQL:    fmt.Sprintf("SELECT t.TABLE_NAME AS %s FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_CATALOG = '' and t.TABLE_SCHEMA = @schema", spanvalue.QuoteIdentifier(session.systemVariables.Feature.DatabaseDialect, alias)),
 		Params: map[string]any{"schema": s.Schema},
 	}
 

--- a/internal/mycli/statements_schema.go
+++ b/internal/mycli/statements_schema.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 
 	"cloud.google.com/go/spanner"
+	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
+	"github.com/apstndb/spanvalue"
 	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/ngicks/go-iterator-helper/hiter/stringsiter"
 	"github.com/samber/lo"
@@ -56,7 +58,7 @@ type ShowTablesStatement struct {
 func (s *ShowTablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	alias := fmt.Sprintf("Tables_in_%s", session.systemVariables.Connection.Database)
 	stmt := spanner.Statement{
-		SQL:    fmt.Sprintf("SELECT t.TABLE_NAME AS `%s` FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_CATALOG = '' and t.TABLE_SCHEMA = @schema", alias),
+		SQL:    fmt.Sprintf("SELECT t.TABLE_NAME AS %s FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_CATALOG = '' and t.TABLE_SCHEMA = @schema", spanvalue.QuoteIdentifier(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, alias)),
 		Params: map[string]any{"schema": s.Schema},
 	}
 


### PR DESCRIPTION
## Summary
Upgrade to the released `spanvalue v0.3.0` and `memebridge v0.6.0` line, remove the temporary local `memebridge` replace, and adopt practical new library functionality in `spanner-mycli`.

## Key Changes
- **go.mod / go.sum**: Upgraded `github.com/apstndb/spanvalue` to `v0.3.0` and `github.com/apstndb/memebridge` to `v0.6.0`, then removed the temporary local `memebridge` replace.
- **internal/mycli/statements.go**: Switched `TRUNCATE TABLE` identifier rendering to `spanvalue`'s conservative quoting helpers.
- **internal/mycli/statements_dump.go**: Replaced manual SQL identifier quoting with `spanvalue.QuoteIdentifier` / `QuoteQualifiedIdentifier` for dump query generation.
- **internal/mycli/statements_schema.go**: Reused `spanvalue` quoting helpers for `SHOW TABLES` alias rendering.
- **internal/mycli/statements_mutations.go**: Removed the local AST-type restriction in `parseLiteralExpr()` and delegated literal evaluation to `memebridge.MemefishExprToGCV`, enabling newly supported `CAST(...)` literal handling.
- **internal/mycli/statements_mutations_test.go**: Added regression coverage for `CAST(...)` inside mutation and `KEY_RANGE(...)` paths.
- **internal/mycli/statements_dump_test.go**: Added coverage for the updated dump-query identifier quoting behavior.

## Development Insights

### Discoveries
- `memebridge v0.6.0`'s new CAST handling was immediately useful because `spanner-mycli` had been pre-filtering Memefish expressions more narrowly than `memebridge` itself required.
- `spanvalue`'s new quoting helpers were a low-risk adoption target, while the `writer` package still needs a larger SQL export pipeline refactor because the current formatter stage operates on pre-formatted `[]string` rows.

## Test Plan
- [x] `make check` passes
