### PR TITLE
chore(deps): bump spannerplan to v0.1.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spanemuboost v0.4.1
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
-	github.com/apstndb/spannerplan v0.1.6
+	github.com/apstndb/spannerplan v0.1.9
 	github.com/apstndb/spantype v0.3.11
 	github.com/apstndb/spanvalue v0.3.0
 	github.com/bufbuild/protocompile v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -2497,8 +2497,8 @@ github.com/apstndb/spanemuboost v0.4.1 h1:c5j21noX6fSY8LBFdoXqPw+zo6NudlWR5qiMwT
 github.com/apstndb/spanemuboost v0.4.1/go.mod h1:5qMaU+8vWhS4jcRi9tpUhy7Z2sY3Ljrl7FbCap8nEGo=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l0QJZRVSRwBXTxaMMAjrmF0kQDjXlCM0bwTCo5Gs=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6/go.mod h1:Enpmw/D11tME865ROYDQzoHSIo9V8uCgWdu+fxA7n2M=
-github.com/apstndb/spannerplan v0.1.6 h1:pm1fcp2ciqxoXW+wOMuH7MENlIsJ50FSPhyTVrVtG6s=
-github.com/apstndb/spannerplan v0.1.6/go.mod h1:PMc14PeeNvrzidbisEuoVwpKmhZz1zy41fw8IzKQVbQ=
+github.com/apstndb/spannerplan v0.1.9 h1:T9itZiO5KVQMvoajA0SLJr/DesMOjdYY6i5mSmrS4l8=
+github.com/apstndb/spannerplan v0.1.9/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spanvalue v0.3.0 h1:MsHW+ZhHXdHmeoVjG/qw785mGvyKJ7GBz3cUPYEIDI4=


### PR DESCRIPTION
## Summary

- Bump `github.com/apstndb/spannerplan` from `v0.1.6` to `v0.1.9`.
- Update `go.sum` checksums for the new module version.

## Upstream diff checked

Checked the full upstream range `v0.1.6...v0.1.9`: 7 commits, 14 changed files.

- `v0.1.7`: fixes hanging-indent tree rendering so wrapped child lines keep visible guide connections.
- `v0.1.8`: removes spannerplan's direct `github.com/apstndb/lox` dependency, adds serialization-friendly `plantree/reference.RenderConfig`, adds `RenderTreeTableWithConfig`, and documents browser/WASM embedding.
- `v0.1.9`: adds `QueryPlan.ParentLinks(childIndex)` and `ResolvedParentLink`, clarifies `QueryPlan.IsVisible`, and treats scalar Full Text Search `Search Predicate` links as predicates in `QueryPlan.IsPredicate`.

## spanner-mycli impact

- Existing `EXPLAIN` and `EXPLAIN ANALYZE` rendering should pick up the Full Text Search predicate improvement automatically through `plantree.ProcessPlan`.
- Existing call sites do not use `RenderTreeTableWithConfig`; it is mainly for cross-language/browser/WASM callers.
- Existing call sites do not use `ParentLinks` yet, but it is a good fit for improving plan-node diagnostics.

## Follow-ups

- #625: use `QueryPlan.ParentLinks` to enhance `SHOW PLAN NODE` with incoming parent links.
- #626: expose hanging-indent EXPLAIN rendering now that the child-guide rendering bug is fixed upstream.

## Validation

- `make check`
