### PR TITLE
build(deps): bump fzf to 0.73.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 > For Table formats with streaming enabled, `CLI_TABLE_PREVIEW_ROWS` (default: 50) controls how many rows are used to calculate column widths before streaming the rest.
 
 > **Note**: `CLI_FUZZY_FINDER_OPTIONS` passes additional fzf options to the fuzzy finder. Options are appended after built-in defaults, so user options take precedence (last wins).
-> Built-in defaults: `--reverse`, `--no-sort`, `--height`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, `--border=rounded`, `--info=inline-right`, and `--header-border=inline` when a header is shown.
+> Built-in defaults: `--reverse`, `--no-sort`, `--height=<computed>`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, `--border=rounded`, `--info=inline-right`, and `--header-border=inline` when a header is shown.
 > `--tmux` and `--popup` are not supported because the fuzzy finder runs fzf in-process via the Go library.
 
 > **Note**: `CLI_TYPE_STYLES` configures ANSI styling for query result values based on their Spanner type. Format: colon-separated `TYPE=STYLE` pairs.

--- a/README.md
+++ b/README.md
@@ -993,8 +993,8 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 > For Table formats with streaming enabled, `CLI_TABLE_PREVIEW_ROWS` (default: 50) controls how many rows are used to calculate column widths before streaming the rest.
 
 > **Note**: `CLI_FUZZY_FINDER_OPTIONS` passes additional fzf options to the fuzzy finder. Options are appended after built-in defaults, so user options take precedence (last wins).
-> Built-in defaults: `--reverse`, `--no-sort`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, `--border=rounded`, `--info=inline-right`.
-> `--tmux` is not supported because the fuzzy finder runs fzf in-process via the Go library.
+> Built-in defaults: `--reverse`, `--no-sort`, `--height`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, `--border=rounded`, `--info=inline-right`, and `--header-border=inline` when a header is shown.
+> `--tmux` and `--popup` are not supported because the fuzzy finder runs fzf in-process via the Go library.
 
 > **Note**: `CLI_TYPE_STYLES` configures ANSI styling for query result values based on their Spanner type. Format: colon-separated `TYPE=STYLE` pairs.
 > - Named colors/attributes: `red`, `green`, `bold`, `dim`, `italic`, `underline`, etc.

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -182,7 +182,7 @@ TODO
 - **Notes**:
   - Options are appended after built-in defaults, so user options take precedence (last wins)
   - Uses standard fzf option syntax (space-separated flags)
-  - Built-in defaults: `--reverse`, `--no-sort`, `--height`, `--border=rounded`, `--info=inline-right`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, and `--header-border=inline` when a header is shown
+  - Built-in defaults: `--reverse`, `--no-sort`, `--height=<computed>`, `--border=rounded`, `--info=inline-right`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, and `--header-border=inline` when a header is shown
   - Useful for customizing appearance (colors, layout) or behavior (sorting, preview)
   - `--tmux` and `--popup` are **not supported** because the fuzzy finder runs fzf in-process via the Go library
 

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -182,9 +182,9 @@ TODO
 - **Notes**:
   - Options are appended after built-in defaults, so user options take precedence (last wins)
   - Uses standard fzf option syntax (space-separated flags)
