### PR TITLE
Replace iterator helpers with samber/lo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/apstndb/genaischema v0.2.0
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe
 	github.com/apstndb/go-tabwrap v0.1.2
-	github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae
+	github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.4.0
@@ -33,14 +33,13 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/googleapis/go-spanner-cassandra v0.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
-	github.com/hymkor/go-multiline-ny v0.22.4
+	github.com/hymkor/go-multiline-ny v0.23.1
 	github.com/junegunn/fzf v0.68.0
 	github.com/k0kubun/pp/v3 v3.5.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.18.4
 	github.com/modelcontextprotocol/go-sdk v1.4.0
-	github.com/ngicks/go-iterator-helper v0.0.21
-	github.com/nyaosorg/go-readline-ny v1.14.1
+	github.com/nyaosorg/go-readline-ny v1.14.3
 	github.com/olekukonko/tablewriter v1.1.3
 	github.com/pelletier/go-toml v1.9.5
 	github.com/samber/lo v1.53.0
@@ -56,7 +55,6 @@ require (
 	google.golang.org/genai v1.47.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.11
-	spheric.cloud/xiter v0.0.0-20250113160306-a1a2c1108100
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2485,8 +2485,8 @@ github.com/apstndb/go-tabwrap v0.1.2 h1:75C3WtTcn4NBw7sM29zWpQzgrwH77lGKj0OC72OB
 github.com/apstndb/go-tabwrap v0.1.2/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
 github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba h1:l9MMbSfCb/JBF3wY3HuDM6cB5Y0AzGkXbmVzQ87J1vU=
 github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba/go.mod h1:adI+0n+0AY1J+qhb7UbW3HjsUD15JCQPIih7FHLcrI4=
-github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae h1:dM4EYL52u6aQh97R2agNDukCYhPs4aSDdkSZkvVvcf8=
-github.com/apstndb/gsqlutils v0.0.0-20250517013444-d2334c88d6ae/go.mod h1:xW+J2790w/YgZZf3y5ff+/iO+dQoJQDGPrNkSLKQ9xc=
+github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0 h1:VySrhGRfqXUDCrUuAEz70DrDnPrvj/nXGnUHwJF3PG4=
+github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0/go.mod h1:VwhJDip+HamDWWt+Ol4ECFU0g0HiveA27DeNkt3U8S0=
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82 h1:l54uIOgcH4r0lTg8xKRhehV71v8m4J+76zpjTGcRqsY=
 github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82/go.mod h1:PbqzTjsPq7Xhn8D7Vk8g/em15kd8vvEL1Y2xkI9CgGs=
 github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGvElI=
@@ -2876,8 +2876,8 @@ github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iP
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/hymkor/go-multiline-ny v0.22.4 h1:Ag2rkBpDnr3jp+AHe1CuXSOQ4AQ8D0+gBNVf+BAX+/0=
-github.com/hymkor/go-multiline-ny v0.22.4/go.mod h1:v2lqQooHVAO53WICAIbgTn74bQtzsg4tFn29d+7JPwY=
+github.com/hymkor/go-multiline-ny v0.23.1 h1:IULtIWsQHhGVxy7ferWNtRav9FZFX19K46GSdC2R2z4=
+github.com/hymkor/go-multiline-ny v0.23.1/go.mod h1:uwuSgo/xlV0UODTd88wNlllw+fjb+P8dlHvh7dlMqT4=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -2982,10 +2982,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/ngicks/go-iterator-helper v0.0.21 h1:34dorbGaeL7RgxdymHBqZeL+VLL3hUyAL9QdE5HZrRQ=
-github.com/ngicks/go-iterator-helper v0.0.21/go.mod h1:g++KxWVGEkOnIhXVvpNNOdn7ON57aOpfu80ccBvPVHI=
-github.com/nyaosorg/go-readline-ny v1.14.1 h1:bWyXpR6jRaCXysx4bnioxk36+YjQ6dypHKMjHnzIXdk=
-github.com/nyaosorg/go-readline-ny v1.14.1/go.mod h1:/BDf3/H/AScnvey4LoDws1bjTZDB76EE7uKnW2apoKU=
+github.com/nyaosorg/go-readline-ny v1.14.3 h1:HcmGfGgq6M7n7U6Cncd6KwghP84NCLeHzewJ4Hl0M6E=
+github.com/nyaosorg/go-readline-ny v1.14.3/go.mod h1:/BDf3/H/AScnvey4LoDws1bjTZDB76EE7uKnW2apoKU=
 github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=
 github.com/nyaosorg/go-ttyadapter v0.3.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
@@ -4393,5 +4391,3 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-spheric.cloud/xiter v0.0.0-20250113160306-a1a2c1108100 h1:zvxvrLygkh0bC7Ui3Vwa29g7v1FJ4utoIoWk5fOtSIc=
-spheric.cloud/xiter v0.0.0-20250113160306-a1a2c1108100/go.mod h1:i4SlkNfFrn1974zbGZWg8FYXAWLnrS6cYAXtSfmIDhU=

--- a/internal/mycli/cli_readline.go
+++ b/internal/mycli/cli_readline.go
@@ -19,11 +19,11 @@ import (
 	"github.com/cloudspannerecosystem/memefish/token"
 	"github.com/fatih/color"
 	"github.com/hymkor/go-multiline-ny"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/nyaosorg/go-readline-ny"
 	"github.com/nyaosorg/go-readline-ny/keys"
 	"github.com/nyaosorg/go-readline-ny/simplehistory"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 	"github.com/spf13/afero"
 )
 
@@ -241,9 +241,9 @@ const (
 
 func commentHighlighter() highlighterFunc {
 	return lexerHighlighterWithError(func(tok token.Token) [][]int {
-		return slices.Collect(hiter.Map(func(comment token.TokenComment) []int {
+		return slices.Collect(loi.Map(slices.Values(tok.Comments), func(comment token.TokenComment) []int {
 			return sliceOf(int(comment.Pos), int(comment.End))
-		}, slices.Values(tok.Comments)))
+		}))
 	}, func(me *memefish.Error) bool {
 		return me.Message == errMessageUnclosedComment
 	})

--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -14,10 +14,8 @@ import (
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/cloudspannerecosystem/memefish/token"
-	"github.com/ngicks/go-iterator-helper/hiter"
-	"github.com/ngicks/go-iterator-helper/hiter/stringsiter"
 	"github.com/samber/lo"
-	scxiter "spheric.cloud/xiter"
+	loi "github.com/samber/lo/it"
 )
 
 // clientSideStatementDescription is a human-readable part of clientSideStatementDef.
@@ -126,9 +124,7 @@ func namedGroups(re *regexp.Regexp, match []string) map[string]string {
 	return groups
 }
 
-var schemaObjectsReStr = stringsiter.Join("|", hiter.Map(func(s string) string {
-	return strings.ReplaceAll(s, " ", `\s+`)
-}, slices.Values([]string{
+var schemaObjectsReStr = strings.Join(slices.Collect(loi.Map(slices.Values([]string{
 	"SCHEMA",
 	"DATABASE",
 	"PLACEMENT",
@@ -143,7 +139,9 @@ var schemaObjectsReStr = stringsiter.Join("|", hiter.Map(func(s string) string {
 	"MODEL",
 	"VECTOR INDEX",
 	"PROPERTY GRAPH",
-})))
+}), func(s string) string {
+	return strings.ReplaceAll(s, " ", `\s+`)
+})), "|")
 
 var whitespaceRe = regexp.MustCompile(`\s+`)
 
@@ -1182,14 +1180,9 @@ func parsePaths(p *memefish.Parser) ([]string, error) {
 		}
 		return sliceOf(name), nil
 	case *ast.TupleStructLiteral:
-		names, err := scxiter.TryCollect(scxiter.MapErr(
-			slices.Values(e.Values),
-			exprToFullName))
-		if err != nil {
-			return nil, err
-		}
-
-		return names, err
+		return lo.MapErr(e.Values, func(expr ast.Expr, _ int) (string, error) {
+			return exprToFullName(expr)
+		})
 	default:
 		return nil, fmt.Errorf("must be paren expr or tuple of path, but: %T", expr)
 	}
@@ -1200,7 +1193,7 @@ func exprToFullName(expr ast.Expr) (string, error) {
 	case *ast.Ident:
 		return e.Name, nil
 	case *ast.Path:
-		return scxiter.Join(hiter.Map(func(ident *ast.Ident) string { return ident.Name }, slices.Values(e.Idents)), "."), nil
+		return strings.Join(slices.Collect(loi.Map(slices.Values(e.Idents), func(ident *ast.Ident) string { return ident.Name })), "."), nil
 	default:
 		return "", fmt.Errorf("must be ident or path, but: %T", expr)
 	}

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -37,7 +36,6 @@ import (
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/samber/lo"
 	"golang.org/x/term"
-	"spheric.cloud/xiter"
 
 	"github.com/apstndb/spanner-mycli/enums"
 )
@@ -525,7 +523,9 @@ func applyDirectedRead(sysVars *systemVariables, opts *spannerOptions) error {
 func applyFormatAndSetOptions(sysVars *systemVariables, opts *spannerOptions) error {
 	// Set CLI_FORMAT defaults based on flags before processing --set
 	// This allows --set CLI_FORMAT=X to override these defaults
-	sets := maps.Collect(xiter.MapKeys(maps.All(opts.Set), strings.ToUpper))
+	sets := lo.MapKeys(opts.Set, func(_ string, key string) string {
+		return strings.ToUpper(key)
+	})
 	if _, ok := sets["CLI_FORMAT"]; !ok {
 		formatMode := getFormatFromOptions(opts)
 		if formatMode != enums.DisplayModeUnspecified {

--- a/internal/mycli/doc_embed.go
+++ b/internal/mycli/doc_embed.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	spannerdocs "github.com/apstndb/spanner-docs-embed"
+	"github.com/samber/lo"
 )
 
 // docInfo describes a known Spanner reference document.
@@ -130,10 +131,9 @@ func loadEmbeddedDocs(cache *docCache) error {
 // formatDocCatalog formats the document catalog for the LLM system prompt.
 // It groups documents by category, marks cached ones, and includes descriptions.
 func formatDocCatalog(cache *docCache) string {
-	cachedNames := make(map[string]bool)
-	for _, name := range cache.Names() {
-		cachedNames[name] = true
-	}
+	cachedNames := lo.Associate(cache.Names(), func(name string) (string, bool) {
+		return name, true
+	})
 
 	var b strings.Builder
 

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -11,8 +11,8 @@ import (
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/go-tabwrap"
 	"github.com/apstndb/lox"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 	"google.golang.org/protobuf/proto"
@@ -147,13 +147,13 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	result := &Result{CommitTimestamp: lastCommitTS}
 	if session.systemVariables.Feature.EchoExecutedDDL {
 		result.TableHeader = toTableHeader("Executed", "Commit Timestamp")
-		result.Rows = slices.Collect(hiter.Unify(
+		result.Rows = slices.Collect(loi.ZipBy2(
+			slices.Values(ddls),
+			slices.Values(metadata.GetCommitTimestamps()),
 			func(ddl string, v *timestamppb.Timestamp) Row {
 				return toRow(ddl+";", v.AsTime().Format(time.RFC3339Nano))
 			},
-			hiter.Pairs(slices.Values(ddls), slices.Values(metadata.GetCommitTimestamps())),
-		),
-		)
+		))
 	}
 
 	return result, nil

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -11,11 +11,12 @@ import (
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/go-tabwrap"
 	"github.com/apstndb/lox"
+	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/samber/lo"
-	loi "github.com/samber/lo/it"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
 )
@@ -146,15 +147,10 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	result := &Result{CommitTimestamp: lastCommitTS}
 	if session.systemVariables.Feature.EchoExecutedDDL {
 		result.TableHeader = toTableHeader("Executed", "Commit Timestamp")
-		commitTimestamps := metadata.GetCommitTimestamps()
-		// Keep the previous "shorter input wins" behavior from hiter.Pairs.
-		// loi.ZipBy2 pads missing values with zero values instead of stopping early.
-		result.Rows = slices.Collect(loi.FilterMapI(slices.Values(ddls), func(ddl string, i int) (Row, bool) {
-			if i >= len(commitTimestamps) {
-				return nil, false
-			}
-			return toRow(ddl+";", commitTimestamps[i].AsTime().Format(time.RFC3339Nano)), true
-		}))
+		result.Rows = slices.Collect(iterutil.ZipShortestBy(slices.Values(ddls), slices.Values(metadata.GetCommitTimestamps()),
+			func(ddl string, commitTimestamp *timestamppb.Timestamp) Row {
+				return toRow(ddl+";", commitTimestamp.AsTime().Format(time.RFC3339Nano))
+			}))
 	}
 
 	return result, nil

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -16,7 +16,6 @@ import (
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
 )
@@ -147,13 +146,15 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	result := &Result{CommitTimestamp: lastCommitTS}
 	if session.systemVariables.Feature.EchoExecutedDDL {
 		result.TableHeader = toTableHeader("Executed", "Commit Timestamp")
-		result.Rows = slices.Collect(loi.ZipBy2(
-			slices.Values(ddls),
-			slices.Values(metadata.GetCommitTimestamps()),
-			func(ddl string, v *timestamppb.Timestamp) Row {
-				return toRow(ddl+";", v.AsTime().Format(time.RFC3339Nano))
-			},
-		))
+		commitTimestamps := metadata.GetCommitTimestamps()
+		// Keep the previous "shorter input wins" behavior from hiter.Pairs.
+		// loi.ZipBy2 pads missing values with zero values instead of stopping early.
+		result.Rows = slices.Collect(loi.FilterMapI(slices.Values(ddls), func(ddl string, i int) (Row, bool) {
+			if i >= len(commitTimestamps) {
+				return nil, false
+			}
+			return toRow(ddl+";", commitTimestamps[i].AsTime().Format(time.RFC3339Nano)), true
+		}))
 	}
 
 	return result, nil

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -10,8 +10,8 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/gsqlutils"
 	"github.com/apstndb/spanner-mycli/enums"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 )
 
 func isInsert(sql string) bool {
@@ -72,11 +72,13 @@ func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.State
 		IsExecutedDML:   true, // This is a batch DML statement
 		CommitTimestamp: result.CommitResponse.CommitTs,
 		CommitStats:     result.CommitResponse.CommitStats,
-		Rows: slices.Collect(hiter.Unify(
+		Rows: slices.Collect(loi.ZipBy2(
+			slices.Values(dmls),
+			slices.Values(affectedRowSlice),
 			func(s spanner.Statement, n int64) Row {
 				return toRow(s.SQL, strconv.FormatInt(n, 10))
 			},
-			hiter.Pairs(slices.Values(dmls), slices.Values(affectedRowSlice)))),
+		)),
 		TableHeader:      toTableHeader("DML", "Rows"),
 		AffectedRows:     int(result.Affected),
 		AffectedRowsType: lo.Ternary(len(dmls) > 1, rowCountTypeUpperBound, rowCountTypeExact),

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -10,8 +10,8 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/gsqlutils"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/samber/lo"
-	loi "github.com/samber/lo/it"
 )
 
 func isInsert(sql string) bool {
@@ -72,13 +72,8 @@ func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.State
 		IsExecutedDML:   true, // This is a batch DML statement
 		CommitTimestamp: result.CommitResponse.CommitTs,
 		CommitStats:     result.CommitResponse.CommitStats,
-		// Keep the previous "shorter input wins" behavior from hiter.Pairs.
-		// loi.ZipBy2 pads missing values with zero values instead of stopping early.
-		Rows: slices.Collect(loi.FilterMapI(slices.Values(dmls), func(s spanner.Statement, i int) (Row, bool) {
-			if i >= len(affectedRowSlice) {
-				return nil, false
-			}
-			return toRow(s.SQL, strconv.FormatInt(affectedRowSlice[i], 10)), true
+		Rows: slices.Collect(iterutil.ZipShortestBy(slices.Values(dmls), slices.Values(affectedRowSlice), func(s spanner.Statement, affectedRows int64) Row {
+			return toRow(s.SQL, strconv.FormatInt(affectedRows, 10))
 		})),
 		TableHeader:      toTableHeader("DML", "Rows"),
 		AffectedRows:     int(result.Affected),

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -72,13 +72,14 @@ func executeBatchDML(ctx context.Context, session *Session, dmls []spanner.State
 		IsExecutedDML:   true, // This is a batch DML statement
 		CommitTimestamp: result.CommitResponse.CommitTs,
 		CommitStats:     result.CommitResponse.CommitStats,
-		Rows: slices.Collect(loi.ZipBy2(
-			slices.Values(dmls),
-			slices.Values(affectedRowSlice),
-			func(s spanner.Statement, n int64) Row {
-				return toRow(s.SQL, strconv.FormatInt(n, 10))
-			},
-		)),
+		// Keep the previous "shorter input wins" behavior from hiter.Pairs.
+		// loi.ZipBy2 pads missing values with zero values instead of stopping early.
+		Rows: slices.Collect(loi.FilterMapI(slices.Values(dmls), func(s spanner.Statement, i int) (Row, bool) {
+			if i >= len(affectedRowSlice) {
+				return nil, false
+			}
+			return toRow(s.SQL, strconv.FormatInt(affectedRowSlice[i], 10)), true
+		})),
 		TableHeader:      toTableHeader("DML", "Rows"),
 		AffectedRows:     int(result.Affected),
 		AffectedRowsType: lo.Ternary(len(dmls) > 1, rowCountTypeUpperBound, rowCountTypeExact),

--- a/internal/mycli/format/format.go
+++ b/internal/mycli/format/format.go
@@ -10,8 +10,8 @@ import (
 	"slices"
 
 	"github.com/apstndb/go-tabwrap"
+	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/olekukonko/tablewriter/tw"
-	loi "github.com/samber/lo/it"
 )
 
 // formatTable formats output as an ASCII table.
@@ -111,13 +111,8 @@ func wrapRowPreserving(row Row, widths []int, rw *tabwrap.Condition) Row {
 	if len(widths) == 0 {
 		return row
 	}
-	// Keep the previous "shorter input wins" behavior from hiter.Pairs.
-	// loi.ZipBy2 pads missing values with zero values instead of stopping early.
-	wrappedTexts := slices.Collect(loi.FilterMapI(slices.Values(Texts(row)), func(text string, i int) (string, bool) {
-		if i >= len(widths) {
-			return "", false
-		}
-		return rw.Wrap(text, widths[i]), true
+	wrappedTexts := slices.Collect(iterutil.ZipShortestBy(slices.Values(Texts(row)), slices.Values(widths), func(text string, width int) string {
+		return rw.Wrap(text, width)
 	}))
 	result := make(Row, len(wrappedTexts))
 	for i, text := range wrappedTexts {

--- a/internal/mycli/format/format.go
+++ b/internal/mycli/format/format.go
@@ -10,8 +10,8 @@ import (
 	"slices"
 
 	"github.com/apstndb/go-tabwrap"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/olekukonko/tablewriter/tw"
+	loi "github.com/samber/lo/it"
 )
 
 // formatTable formats output as an ASCII table.
@@ -111,9 +111,12 @@ func wrapRowPreserving(row Row, widths []int, rw *tabwrap.Condition) Row {
 	if len(widths) == 0 {
 		return row
 	}
-	wrappedTexts := slices.Collect(hiter.Unify(
-		rw.Wrap,
-		hiter.Pairs(slices.Values(Texts(row)), slices.Values(widths))))
+	wrappedTexts := slices.Collect(loi.FilterMapI(slices.Values(Texts(row)), func(text string, i int) (string, bool) {
+		if i >= len(widths) {
+			return "", false
+		}
+		return rw.Wrap(text, widths[i]), true
+	}))
 	result := make(Row, len(wrappedTexts))
 	for i, text := range wrappedTexts {
 		if i < len(row) {

--- a/internal/mycli/format/format.go
+++ b/internal/mycli/format/format.go
@@ -111,6 +111,8 @@ func wrapRowPreserving(row Row, widths []int, rw *tabwrap.Condition) Row {
 	if len(widths) == 0 {
 		return row
 	}
+	// Keep the previous "shorter input wins" behavior from hiter.Pairs.
+	// loi.ZipBy2 pads missing values with zero values instead of stopping early.
 	wrappedTexts := slices.Collect(loi.FilterMapI(slices.Values(Texts(row)), func(text string, i int) (string, bool) {
 		if i >= len(widths) {
 			return "", false

--- a/internal/mycli/format/streaming_table.go
+++ b/internal/mycli/format/streaming_table.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/apstndb/go-tabwrap"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
+	loi "github.com/samber/lo/it"
 )
 
 var (
@@ -249,9 +249,12 @@ func (f *TableStreamingFormatter) wrapHeaders(headers []string) []string {
 	}
 
 	rw := f.newCondition()
-	return slices.Collect(hiter.Unify(
-		rw.Wrap,
-		hiter.Pairs(slices.Values(headers), slices.Values(f.widths))))
+	return slices.Collect(loi.FilterMapI(slices.Values(headers), func(header string, i int) (string, bool) {
+		if i >= len(f.widths) {
+			return "", false
+		}
+		return rw.Wrap(header, f.widths[i]), true
+	}))
 }
 
 // wrapRow wraps row columns according to calculated widths, preserving cell metadata.

--- a/internal/mycli/format/streaming_table.go
+++ b/internal/mycli/format/streaming_table.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/apstndb/go-tabwrap"
+	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
-	loi "github.com/samber/lo/it"
 )
 
 var (
@@ -249,13 +249,8 @@ func (f *TableStreamingFormatter) wrapHeaders(headers []string) []string {
 	}
 
 	rw := f.newCondition()
-	// Keep the previous "shorter input wins" behavior from hiter.Pairs.
-	// loi.ZipBy2 pads missing values with zero values instead of stopping early.
-	return slices.Collect(loi.FilterMapI(slices.Values(headers), func(header string, i int) (string, bool) {
-		if i >= len(f.widths) {
-			return "", false
-		}
-		return rw.Wrap(header, f.widths[i]), true
+	return slices.Collect(iterutil.ZipShortestBy(slices.Values(headers), slices.Values(f.widths), func(header string, width int) string {
+		return rw.Wrap(header, width)
 	}))
 }
 

--- a/internal/mycli/format/streaming_table.go
+++ b/internal/mycli/format/streaming_table.go
@@ -249,6 +249,8 @@ func (f *TableStreamingFormatter) wrapHeaders(headers []string) []string {
 	}
 
 	rw := f.newCondition()
+	// Keep the previous "shorter input wins" behavior from hiter.Pairs.
+	// loi.ZipBy2 pads missing values with zero values instead of stopping early.
 	return slices.Collect(loi.FilterMapI(slices.Values(headers), func(header string, i int) (string, bool) {
 		if i >= len(f.widths) {
 			return "", false

--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -11,9 +11,8 @@ import (
 	"github.com/apstndb/go-tabwrap"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spanner-mycli/enums"
-	"github.com/ngicks/go-iterator-helper/hiter"
-	"github.com/ngicks/go-iterator-helper/hiter/stringsiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 )
 
 // minColumnWidth is the hard minimum width for any column.
@@ -112,9 +111,7 @@ func (wc *widthCalculator) StringWidth(s string) int {
 }
 
 func (wc *widthCalculator) maxWidth(s string) int {
-	return hiter.Max(hiter.Map(
-		wc.StringWidth,
-		stringsiter.SplitFunc(s, 0, stringsiter.CutNewLine)))
+	return loi.Max(loi.Map(splitLines(s), wc.StringWidth))
 }
 
 func asc[T cmp.Ordered](left, right T) int {
@@ -204,22 +201,24 @@ func (wc *widthCalculator) maxIndex(ignoreMax int, adjustWidths []int, seq iter.
 	return MaxByWithIdx(
 		invalidWidthCount,
 		WidthCount.Count,
-		hiter.Unify(
-			func(adjustWidth int, wc WidthCount) WidthCount {
-				return lo.Ternary(wc.Length()-adjustWidth <= ignoreMax, wc, invalidWidthCount)
-			},
-			hiter.Pairs(slices.Values(adjustWidths), seq)))
+		loi.FilterMapI(seq, func(wc WidthCount, i int) (WidthCount, bool) {
+			if i >= len(adjustWidths) {
+				return invalidWidthCount, false
+			}
+			return lo.Ternary(wc.Length()-adjustWidths[i] <= ignoreMax, wc, invalidWidthCount), true
+		}))
 }
 
 func (wc *widthCalculator) countWidth(ss []string) iter.Seq[WidthCount] {
-	return hiter.Map(
+	return loi.Map(
+		slices.Values(lox.EntriesSortedByKey(lo.CountValuesBy(ss, wc.maxWidth))),
 		func(e lo.Entry[int, int]) WidthCount {
 			return WidthCount{
 				width: e.Key,
 				count: e.Value,
 			}
 		},
-		slices.Values(lox.EntriesSortedByKey(lo.CountValuesBy(ss, wc.maxWidth))))
+	)
 }
 
 func (wc *widthCalculator) calculateWidthCounts(currentWidths []int, rows [][]string) [][]WidthCount {
@@ -228,11 +227,11 @@ func (wc *widthCalculator) calculateWidthCounts(currentWidths []int, rows [][]st
 		currentWidth := currentWidths[columnNo]
 		columnValues := rows[columnNo]
 		largerWidthCounts := slices.Collect(
-			hiter.Filter(
+			loi.Filter(
+				wc.countWidth(columnValues),
 				func(v WidthCount) bool {
 					return v.Length() > currentWidth
 				},
-				wc.countWidth(columnValues),
 			))
 		result = append(result, largerWidthCounts)
 	}
@@ -249,7 +248,7 @@ func (wc WidthCount) Length() int { return wc.width }
 func (wc WidthCount) Count() int { return wc.count }
 
 func adjustByHeader(headers []string, availableWidth int) []int {
-	nameWidths := slices.Collect(hiter.Map(tabwrap.StringWidth, slices.Values(headers)))
+	nameWidths := slices.Collect(loi.Map(slices.Values(headers), tabwrap.StringWidth))
 
 	adjustWidths, _ := adjustToSum(availableWidth, nameWidths)
 

--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -201,6 +201,8 @@ func (wc *widthCalculator) maxIndex(ignoreMax int, adjustWidths []int, seq iter.
 	return MaxByWithIdx(
 		invalidWidthCount,
 		WidthCount.Count,
+		// Keep the previous "shorter input wins" behavior from hiter.Pairs.
+		// loi.ZipBy2 pads missing values with zero values instead of stopping early.
 		loi.FilterMapI(seq, func(wc WidthCount, i int) (WidthCount, bool) {
 			if i >= len(adjustWidths) {
 				return invalidWidthCount, false

--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -111,6 +111,7 @@ func (wc *widthCalculator) StringWidth(s string) int {
 }
 
 func (wc *widthCalculator) maxWidth(s string) int {
+	// splitLines is the package-local newline iterator defined at the bottom of this file.
 	return loi.Max(loi.Map(splitLines(s), wc.StringWidth))
 }
 

--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apstndb/go-tabwrap"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/samber/lo"
 	loi "github.com/samber/lo/it"
 )
@@ -202,13 +203,8 @@ func (wc *widthCalculator) maxIndex(ignoreMax int, adjustWidths []int, seq iter.
 	return MaxByWithIdx(
 		invalidWidthCount,
 		WidthCount.Count,
-		// Keep the previous "shorter input wins" behavior from hiter.Pairs.
-		// loi.ZipBy2 pads missing values with zero values instead of stopping early.
-		loi.FilterMapI(seq, func(wc WidthCount, i int) (WidthCount, bool) {
-			if i >= len(adjustWidths) {
-				return invalidWidthCount, false
-			}
-			return lo.Ternary(wc.Length()-adjustWidths[i] <= ignoreMax, wc, invalidWidthCount), true
+		iterutil.ZipShortestBy(seq, slices.Values(adjustWidths), func(wc WidthCount, adjustWidth int) WidthCount {
+			return lo.Ternary(wc.Length()-adjustWidth <= ignoreMax, wc, invalidWidthCount)
 		}))
 }
 

--- a/internal/mycli/format/width_strategy_greedy.go
+++ b/internal/mycli/format/width_strategy_greedy.go
@@ -19,8 +19,8 @@ import (
 	"log/slog"
 	"slices"
 
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 )
 
 // GreedyFrequencyStrategy implements the original frequency-based greedy expansion
@@ -69,11 +69,12 @@ func (GreedyFrequencyStrategy) CalculateWidths(wc *widthCalculator, availableWid
 	for {
 		slog.Debug("widthCounts", "counts", widthCounts)
 
-		firstCounts := hiter.Map(
+		firstCounts := loi.Map(
+			slices.Values(widthCounts),
 			func(wcs []WidthCount) WidthCount {
 				return lo.FirstOr(wcs, invalidWidthCount)
 			},
-			slices.Values(widthCounts))
+		)
 
 		// find the largest count idx within available width
 		idx, target := wc.maxIndex(availableWidth-sumWidths(adjustedWidths), adjustedWidths, firstCounts)

--- a/internal/mycli/iterutil/iterutil.go
+++ b/internal/mycli/iterutil/iterutil.go
@@ -1,0 +1,45 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterutil
+
+import "iter"
+
+// ZipShortestBy pairs values from two sequences and stops when either sequence ends.
+//
+// This keeps the shorter-input semantics of go-iterator-helper's hiter.Pairs.
+// It intentionally differs from samber/lo/it.ZipBy2, which pads missing values
+// with zero values when the sequences have different lengths.
+func ZipShortestBy[A, B, R any](as iter.Seq[A], bs iter.Seq[B], f func(A, B) R) iter.Seq[R] {
+	return func(yield func(R) bool) {
+		nextA, stopA := iter.Pull(as)
+		defer stopA()
+		nextB, stopB := iter.Pull(bs)
+		defer stopB()
+
+		for {
+			a, ok := nextA()
+			if !ok {
+				return
+			}
+			b, ok := nextB()
+			if !ok {
+				return
+			}
+			if !yield(f(a, b)) {
+				return
+			}
+		}
+	}
+}

--- a/internal/mycli/iterutil/iterutil_test.go
+++ b/internal/mycli/iterutil/iterutil_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterutil
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+)
+
+func TestZipShortestBy(t *testing.T) {
+	t.Parallel()
+
+	got := slices.Collect(ZipShortestBy(
+		slices.Values([]string{"a", "b", "c"}),
+		slices.Values([]int{1, 2}),
+		func(s string, n int) string {
+			return s + strconv.Itoa(n)
+		},
+	))
+
+	want := []string{"a1", "b2"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ZipShortestBy() = %v, want %v", got, want)
+	}
+}
+
+func TestZipShortestByStopsWhenFirstSequenceIsShorter(t *testing.T) {
+	t.Parallel()
+
+	got := slices.Collect(ZipShortestBy(
+		slices.Values([]string{"a"}),
+		slices.Values([]int{1, 2}),
+		func(s string, n int) string {
+			return s + strconv.Itoa(n)
+		},
+	))
+
+	want := []string{"a1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ZipShortestBy() = %v, want %v", got, want)
+	}
+}

--- a/internal/mycli/lint_plan.go
+++ b/internal/mycli/lint_plan.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ngicks/go-iterator-helper/hiter"
+	loi "github.com/samber/lo/it"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spannerplan"
@@ -126,7 +126,8 @@ func lintPlan(plan *sppb.QueryPlan) []string {
 }
 
 func formatKeyElemForLinkType(qp *spannerplan.QueryPlan, variableToExp map[string]*sppb.PlanNode, node *sppb.PlanNode, linkType string) []string {
-	return slices.Collect(hiter.Map(
+	return slices.Collect(loi.Map(
+		loi.Filter(slices.Values(node.GetChildLinks()), LinkTypePred(linkType)),
 		formatKeyElem(qp, variableToExp),
-		hiter.Filter(LinkTypePred(linkType), slices.Values(node.GetChildLinks()))))
+	))
 }

--- a/internal/mycli/row_iter.go
+++ b/internal/mycli/row_iter.go
@@ -10,13 +10,13 @@ import (
 	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
 	"github.com/apstndb/spanvalue"
 	"github.com/go-json-experiment/json"
-	"github.com/ngicks/go-iterator-helper/hiter"
+	loi "github.com/samber/lo/it"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // extractColumnNames extract column names from ResultSetMetadata.RowType.Fields.
 func extractColumnNames(fields []*sppb.StructType_Field) []string {
-	return slices.Collect(hiter.Map((*sppb.StructType_Field).GetName, slices.Values(fields)))
+	return slices.Collect(loi.Map(slices.Values(fields), (*sppb.StructType_Field).GetName))
 }
 
 // parseQueryStats parses spanner.RowIterator.QueryStats.

--- a/internal/mycli/separator.go
+++ b/internal/mycli/separator.go
@@ -22,7 +22,7 @@ import (
 	"github.com/apstndb/gsqlutils"
 
 	"github.com/samber/lo"
-	"spheric.cloud/xiter"
+	loi "github.com/samber/lo/it"
 )
 
 const (
@@ -38,7 +38,7 @@ type inputStatement struct {
 
 func separateInput(input string) ([]inputStatement, error) {
 	stmts, err := gsqlutils.SeparateInputPreserveCommentsWithStatus("", input)
-	return slices.Collect(xiter.Map(slices.Values(stmts), convertStatement)), err
+	return slices.Collect(loi.Map(slices.Values(stmts), convertStatement)), err
 }
 
 func convertStatement(stmt gsqlutils.RawStatement) inputStatement {

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -33,9 +33,9 @@ import (
 	"github.com/apstndb/spannerplan/protoyaml"
 	spstats "github.com/apstndb/spannerplan/stats"
 	"github.com/goccy/go-yaml"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/olekukonko/tablewriter/tw"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -368,8 +368,8 @@ func explainAnalyzeHeader(def []columnRenderDef, width int64) ([]string, []tw.Al
 	baseAlign := explainColumnAlign
 
 	// Extract the names and alignments from the custom column definitions.
-	customNames := slices.Collect(hiter.Map(func(d columnRenderDef) string { return d.Name }, slices.Values(def)))
-	customAligns := slices.Collect(hiter.Map(func(d columnRenderDef) tw.Align { return d.Alignment }, slices.Values(def)))
+	customNames := slices.Collect(loi.Map(slices.Values(def), func(d columnRenderDef) string { return d.Name }))
+	customAligns := slices.Collect(loi.Map(slices.Values(def), func(d columnRenderDef) tw.Align { return d.Alignment }))
 
 	// Concatenate the base and custom parts.
 	columnNames := slices.Concat(baseNames, customNames)

--- a/internal/mycli/statements_llm_tooluse.go
+++ b/internal/mycli/statements_llm_tooluse.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/samber/lo"
 	"golang.org/x/time/rate"
 	"google.golang.org/genai"
 )
@@ -162,11 +163,9 @@ func argsToStringSlice(args map[string]any, key string) []string {
 
 // searchResultsToItems converts DocSearchResults to the map format expected by the LLM.
 func searchResultsToItems(results []DocSearchResult) []map[string]any {
-	items := make([]map[string]any, len(results))
-	for i, r := range results {
-		items[i] = map[string]any{"name": r.Name, "snippet": r.Snippet}
-	}
-	return items
+	return lo.Map(results, func(r DocSearchResult, _ int) map[string]any {
+		return map[string]any{"name": r.Name, "snippet": r.Snippet}
+	})
 }
 
 // batchGetToResponse performs a BatchGet and formats the results as a tool response,
@@ -174,10 +173,9 @@ func searchResultsToItems(results []DocSearchResult) []map[string]any {
 func batchGetToResponse(ctx context.Context, cache *docCache, names []string, errMsg string) map[string]any {
 	docs := cache.BatchGet(ctx, names)
 
-	fetched := make(map[string]string, len(docs))
-	for _, doc := range docs {
-		fetched[doc.Name] = doc.Content
-	}
+	fetched := lo.Associate(docs, func(doc DocResult) (string, string) {
+		return doc.Name, doc.Content
+	})
 
 	documents := make(map[string]any, len(names))
 	for _, name := range names {

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -263,6 +263,8 @@ func parseLiteralString(s string) ([]string, [][]spanner.GenericColumnValue, err
 }
 
 func extractStructValues(structTypefields []*sppb.StructType_Field, structValues []*structpb.Value) []spanner.GenericColumnValue {
+	// Keep the previous "shorter input wins" behavior from hiter.Pairs.
+	// loi.ZipBy2 pads missing values with zero values instead of stopping early.
 	return slices.Collect(loi.FilterMapI(slices.Values(structTypefields), func(field *sppb.StructType_Field, i int) (spanner.GenericColumnValue, bool) {
 		if i >= len(structValues) {
 			return spanner.GenericColumnValue{}, false

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -200,9 +200,13 @@ func parseDeleteMutation(table, s string) ([]*spanner.Mutation, error) {
 }
 
 func toKeys(values []spanner.GenericColumnValue) (spanner.Key, error) {
-	return lo.MapErr(values, func(value spanner.GenericColumnValue, _ int) (any, error) {
+	key, err := lo.MapErr(values, func(value spanner.GenericColumnValue, _ int) (any, error) {
 		return gcvToKeyable(value)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return spanner.Key(key), nil
 }
 
 func typeValueToGCV(k *sppb.StructType_Field, v *structpb.Value) spanner.GenericColumnValue {

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -98,12 +98,9 @@ func parseCallExpr(e *ast.CallExpr) (spanner.KeyRange, error) {
 	if len(e.Args) > 0 {
 		return spanner.KeyRange{}, fmt.Errorf("unknown args: %v", e.SQL())
 	}
-	namedArgMap := loi.Associate(
-		slices.Values(e.NamedArgs),
-		func(u *ast.NamedArg) (string, ast.Expr) {
-			return strings.ToLower(u.Name.Name), u.Value
-		},
-	)
+	namedArgMap := lo.Associate(e.NamedArgs, func(u *ast.NamedArg) (string, ast.Expr) {
+		return strings.ToLower(u.Name.Name), u.Value
+	})
 	startClosed, hasStartClosed := namedArgMap["start_closed"]
 	startOpen, hasStartOpen := namedArgMap["start_open"]
 	endClosed, hasEndClosed := namedArgMap["end_closed"]

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -17,8 +16,8 @@ import (
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/cloudspannerecosystem/memefish/char"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -98,11 +97,12 @@ func parseCallExpr(e *ast.CallExpr) (spanner.KeyRange, error) {
 	if len(e.Args) > 0 {
 		return spanner.KeyRange{}, fmt.Errorf("unknown args: %v", e.SQL())
 	}
-	namedArgMap := maps.Collect(hiter.Divide(
+	namedArgMap := loi.Associate(
+		slices.Values(e.NamedArgs),
 		func(u *ast.NamedArg) (string, ast.Expr) {
 			return strings.ToLower(u.Name.Name), u.Value
 		},
-		slices.Values(e.NamedArgs)))
+	)
 	startClosed, hasStartClosed := namedArgMap["start_closed"]
 	startOpen, hasStartOpen := namedArgMap["start_open"]
 	endClosed, hasEndClosed := namedArgMap["end_closed"]
@@ -185,13 +185,11 @@ func parseDeleteMutation(table, s string) ([]*spanner.Mutation, error) {
 			slog.Warn("delete mutation ignores column names", "columns", columns)
 		}
 
-		var keys []spanner.Key
-		for _, values := range valuesList {
-			key, err := toKeys(values)
-			if err != nil {
-				return nil, err
-			}
-			keys = append(keys, key)
+		keys, err := lo.MapErr(valuesList, func(values []spanner.GenericColumnValue, _ int) (spanner.Key, error) {
+			return toKeys(values)
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		if len(keys) == 1 {
@@ -202,15 +200,9 @@ func parseDeleteMutation(table, s string) ([]*spanner.Mutation, error) {
 }
 
 func toKeys(values []spanner.GenericColumnValue) (spanner.Key, error) {
-	var key []any
-	for _, value := range values {
-		keyElem, err := gcvToKeyable(value)
-		if err != nil {
-			return nil, err
-		}
-		key = append(key, keyElem)
-	}
-	return key, nil
+	return lo.MapErr(values, func(value spanner.GenericColumnValue, _ int) (any, error) {
+		return gcvToKeyable(value)
+	})
 }
 
 func typeValueToGCV(k *sppb.StructType_Field, v *structpb.Value) spanner.GenericColumnValue {
@@ -237,16 +229,16 @@ func convertToColumnsValues(gcv spanner.GenericColumnValue) ([]string, [][]spann
 			nil
 	case sppb.TypeCode_ARRAY:
 		if gcv.Type.GetArrayElementType().GetCode() != sppb.TypeCode_STRUCT {
-			return nil, slices.Collect(hiter.Map(func(v *structpb.Value) []spanner.GenericColumnValue {
+			return nil, slices.Collect(loi.Map(slices.Values(gcv.Value.GetListValue().GetValues()), func(v *structpb.Value) []spanner.GenericColumnValue {
 				return sliceOf(spanner.GenericColumnValue{
 					Type:  gcv.Type.GetArrayElementType(),
 					Value: v,
 				})
-			}, slices.Values(gcv.Value.GetListValue().GetValues()))), nil
+			})), nil
 		}
 		structTypeFields := gcv.Type.GetArrayElementType().GetStructType().GetFields()
 		return extractColumnNames(structTypeFields),
-			slices.Collect(hiter.Map(extractStructValuesUsingType(structTypeFields), slices.Values(gcv.Value.GetListValue().GetValues()))),
+			slices.Collect(loi.Map(slices.Values(gcv.Value.GetListValue().GetValues()), extractStructValuesUsingType(structTypeFields))),
 			nil
 	default:
 		// [[value]]
@@ -271,9 +263,12 @@ func parseLiteralString(s string) ([]string, [][]spanner.GenericColumnValue, err
 }
 
 func extractStructValues(structTypefields []*sppb.StructType_Field, structValues []*structpb.Value) []spanner.GenericColumnValue {
-	return slices.Collect(hiter.Unify(
-		typeValueToGCV,
-		hiter.Pairs(slices.Values(structTypefields), slices.Values(structValues))))
+	return slices.Collect(loi.FilterMapI(slices.Values(structTypefields), func(field *sppb.StructType_Field, i int) (spanner.GenericColumnValue, bool) {
+		if i >= len(structValues) {
+			return spanner.GenericColumnValue{}, false
+		}
+		return typeValueToGCV(field, structValues[i]), true
+	}))
 }
 
 func parseMutation(table, op, s string) ([]*spanner.Mutation, error) {
@@ -306,9 +301,7 @@ func parseMutation(table, op, s string) ([]*spanner.Mutation, error) {
 		return nil, fmt.Errorf("unsupported operation: %q", op)
 	}
 
-	var mutations []*spanner.Mutation
-	for _, v := range values {
-		mutations = append(mutations, mutationF(table, columns, lo.ToAnySlice(v)))
-	}
-	return mutations, nil
+	return lo.Map(values, func(v []spanner.GenericColumnValue, _ int) *spanner.Mutation {
+		return mutationF(table, columns, lo.ToAnySlice(v))
+	}), nil
 }

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/memebridge"
+	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/apstndb/spanvalue"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
@@ -267,13 +268,8 @@ func parseLiteralString(s string) ([]string, [][]spanner.GenericColumnValue, err
 }
 
 func extractStructValues(structTypefields []*sppb.StructType_Field, structValues []*structpb.Value) []spanner.GenericColumnValue {
-	// Keep the previous "shorter input wins" behavior from hiter.Pairs.
-	// loi.ZipBy2 pads missing values with zero values instead of stopping early.
-	return slices.Collect(loi.FilterMapI(slices.Values(structTypefields), func(field *sppb.StructType_Field, i int) (spanner.GenericColumnValue, bool) {
-		if i >= len(structValues) {
-			return spanner.GenericColumnValue{}, false
-		}
-		return typeValueToGCV(field, structValues[i]), true
+	return slices.Collect(iterutil.ZipShortestBy(slices.Values(structTypefields), slices.Values(structValues), func(field *sppb.StructType_Field, value *structpb.Value) spanner.GenericColumnValue {
+		return typeValueToGCV(field, value)
 	}))
 }
 

--- a/internal/mycli/statements_params.go
+++ b/internal/mycli/statements_params.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/samber/lo"
-	loi "github.com/samber/lo/it"
 )
 
 type ShowParamsStatement struct{}
@@ -18,11 +17,10 @@ type ShowParamsStatement struct{}
 func (s *ShowParamsStatement) isDetachedCompatible() {}
 
 func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	rows := slices.SortedFunc(
-		loi.MapToSeq(session.systemVariables.Params, func(k string, v ast.Node) Row {
-			return toRow(k, lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"), v.SQL())
-		}),
-		func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* parameter name */ })
+	rows := lo.MapToSlice(session.systemVariables.Params, func(k string, v ast.Node) Row {
+		return toRow(k, lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"), v.SQL())
+	})
+	slices.SortFunc(rows, func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* parameter name */ })
 
 	return &Result{
 		TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),

--- a/internal/mycli/statements_params.go
+++ b/internal/mycli/statements_params.go
@@ -4,14 +4,13 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"maps"
 	"slices"
 
 	"github.com/apstndb/lox"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/samber/lo"
-	scxiter "spheric.cloud/xiter"
+	loi "github.com/samber/lo/it"
 )
 
 type ShowParamsStatement struct{}
@@ -19,13 +18,8 @@ type ShowParamsStatement struct{}
 func (s *ShowParamsStatement) isDetachedCompatible() {}
 
 func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	strMap := make(map[string]string)
-	for k, v := range session.systemVariables.Params {
-		strMap[k] = v.SQL()
-	}
-
 	rows := slices.SortedFunc(
-		scxiter.MapLower(maps.All(session.systemVariables.Params), func(k string, v ast.Node) Row {
+		loi.MapToSeq(session.systemVariables.Params, func(k string, v ast.Node) Row {
 			return toRow(k, lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"), v.SQL())
 		}),
 		func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* parameter name */ })

--- a/internal/mycli/statements_partitioned_query.go
+++ b/internal/mycli/statements_partitioned_query.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 
 	"cloud.google.com/go/spanner"
-	"github.com/ngicks/go-iterator-helper/hiter"
+	loi "github.com/samber/lo/it"
 )
 
 type PartitionStatement struct{ SQL string }
@@ -23,11 +23,12 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 		return nil, err
 	}
 
-	rows := slices.Collect(hiter.Map(
+	rows := slices.Collect(loi.Map(
+		slices.Values(partitions),
 		func(partition *spanner.Partition) Row {
 			return toRow(base64.StdEncoding.EncodeToString(partition.GetPartitionToken()))
 		},
-		slices.Values(partitions)))
+	))
 
 	ts, err := batchROTx.Timestamp()
 	if err != nil {

--- a/internal/mycli/statements_proto.go
+++ b/internal/mycli/statements_proto.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"iter"
 	"log/slog"
-	"maps"
 	"slices"
 	"strings"
 
 	"github.com/apstndb/lox"
 	"github.com/bufbuild/protocompile/walk"
 	"github.com/cloudspannerecosystem/memefish/ast"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
-	scxiter "spheric.cloud/xiter"
 
 	"github.com/apstndb/spanner-mycli/internal/proto/zetasql"
 )
@@ -43,10 +41,11 @@ func (s *SyncProtoStatement) Execute(ctx context.Context, session *Session) (*Re
 }
 
 func composeProtoBundleDDLs(fds *descriptorpb.FileDescriptorSet, upsertPaths, deletePaths []string) []string {
-	fullNameSetFds := maps.Collect(
-		scxiter.MapLift(fdsToInfoSeq(fds), func(info *descriptorInfo) (string, struct{}) {
+	fullNameSetFds := loi.Associate(
+		fdsToInfoSeq(fds),
+		func(info *descriptorInfo) (string, struct{}) {
 			return info.FullName, struct{}{}
-		}),
+		},
 	)
 
 	upsertExists, upsertNotExists := splitExistence(fullNameSetFds, upsertPaths)
@@ -84,8 +83,8 @@ func (s *ShowLocalProtoStatement) Execute(ctx context.Context, session *Session)
 	fds := session.systemVariables.Internal.ProtoDescriptor
 
 	rows := slices.Collect(
-		scxiter.Map(
-			scxiter.Flatmap(slices.Values(fds.GetFile()), fdpToInfo),
+		loi.Map(
+			loi.FlatMap(slices.Values(fds.GetFile()), fdpToInfo),
 			func(info *descriptorInfo) Row {
 				return toRow(info.FullName, info.Kind, info.Package, info.FileName)
 			},
@@ -114,8 +113,8 @@ func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session
 	}
 
 	rows := slices.Collect(
-		scxiter.Map(
-			scxiter.Flatmap(slices.Values(fds.GetFile()), fdpToInfo),
+		loi.Map(
+			loi.FlatMap(slices.Values(fds.GetFile()), fdpToInfo),
 			func(info *descriptorInfo) Row {
 				return toRow(info.FullName, info.Kind, info.Package)
 			},
@@ -133,7 +132,7 @@ func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session
 // Helper functions
 
 func fdsToInfoSeq(fds *descriptorpb.FileDescriptorSet) iter.Seq[*descriptorInfo] {
-	return scxiter.Flatmap(slices.Values(fds.GetFile()), fdpToInfo)
+	return loi.FlatMap(slices.Values(fds.GetFile()), fdpToInfo)
 }
 
 func splitExistence(fullNameSet map[string]struct{}, paths []string) ([]string, []string) {
@@ -169,15 +168,16 @@ func fdpToSeq(fdp *descriptorpb.FileDescriptorProto) iter.Seq2[string, proto.Mes
 }
 
 func fdpToInfo(fdp *descriptorpb.FileDescriptorProto) iter.Seq[*descriptorInfo] {
-	return scxiter.MapLower(
-		scxiter.FilterValue(
-			fdpToSeq(fdp),
-			isValidDescriptorProto,
-		),
-		func(name string, message proto.Message) *descriptorInfo {
-			return &descriptorInfo{FullName: name, Kind: toKind(message), Package: fdp.GetPackage(), FileName: fdp.GetName()}
-		},
-	)
+	return func(yield func(*descriptorInfo) bool) {
+		for name, message := range fdpToSeq(fdp) {
+			if !isValidDescriptorProto(message) {
+				continue
+			}
+			if !yield(&descriptorInfo{FullName: name, Kind: toKind(message), Package: fdp.GetPackage(), FileName: fdp.GetName()}) {
+				return
+			}
+		}
+	}
 }
 
 func toKind(message proto.Message) string {
@@ -215,14 +215,15 @@ func isValidDescriptorProto(message proto.Message) bool {
 
 func toNamedType(fullName string) *ast.NamedType {
 	return &ast.NamedType{
-		Path: slices.Collect(hiter.Map(
+		Path: slices.Collect(loi.Map(
+			slices.Values(strings.Split(fullName, ".")),
 			func(s string) *ast.Ident {
 				return &ast.Ident{Name: s}
 			},
-			slices.Values(strings.Split(fullName, ".")))),
+		)),
 	}
 }
 
 func toNamedTypes(fullNames []string) []*ast.NamedType {
-	return slices.Collect(hiter.Map(toNamedType, slices.Values(fullNames)))
+	return slices.Collect(loi.Map(slices.Values(fullNames), toNamedType))
 }

--- a/internal/mycli/statements_proto.go
+++ b/internal/mycli/statements_proto.go
@@ -41,12 +41,10 @@ func (s *SyncProtoStatement) Execute(ctx context.Context, session *Session) (*Re
 }
 
 func composeProtoBundleDDLs(fds *descriptorpb.FileDescriptorSet, upsertPaths, deletePaths []string) []string {
-	fullNameSetFds := loi.Associate(
-		fdsToInfoSeq(fds),
-		func(info *descriptorInfo) (string, struct{}) {
-			return info.FullName, struct{}{}
-		},
-	)
+	fullNameSetFds := make(map[string]struct{})
+	for info := range fdsToInfoSeq(fds) {
+		fullNameSetFds[info.FullName] = struct{}{}
+	}
 
 	upsertExists, upsertNotExists := splitExistence(fullNameSetFds, upsertPaths)
 	deleteExists, _ := splitExistence(fullNameSetFds, deletePaths)

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -18,8 +18,8 @@ import (
 	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/k0kubun/pp/v3"
-	"github.com/ngicks/go-iterator-helper/hiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -81,16 +81,17 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 			return nil, err
 		}
 
-		maxIDLength := max(hiter.Max(hiter.Map(func(row Row) int { return len(row[0].RawText()) /* ID */ }, slices.Values(rows))), 2)
+		maxIDLength := max(loi.Max(loi.Map(slices.Values(rows), func(row Row) int { return len(row[0].RawText()) /* ID */ })), 2)
 
 		pprinter := pp.New()
 		pprinter.SetColoringEnabled(false)
 
-		tree := strings.Join(slices.Collect(hiter.Map(
+		tree := strings.Join(slices.Collect(loi.Map(
+			slices.Values(rows),
 			func(r Row) string {
 				return tabwrap.FillLeft(r[0].RawText() /* ID */, maxIDLength) + " | " + r[1].RawText() /* Plan */
 			},
-			slices.Values(rows))), "\n")
+		)), "\n")
 
 		resultRows = append(resultRows, toRow(row.QueryProfile.QueryStats.QueryText+"\n"+tabwrap.FillRight("ID", maxIDLength)+" | Plan\n"+tree+
 			lox.IfOrEmpty(len(predicates) > 0, "\nPredicates:\n"+strings.Join(predicates, "\n"))+"\n"+

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -81,7 +81,7 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 			return nil, err
 		}
 
-		maxIDLength := max(loi.Max(loi.Map(slices.Values(rows), func(row Row) int { return len(row[0].RawText()) /* ID */ })), 2)
+		maxIDLength := max(lo.Max(lo.Map(rows, func(row Row, _ int) int { return len(row[0].RawText()) /* ID */ })), 2)
 
 		pprinter := pp.New()
 		pprinter.SetColoringEnabled(false)

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -81,7 +81,10 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 			return nil, err
 		}
 
-		maxIDLength := max(lo.Max(lo.Map(rows, func(row Row, _ int) int { return len(row[0].RawText()) /* ID */ })), 2)
+		maxIDLength := 2
+		for _, row := range rows {
+			maxIDLength = max(maxIDLength, len(row[0].RawText()) /* ID */)
+		}
 
 		pprinter := pp.New()
 		pprinter.SetColoringEnabled(false)

--- a/internal/mycli/statements_schema.go
+++ b/internal/mycli/statements_schema.go
@@ -11,9 +11,8 @@ import (
 	"github.com/apstndb/lox"
 	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
 	"github.com/apstndb/spanvalue"
-	"github.com/ngicks/go-iterator-helper/hiter"
-	"github.com/ngicks/go-iterator-helper/hiter/stringsiter"
 	"github.com/samber/lo"
+	loi "github.com/samber/lo/it"
 )
 
 type ShowCreateStatement struct {
@@ -137,9 +136,7 @@ func (s *ShowDdlsStatement) Execute(ctx context.Context, session *Session) (*Res
 		KeepVariables: true,
 		// intentionally empty column name to make TAB format valid DDL
 		TableHeader: toTableHeader(""),
-		Rows: sliceOf(toRow(stringsiter.Collect(hiter.Map(
-			func(s string) string { return s + ";\n" },
-			slices.Values(resp.GetStatements()))))),
+		Rows:        sliceOf(toRow(strings.Join(slices.Collect(loi.Map(slices.Values(resp.GetStatements()), func(s string) string { return s + ";\n" })), ""))),
 	}, nil
 }
 

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -164,8 +164,11 @@ func (s *HelpVariablesStatement) Execute(ctx context.Context, session *Session) 
 		Description: "",
 	})
 
-	rows := slices.SortedFunc(loi.Map(slices.Values(merged), func(v variableDesc) Row { return toRow(v.Name, strings.Join(v.Operations, ","), v.Description) }), func(lhs Row, rhs Row) int {
-		return strings.Compare(lhs[0].RawText(), rhs[0].RawText())
+	rows := lo.Map(merged, func(v variableDesc, _ int) Row {
+		return toRow(v.Name, strings.Join(v.Operations, ","), v.Description)
+	})
+	slices.SortFunc(rows, func(lhs Row, rhs Row) int {
+		return cmp.Compare(lhs[0].RawText(), rhs[0].RawText())
 	})
 
 	return &Result{

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/samber/lo"
 	loi "github.com/samber/lo/it"
 )
 
@@ -63,9 +64,8 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 		merged["CLI_DIRECT_READ"] = values
 	}
 
-	rows := slices.SortedFunc(
-		loi.MapToSeq(merged, func(k, v string) Row { return toRow(k, v) }),
-		func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* name */ })
+	rows := lo.MapToSlice(merged, func(k, v string) Row { return toRow(k, v) })
+	slices.SortFunc(rows, func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* name */ })
 
 	return &Result{
 		TableHeader:   toTableHeader("name", "value"),

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -11,8 +11,7 @@ import (
 	"time"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/ngicks/go-iterator-helper/hiter"
-	scxiter "spheric.cloud/xiter"
+	loi "github.com/samber/lo/it"
 )
 
 type ShowVariableStatement struct {
@@ -55,17 +54,17 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 
 	// Special handling for CLI_DIRECT_READ
 	if session.systemVariables.Query.DirectedRead != nil {
-		values := scxiter.Join(scxiter.Map(
+		values := strings.Join(slices.Collect(loi.Map(
 			slices.Values(session.systemVariables.Query.DirectedRead.GetIncludeReplicas().GetReplicaSelections()),
 			func(rs *sppb.DirectedReadOptions_ReplicaSelection) string {
 				return fmt.Sprintf("%s:%s", rs.GetLocation(), rs.GetType())
 			},
-		), ";")
+		)), ";")
 		merged["CLI_DIRECT_READ"] = values
 	}
 
 	rows := slices.SortedFunc(
-		scxiter.MapLower(maps.All(merged), func(k, v string) Row { return toRow(k, v) }),
+		loi.MapToSeq(merged, func(k, v string) Row { return toRow(k, v) }),
 		func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* name */ })
 
 	return &Result{
@@ -165,7 +164,7 @@ func (s *HelpVariablesStatement) Execute(ctx context.Context, session *Session) 
 		Description: "",
 	})
 
-	rows := slices.SortedFunc(hiter.Map(func(v variableDesc) Row { return toRow(v.Name, strings.Join(v.Operations, ","), v.Description) }, slices.Values(merged)), func(lhs Row, rhs Row) int {
+	rows := slices.SortedFunc(loi.Map(slices.Values(merged), func(v variableDesc) Row { return toRow(v.Name, strings.Join(v.Operations, ","), v.Description) }), func(lhs Row, rhs Row) int {
 		return strings.Compare(lhs[0].RawText(), rhs[0].RawText())
 	})
 

--- a/internal/mycli/system_variables_registry.go
+++ b/internal/mycli/system_variables_registry.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"spheric.cloud/xiter"
+	loi "github.com/samber/lo/it"
 )
 
 // ensureRegistry initializes the registry if needed.
@@ -155,12 +155,12 @@ func (sv *systemVariables) get(name string) (map[string]string, error) {
 			return nil, errIgnored
 		}
 		// Format DirectedRead for display
-		values := xiter.Join(xiter.Map(
+		values := strings.Join(slices.Collect(loi.Map(
 			slices.Values(sv.Query.DirectedRead.GetIncludeReplicas().GetReplicaSelections()),
 			func(rs *sppb.DirectedReadOptions_ReplicaSelection) string {
 				return fmt.Sprintf("%s:%s", rs.GetLocation(), rs.GetType())
 			},
-		), ";")
+		)), ";")
 		return singletonMap(name, values), nil
 	}
 

--- a/internal/mycli/var_enum_handlers.go
+++ b/internal/mycli/var_enum_handlers.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/samber/lo"
 )
 
 // EnumVar handles enum-like variables
@@ -207,11 +208,9 @@ func QueryModeVar(ptr *sppb.ExecuteSqlRequest_QueryMode, desc string) *ProtoEnum
 
 // enumerValues is a generic helper for creating value maps from enumer-generated types
 func enumerValues[T fmt.Stringer](values []T) map[string]T {
-	m := make(map[string]T, len(values))
-	for _, v := range values {
-		m[v.String()] = v
-	}
-	return m
+	return lo.Associate(values, func(v T) (string, T) {
+		return v.String(), v
+	})
 }
 
 // DisplayModeVar creates an enum handler for DisplayMode


### PR DESCRIPTION
## Summary

- replace remaining iterator-helper and direct xiter usage with `samber/lo` and `lo/it`
- simplify a few error/map-building paths with core `lo` helpers such as `MapErr`, `Map`, and `Associate`
- update `github.com/apstndb/gsqlutils` to the merged xiter-removal commit so the transitive `spheric.cloud/xiter` dependency disappears

## Validation

- `make check`
