### PR TITLE
Update spanvalue to v0.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ credentials.json
 
 # IDE and tool directories - DO NOT delete in main workspace, safe to delete ONLY in phantom worktrees
 .idea/
+.agents/
 .claude/*
 !.claude/settings.json
+.codex/
 
 # Cache and temporary files - safe to delete anywhere
 .cache/

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spantype v0.3.11
-	github.com/apstndb/spanvalue v0.3.0
+	github.com/apstndb/spanvalue v0.4.1
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spantype v0.3.11
-	github.com/apstndb/spanvalue v0.4.1
+	github.com/apstndb/spanvalue v0.4.2
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -2501,8 +2501,8 @@ github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.4.1 h1:5G4TzCb5KPovcx8dsmRu81dKOyKydMaJlWgJdomTutI=
-github.com/apstndb/spanvalue v0.4.1/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
+github.com/apstndb/spanvalue v0.4.2 h1:aM/8J8KBtciiEht7cRl1sX8N3QuyuNcaxX+ZkEmC4aI=
+github.com/apstndb/spanvalue v0.4.2/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
 github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
 github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=

--- a/go.sum
+++ b/go.sum
@@ -2501,8 +2501,8 @@ github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.3.0 h1:MsHW+ZhHXdHmeoVjG/qw785mGvyKJ7GBz3cUPYEIDI4=
-github.com/apstndb/spanvalue v0.3.0/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
+github.com/apstndb/spanvalue v0.4.1 h1:5G4TzCb5KPovcx8dsmRu81dKOyKydMaJlWgJdomTutI=
+github.com/apstndb/spanvalue v0.4.1/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
 github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
 github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=

--- a/internal/mycli/decoder/decoder.go
+++ b/internal/mycli/decoder/decoder.go
@@ -50,19 +50,15 @@ func FormatConfigWithProto(fds *descriptorpb.FileDescriptorSet, multiline bool) 
 		return nil, err
 	}
 
-	return &spanvalue.FormatConfig{
-		NullString:  "NULL",
-		FormatArray: spanvalue.FormatUntypedArray,
-		FormatStruct: spanvalue.FormatStruct{
-			FormatStructField: spanvalue.FormatSimpleStructField,
-			FormatStructParen: spanvalue.FormatBracketStruct,
-		},
-		FormatComplexPlugins: []spanvalue.FormatComplexFunc{
+	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
+	fc.FormatComplexPlugins = append(
+		[]spanvalue.FormatComplexFunc{
 			formatProto(types, multiline),
 			formatEnum(types),
 		},
-		FormatNullable: spanvalue.FormatNullableSpannerCLICompatible,
-	}, nil
+		fc.FormatComplexPlugins...,
+	)
+	return fc, nil
 }
 
 func dynamicTypesByFDS(fds *descriptorpb.FileDescriptorSet) (*dynamicpb.Types, error) {


### PR DESCRIPTION
## Summary

- Update `github.com/apstndb/spanvalue` from `v0.3.0` to `v0.4.2`.
- Use `FormatConfig.Clone()` to derive the proto-aware formatter from the upstream Spanner CLI compatible preset.
- Ignore local agent/Codex configuration directories so they do not appear as untracked PR noise.

## Release Notes Checked

All releases between the previous dependency and the latest stable release were checked:

- `v0.3.1`
- `v0.3.2`
- `v0.4.0-alpha.1`
- `v0.4.0`
- `v0.4.1-alpha.1`
- `v0.4.1-alpha.2`
- `v0.4.1`
- `v0.4.2`

Relevant new APIs considered:

- `FormatConfig.Clone()` is used in this PR.
- `v0.4.2` adds scalar `FormatComplexFunc` plugins (`FormatSimpleValue`, `FormatLiteralValue`, `FormatSpannerCLIValue`) and `FormatConfigWithoutScalarPlugins`. The current custom PROTO/ENUM plugins are prepended to the cloned preset so they still take precedence.
- `v0.4.2` also adds `writer.RunRowIterator` and `writer.WriteRowIterator`. These are good candidates for the typed-row export follow-up in #643, but adopting that path in this dependency PR would be a larger formatter pipeline change.
- `writer.SQLInsertKind` was reviewed, but the current SQL export code supports multi-row batching while upstream `SQLInsertWriter` does not yet cover that path.
- Nullable `gcvctor` helpers were reviewed and do not have a useful production-code adoption point in this change.

## Review

- Checked `git diff origin/main`; the PR diff is limited to `.gitignore`, `go.mod`, `go.sum`, and `internal/mycli/decoder/decoder.go`.
- `review-router` was run before the `v0.4.2` refresh with explicit routes:
  - `copilot-gpt-5.4`: no material issues
  - `codex-gpt-5.5`: only flagged untracked local agent configuration risk; this PR now ignores those directories
  - `antigravity-default`: no material issues
  - `cursor-agent-composer-2.5-fast`: route failed before review because Cursor Agent authentication was not configured

## Verification

- `go mod verify`
- `make check`