-  - Built-in defaults: `--reverse`, `--no-sort`, `--height`, `--border=rounded`, `--info=inline-right`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`
+  - Built-in defaults: `--reverse`, `--no-sort`, `--height`, `--border=rounded`, `--info=inline-right`, `--select-1`, `--exit-0`, `--highlight-line`, `--cycle`, and `--header-border=inline` when a header is shown
   - Useful for customizing appearance (colors, layout) or behavior (sorting, preview)
-  - `--tmux` is **not supported** because the fuzzy finder runs fzf in-process via the Go library
+  - `--tmux` and `--popup` are **not supported** because the fuzzy finder runs fzf in-process via the Go library
 
 ##### CLI_TYPE_STYLES
 - **Type**: STRING

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/googleapis/go-spanner-cassandra v0.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/hymkor/go-multiline-ny v0.23.1
-	github.com/junegunn/fzf v0.68.0
+	github.com/junegunn/fzf v0.73.0
 	github.com/k0kubun/pp/v3 v3.5.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.18.5
@@ -125,7 +125,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20250821153705-5981dea3221d // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mattn/go-tty v0.0.7 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2885,8 +2885,8 @@ github.com/itchyny/timefmt-go v0.1.6/go.mod h1:RRDZYC5s9ErkjQvTvvU7keJjxUYzIISJG
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/junegunn/fzf v0.68.0 h1:5ZpGfEVOaU9bsPaIQowepyF36/sxG+czr7mTdtnZS1E=
-github.com/junegunn/fzf v0.68.0/go.mod h1:xlXX2/rmsccKQUnr9QOXPDi5DyV9cM0UjKy/huScBeE=
+github.com/junegunn/fzf v0.73.0 h1:dpFAnHFQK8XW/RLx6uuijHkKw3l1kSanVcu6DH0sFtA=
+github.com/junegunn/fzf v0.73.0/go.mod h1:hKDkO8orBWT5VLIZOL8oyhxn7mRLXdGyu+gz1Ss58pU=
 github.com/junegunn/go-shellwords v0.0.0-20250127100254-2aa3b3277741 h1:7dYDtfMDfKzjT+DVfIS4iqknSEKtZpEcXtu6vuaasHs=
 github.com/junegunn/go-shellwords v0.0.0-20250127100254-2aa3b3277741/go.mod h1:6EILKtGpo5t+KLb85LNZLAF6P9LKp78hJI80PXMcn3c=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
@@ -2936,8 +2936,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/internal/mycli/fuzzy_finder.go
+++ b/internal/mycli/fuzzy_finder.go
@@ -301,7 +301,7 @@ func prepareFzfOptions(candidates []fzfItem, header string) fzfPrepared {
 	if hasMultiline {
 		extra := 4 // border(2) + prompt(1) + separator(1)
 		if header != "" {
-			extra++
+			extra += 2 // header text + inline header separator
 		}
 		gaps := len(candidates) - 1 // --gap adds 1 line between items
 		h := min(totalDisplayLines+gaps+extra, 20)
@@ -314,6 +314,9 @@ func prepareFzfOptions(candidates []fzfItem, header string) fzfPrepared {
 		"--info=inline-right",
 		"--select-1", "--exit-0",
 		"--highlight-line", "--cycle",
+	}
+	if header != "" {
+		fzfArgs = append(fzfArgs, "--header-border=inline")
 	}
 	if hasLabels {
 		fzfArgs = append(fzfArgs, "--delimiter="+fzfDelimiter, "--with-nth=2..")

--- a/internal/mycli/fuzzy_finder.go
+++ b/internal/mycli/fuzzy_finder.go
@@ -268,7 +268,7 @@ type fzfPrepared struct {
 
 // prepareFzfOptions is a pure function that deterministically computes fzf arguments
 // and formatted input lines from candidates. This enables unit testing without TTY.
-// The header parameter affects height calculation (adds 1 line if non-empty).
+// The header parameter affects height calculation (adds header text and separator lines).
 func prepareFzfOptions(candidates []fzfItem, header string) fzfPrepared {
 	// Determine if any candidate needs display/insert separation.
 	hasLabels := false

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -905,7 +905,7 @@ func TestPrepareFzfOptions_HeightCap(t *testing.T) {
 		}
 	}
 
-	// totalDisplayLines(40) + gaps(9) + extra(5) = 54, capped at 20
+	// totalDisplayLines(40) + gaps(9) + extra(6) = 55, capped at 20
 	assert.Equal(t, "20", heightVal)
 }
 

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -745,6 +745,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 		wantHasLabels      bool
 		wantDelimiterArg   bool
 		wantMultilineArgs  bool
+		wantHeaderBorder   bool
 		wantFixedHeight    bool // true = fixed height (no ~), false = shrink height (~N)
 		wantFormattedCount int
 	}{
@@ -758,6 +759,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 			wantHasLabels:      false,
 			wantDelimiterArg:   false,
 			wantMultilineArgs:  false,
+			wantHeaderBorder:   false,
 			wantFixedHeight:    false,
 			wantFormattedCount: 2,
 		},
@@ -771,6 +773,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 			wantHasLabels:      true,
 			wantDelimiterArg:   true,
 			wantMultilineArgs:  false,
+			wantHeaderBorder:   true,
 			wantFixedHeight:    false,
 			wantFormattedCount: 2,
 		},
@@ -784,6 +787,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 			wantHasLabels:      true,
 			wantDelimiterArg:   true,
 			wantMultilineArgs:  true,
+			wantHeaderBorder:   true,
 			wantFixedHeight:    true,
 			wantFormattedCount: 2,
 		},
@@ -797,6 +801,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 			wantHasLabels:      true,
 			wantDelimiterArg:   true,
 			wantMultilineArgs:  true,
+			wantHeaderBorder:   false,
 			wantFixedHeight:    true,
 			wantFormattedCount: 2,
 		},
@@ -815,6 +820,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 			hasReadZero := false
 			hasMultiLine := false
 			hasGap := false
+			hasHeaderBorder := false
 			hasFixedHeight := false
 			for _, arg := range p.args {
 				if strings.HasPrefix(arg, "--delimiter=") {
@@ -832,6 +838,9 @@ func TestPrepareFzfOptions(t *testing.T) {
 				if arg == "--gap" {
 					hasGap = true
 				}
+				if arg == "--header-border=inline" {
+					hasHeaderBorder = true
+				}
 				if heightVal, ok := strings.CutPrefix(arg, "--height="); ok {
 					hasFixedHeight = !strings.HasPrefix(heightVal, "~")
 				}
@@ -842,6 +851,7 @@ func TestPrepareFzfOptions(t *testing.T) {
 			assert.Equal(t, tt.wantMultilineArgs, hasReadZero, "read0 arg")
 			assert.Equal(t, tt.wantMultilineArgs, hasMultiLine, "multi-line arg")
 			assert.Equal(t, tt.wantMultilineArgs, hasGap, "gap arg")
+			assert.Equal(t, tt.wantHeaderBorder, hasHeaderBorder, "header border arg")
 			assert.Equal(t, tt.wantFixedHeight, hasFixedHeight, "fixed height")
 
 			// Verify formatted lines structure.
@@ -871,9 +881,9 @@ func TestPrepareFzfOptions_DynamicHeight(t *testing.T) {
 		}
 	}
 
-	// Expected: totalDisplayLines(5) + gaps(1) + extra(5: border(2)+prompt(1)+separator(1)+header(1))
-	// = 11, capped at min(11, 20) = 11
-	assert.Equal(t, "11", heightVal)
+	// Expected: totalDisplayLines(5) + gaps(1) + extra(6: border(2)+prompt(1)+separator(1)+header(1)+inline header separator(1))
+	// = 12, capped at min(12, 20) = 12
+	assert.Equal(t, "12", heightVal)
 }
 
 func TestPrepareFzfOptions_HeightCap(t *testing.T) {


### PR DESCRIPTION
## Summary

- Bump `github.com/junegunn/fzf` from `v0.68.0` to `v0.73.0`
- Use fzf's inline header border for fuzzy finder headers
- Document the new built-in header border default and clarify that both `--tmux` and its newer `--popup` alias are unsupported with the in-process fzf runner

## Verification

- `go test ./internal/mycli -run 'TestPrepareFzfOptions|TestRunFzfFilter'`
- `go test ./internal/mycli -run 'TestRun/embedded_emulator_success|TestRuntimePlatform' -count=1`
- `DOCKER_HOST=$(colima status --json | jq -r .docker_socket) TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock make check`
- `go mod verify`
