### PR TITLE
Stream non-table output by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Flags:
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
   -o, --output=STRING                          Redirect query/data output to file (overwrites existing file)
       --skip-column-names                      Suppress column headers in output
-      --streaming="AUTO"                       Streaming output mode: AUTO (format-dependent default), TRUE (always
-                                               stream), FALSE (never stream)
+      --streaming="AUTO"                       Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams
+                                               table output. Non-table formats always stream.
       --color="AUTO"                           ANSI styling in output: AUTO (styled if TTY), TRUE (always styled),
                                                FALSE (never styled)
   -q, --quiet                                  Suppress result lines like 'rows in set' for clean output
@@ -986,10 +986,10 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 >
 > You can change the output format at runtime using `SET CLI_FORMAT = 'CSV';` or use command-line flags `--table`, `--html`, `--xml`, or `--csv`.
 
-> **Note**: `CLI_STREAMING` controls streaming output mode:
-> - `AUTO` (default) - Automatically selects streaming for CSV/Tab/Vertical/HTML/XML formats, buffered for Table formats
-> - `TRUE` - Forces streaming for all formats (reduces memory usage, faster time-to-first-byte)
-> - `FALSE` - Forces buffered mode for all formats (allows accurate column width calculation)
+> **Note**: `CLI_STREAMING` controls table streaming output mode:
+> - `AUTO` (default) - Buffers Table formats for accurate column width calculation; non-table formats stream
+> - `TRUE` - Streams Table formats too (reduces memory usage, faster time-to-first-byte)
+> - `FALSE` - Buffers Table formats; non-table formats still stream
 >
 > For Table formats with streaming enabled, `CLI_TABLE_PREVIEW_ROWS` (default: 50) controls how many rows are used to calculate column widths before streaming the rest.
 

--- a/internal/mycli/cli_output.go
+++ b/internal/mycli/cli_output.go
@@ -72,56 +72,44 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 		return nil
 	}
 
-	// Determine the display format to use
-	displayFormat := sysVars.Display.CLIFormat
+	// Build FormatConfig from systemVariables
+	config := sysVars.toFormatConfig()
 
-	// Modes that require SQL literal values (e.g., SQL_INSERT) must fall back to table format
-	// when values were not formatted as SQL literals (HasSQLFormattedValues is false).
-	// This affects metadata queries (SHOW CREATE TABLE, EXPLAIN) and DML with THEN RETURN.
-	fmtMode := format.Mode(displayFormat.String())
+	fmtMode := format.Mode(sysVars.Display.CLIFormat.String())
+	if fmtMode == format.ModeUnspecified {
+		fmtMode = format.ModeTable
+	}
+
+	// Modes that require SQL literal values (e.g., SQL_INSERT) must fall back to
+	// table format when values were not formatted as SQL literals. This affects
+	// non-query buffered results such as metadata statements and DML THEN RETURN.
 	if format.ValueFormatModeFor(fmtMode) == format.SQLLiteralValues && !result.HasSQLFormattedValues {
 		slog.Warn("SQL export format not applicable for this statement type, using table format instead",
 			"requestedFormat", sysVars.Display.CLIFormat,
 			"statementType", "non-SELECT/DML")
-		displayFormat = enums.DisplayModeTable // Fall back to table format
+		fmtMode = format.ModeTable
 	}
 
-	// Build FormatConfig from systemVariables
-	config := sysVars.toFormatConfig()
-
-	// Recompute fmtMode after potential fallback above
-	fmtMode = format.Mode(displayFormat.String())
-
-	// For SQL export, resolve the table name from Result if available
 	if format.ValueFormatModeFor(fmtMode) == format.SQLLiteralValues && result.SQLTableNameForExport != "" {
 		config.SQLTableName = result.SQLTableNameForExport
 	}
 
-	// Create the appropriate formatter based on the display mode
-	formatter, err := format.NewFormatter(fmtMode)
-	if err != nil {
-		return fmt.Errorf("failed to create formatter: %w", err)
-	}
-
-	// For table mode, pass verbose headers and column align via WriteTableWithParams
-	if fmtMode.IsTableMode() || fmtMode == format.ModeUnspecified {
-		verboseHeaders := renderTableHeader(result.TableHeader, true)
-		tableMode := fmtMode
-		if tableMode == format.ModeUnspecified {
-			tableMode = format.ModeTable
+	if !fmtMode.IsTableMode() {
+		formatter, err := format.NewStreamingFormatter(fmtMode, out, config)
+		if err != nil {
+			return fmt.Errorf("failed to create streaming formatter for buffered rows: %w", err)
 		}
-		return format.WriteTableWithParams(out, result.Rows, columnNames, config, screenWidth, tableMode, format.TableParams{
-			VerboseHeaders: verboseHeaders,
-			ColumnAlign:    result.ColumnAlign,
-		})
+		if err := format.ExecuteWithFormatter(formatter, result.Rows, columnNames, config); err != nil {
+			return fmt.Errorf("streaming formatter failed for buffered rows in mode %v: %w", sysVars.Display.CLIFormat, err)
+		}
+		return nil
 	}
 
-	// Format and write the result
-	if err := formatter(out, result.Rows, columnNames, config, screenWidth); err != nil {
-		return fmt.Errorf("formatting failed for mode %v: %w", sysVars.Display.CLIFormat, err)
-	}
-
-	return nil
+	verboseHeaders := renderTableHeader(result.TableHeader, true)
+	return format.WriteTableWithParams(out, result.Rows, columnNames, config, screenWidth, fmtMode, format.TableParams{
+		VerboseHeaders: verboseHeaders,
+		ColumnAlign:    result.ColumnAlign,
+	})
 }
 
 func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result, interactive bool, input string) error {
@@ -136,10 +124,17 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 		fmt.Fprintln(out, input+";")
 	}
 
-	// Skip table data if already streamed
+	// Skip table data if already streamed or pre-rendered by an execution path
+	// that needs atomic output after side effects such as implicit DML commit.
 	if !result.Streamed {
-		if err := printTableData(sysVars, screenWidth, out, result); err != nil {
-			return err
+		if result.HasRenderedOutput {
+			if _, err := out.Write(result.RenderedOutput); err != nil {
+				return err
+			}
+		} else {
+			if err := printTableData(sysVars, screenWidth, out, result); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/mycli/cli_output_test.go
+++ b/internal/mycli/cli_output_test.go
@@ -24,24 +24,6 @@ func runPrintTableData(t *testing.T, mode enums.DisplayMode, skipColNames bool, 
 	return buf.String(), err
 }
 
-func assertContains(t *testing.T, output string, want []string) {
-	t.Helper()
-	for _, w := range want {
-		if !strings.Contains(output, w) {
-			t.Errorf("output missing %q\nGot:\n%s", w, output)
-		}
-	}
-}
-
-func assertNotContains(t *testing.T, output string, notWant []string) {
-	t.Helper()
-	for _, nw := range notWant {
-		if strings.Contains(output, nw) {
-			t.Errorf("output should not contain %q\nGot:\n%s", nw, output)
-		}
-	}
-}
-
 func assertErrorStatus(t *testing.T, err error, wantError bool) {
 	t.Helper()
 	if (err != nil) != wantError {

--- a/internal/mycli/cli_output_test.go
+++ b/internal/mycli/cli_output_test.go
@@ -6,9 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/apstndb/spanner-mycli/enums"
-	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 )
 
 // Helper functions for common test operations
@@ -48,189 +46,6 @@ func assertErrorStatus(t *testing.T, err error, wantError bool) {
 	t.Helper()
 	if (err != nil) != wantError {
 		t.Errorf("error = %v, wantError %v", err, wantError)
-	}
-}
-
-func TestPrintTableDataHTML(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name         string
-		result       *Result
-		skipColNames bool
-		wantContains []string
-		wantOutput   string
-		wantError    bool
-	}{
-		{
-			name: "simple HTML output",
-			result: &Result{
-				TableHeader: toTableHeader("num", "str", "bool"),
-				Rows: []Row{
-					toRow("1", "test", "true"),
-					toRow("2", "data", "false"),
-				},
-			},
-			wantOutput: `<TABLE BORDER='1'><TR><TH>num</TH><TH>str</TH><TH>bool</TH></TR><TR><TD>1</TD><TD>test</TD><TD>true</TD></TR><TR><TD>2</TD><TD>data</TD><TD>false</TD></TR></TABLE>
-`,
-		},
-		{
-			name: "HTML with special characters escaping",
-			result: &Result{
-				TableHeader: toTableHeader("xml_chars", "quote", "ampersand"),
-				Rows: []Row{
-					toRow("<tag>", "\"quotes\"", "A&B"),
-					toRow("<script>alert('xss')</script>", "'single'", "C&D"),
-				},
-			},
-			wantContains: []string{
-				"&lt;tag&gt;",
-				"&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;",
-				"&#34;quotes&#34;",
-				"&#39;single&#39;",
-				"A&amp;B",
-				"C&amp;D",
-			},
-		},
-		{
-			name: "HTML with skip column names",
-			result: &Result{
-				TableHeader: toTableHeader("col1", "col2"),
-				Rows: []Row{
-					toRow("val1", "val2"),
-				},
-			},
-			skipColNames: true,
-			wantOutput: `<TABLE BORDER='1'><TR><TD>val1</TD><TD>val2</TD></TR></TABLE>
-`,
-		},
-		{
-			name: "empty result",
-			result: &Result{
-				TableHeader: nil,
-				Rows:        []Row{},
-			},
-			wantOutput: "",
-			wantError:  false, // Now we skip formatting for empty results
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := runPrintTableData(t, enums.DisplayModeHTML, tt.skipColNames, tt.result)
-			assertErrorStatus(t, err, tt.wantError)
-			if err != nil {
-				return
-			}
-
-			if tt.wantOutput != "" && got != tt.wantOutput {
-				t.Errorf("printTableData() = %q, want %q", got, tt.wantOutput)
-			}
-
-			assertContains(t, got, tt.wantContains)
-		})
-	}
-}
-
-func TestPrintTableDataXML(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name            string
-		result          *Result
-		skipColNames    bool
-		wantContains    []string
-		wantNotContains []string
-		wantError       bool
-	}{
-		{
-			name: "simple XML output",
-			result: &Result{
-				TableHeader: toTableHeader("num", "str", "bool"),
-				Rows: []Row{
-					toRow("1", "test", "true"),
-					toRow("2", "data", "false"),
-				},
-			},
-			wantContains: []string{
-				"<?xml version='1.0'?>",
-				`<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`,
-				"<header>",
-				"<field>num</field>",
-				"<field>str</field>",
-				"<field>bool</field>",
-				"</header>",
-				"<row>",
-				"<field>1</field>",
-				"<field>test</field>",
-				"<field>true</field>",
-				"</row>",
-				"<row>",
-				"<field>2</field>",
-				"<field>data</field>",
-				"<field>false</field>",
-				"</row>",
-				"</resultset>",
-			},
-		},
-		{
-			name: "XML with special characters escaping",
-			result: &Result{
-				TableHeader: toTableHeader("xml_chars", "quote", "ampersand"),
-				Rows: []Row{
-					toRow("<tag>", "\"quotes\"", "A&B"),
-					toRow("<script>alert('xss')</script>", "'single'", "C&D"),
-				},
-			},
-			wantContains: []string{
-				"&lt;tag&gt;",
-				"&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;",
-				"&#34;quotes&#34;",
-				"&#39;single&#39;",
-				"A&amp;B",
-				"C&amp;D",
-			},
-		},
-		{
-			name: "XML with skip column names",
-			result: &Result{
-				TableHeader: toTableHeader("col1", "col2"),
-				Rows: []Row{
-					toRow("val1", "val2"),
-				},
-			},
-			skipColNames: true,
-			wantNotContains: []string{
-				"<header>",
-				"col1",
-				"col2",
-			},
-			wantContains: []string{
-				"<row>",
-				"<field>val1</field>",
-				"<field>val2</field>",
-			},
-		},
-		{
-			name: "empty result",
-			result: &Result{
-				TableHeader: nil,
-				Rows:        []Row{},
-			},
-			wantContains: []string{},
-			wantError:    false, // Now we skip formatting for empty results
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := runPrintTableData(t, enums.DisplayModeXML, tt.skipColNames, tt.result)
-			assertErrorStatus(t, err, tt.wantError)
-			if err != nil {
-				return
-			}
-
-			assertContains(t, got, tt.wantContains)
-			assertNotContains(t, got, tt.wantNotContains)
-		})
 	}
 }
 
@@ -349,7 +164,7 @@ func TestPrintTableDataEdgeCases(t *testing.T) {
 			wantError:  false, // Now we skip formatting for empty results
 		},
 		{
-			name: "All display modes with unicode data",
+			name: "Non-table mode with buffered data rows uses streaming formatter",
 			mode: enums.DisplayModeHTML,
 			result: &Result{
 				TableHeader: toTableHeader("列1", "列2"),
@@ -379,237 +194,73 @@ func TestPrintTableDataEdgeCases(t *testing.T) {
 	}
 }
 
-func TestFormatHelpers(t *testing.T) {
-	t.Parallel()
-
-	// Helper to test empty input handling for different formatters
-	testEmptyFormatter := func(t *testing.T, name string, formatter format.FormatFunc) {
-		t.Helper()
-		t.Run(name+" with empty input", func(t *testing.T) {
-			var buf bytes.Buffer
-			config := format.FormatConfig{SkipColumnNames: false}
-			err := formatter(&buf, []Row{}, []string{}, config, 0)
-			if err != nil {
-				t.Errorf("expected nil for empty columns, got error: %v", err)
-			}
-			if buf.String() != "" {
-				t.Errorf("expected empty output, got: %q", buf.String())
-			}
-		})
-	}
-
-	htmlFormatter, _ := format.NewFormatter(format.ModeHTML)
-	xmlFormatter, _ := format.NewFormatter(format.ModeXML)
-	csvFormatter, _ := format.NewFormatter(format.ModeCSV)
-	testEmptyFormatter(t, "formatHTML", htmlFormatter)
-	testEmptyFormatter(t, "formatXML", xmlFormatter)
-	testEmptyFormatter(t, "formatCSV", csvFormatter)
-
-	t.Run("XML with large dataset", func(t *testing.T) {
-		// Test with a larger dataset to ensure performance
-		columns := []string{"id", "name", "value"}
-		rows := make([]Row, 100)
-		for i := range rows {
-			rows[i] = toRow(
-				strings.Repeat("a", 100),
-				strings.Repeat("b", 100),
-				strings.Repeat("c", 100),
-			)
-		}
-
-		var buf bytes.Buffer
-		config := format.FormatConfig{SkipColumnNames: false}
-		err := xmlFormatter(&buf, rows, columns, config, 0)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-
-		output := buf.String()
-		assertContains(t, output, []string{
-			"<?xml version='1.0'?>",
-			"</resultset>",
-		})
-	})
-}
-
-func TestPrintTableDataCSV(t *testing.T) {
+func TestPrintTableDataStreamsBufferedRowsForNonTableModes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name         string
-		result       *Result
-		skipColNames bool
-		wantOutput   string
-		wantError    bool
+		name       string
+		mode       enums.DisplayMode
+		result     *Result
+		wantOutput string
 	}{
 		{
-			name: "simple CSV output",
+			name: "CSV",
+			mode: enums.DisplayModeCSV,
 			result: &Result{
-				TableHeader: toTableHeader("num", "str", "bool"),
-				Rows: []Row{
-					toRow("1", "test", "true"),
-					toRow("2", "data", "false"),
-				},
+				TableHeader: toTableHeader("col1"),
+				Rows:        []Row{toRow("value")},
 			},
-			wantOutput: heredoc.Doc(`
-				num,str,bool
-				1,test,true
-				2,data,false
-			`),
+			wantOutput: "col1\nvalue\n",
 		},
 		{
-			name: "CSV with special characters",
+			name: "SQL export without SQL literals falls back to table",
+			mode: enums.DisplayModeSQLInsert,
 			result: &Result{
-				TableHeader: toTableHeader("name", "description", "value"),
-				Rows: []Row{
-					toRow("John, Jr.", "Says \"Hello\"", "100"),
-					toRow("Jane\nDoe", "Has,comma", "$50"),
-					toRow("Bob", "Normal text", "75"),
-				},
+				TableHeader:           toTableHeader("col1"),
+				Rows:                  []Row{toRow("value")},
+				HasSQLFormattedValues: false,
 			},
-			wantOutput: heredoc.Doc(`
-				name,description,value
-				"John, Jr.","Says ""Hello""",100
-				"Jane
-				Doe","Has,comma",$50
-				Bob,Normal text,75
-			`),
-		},
-		{
-			name: "CSV with skip column names",
-			result: &Result{
-				TableHeader: toTableHeader("col1", "col2"),
-				Rows: []Row{
-					toRow("val1", "val2"),
-					toRow("val3", "val4"),
-				},
-			},
-			skipColNames: true,
-			wantOutput: heredoc.Doc(`
-				val1,val2
-				val3,val4
-			`),
-		},
-		{
-			name: "empty result",
-			result: &Result{
-				TableHeader: nil,
-				Rows:        []Row{},
-			},
-			wantOutput: "",
-			wantError:  false, // Now we skip formatting for empty results
-		},
-		{
-			name: "CSV with quotes and newlines",
-			result: &Result{
-				TableHeader: toTableHeader("text"),
-				Rows: []Row{
-					toRow("Line 1\nLine 2"),
-					toRow("\"Quoted\""),
-					toRow("Normal"),
-				},
-			},
-			wantOutput: heredoc.Doc(`
-				text
-				"Line 1
-				Line 2"
-				"""Quoted"""
-				Normal
-			`),
+			wantOutput: "+-------+\n| col1  |\n+-------+\n| value |\n+-------+\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := runPrintTableData(t, enums.DisplayModeCSV, tt.skipColNames, tt.result)
-			assertErrorStatus(t, err, tt.wantError)
+			got, err := runPrintTableData(t, tt.mode, false, tt.result)
 			if err != nil {
-				return
+				t.Fatalf("printTableData() error = %v", err)
 			}
-
 			if got != tt.wantOutput {
-				t.Errorf("printTableData() = %q, want %q", got, tt.wantOutput)
+				t.Fatalf("printTableData() = %q, want %q", got, tt.wantOutput)
 			}
 		})
 	}
 }
 
-func TestSQLExportFallbackForNonDataStatements(t *testing.T) {
+func TestPrintResultWritesRenderedOutput(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name            string
-		hasSQLFormatted bool
-		cliFormat       enums.DisplayMode
-		expectSQLOutput bool
-	}{
-		{
-			name:            "SQL export with SQL-formatted values (SELECT result)",
-			hasSQLFormatted: true,
-			cliFormat:       enums.DisplayModeSQLInsert,
-			expectSQLOutput: true,
-		},
-		{
-			name:            "SQL export without SQL-formatted values (SHOW CREATE TABLE)",
-			hasSQLFormatted: false,
-			cliFormat:       enums.DisplayModeSQLInsert,
-			expectSQLOutput: false, // Falls back to table
-		},
-		{
-			name:            "SQL INSERT OR UPDATE without SQL-formatted values (EXPLAIN)",
-			hasSQLFormatted: false,
-			cliFormat:       enums.DisplayModeSQLInsertOrUpdate,
-			expectSQLOutput: false,
-		},
-		{
-			name:            "SQL INSERT OR IGNORE without SQL-formatted values (SHOW TABLES)",
-			hasSQLFormatted: false,
-			cliFormat:       enums.DisplayModeSQLInsertOrIgnore,
-			expectSQLOutput: false,
-		},
+
+	result := &Result{
+		TableHeader:       toTableHeader("col1"),
+		Rows:              []Row{toRow("should not be formatted")},
+		RenderedOutput:    []byte("rendered output\n"),
+		HasRenderedOutput: true,
+		AffectedRows:      1,
+	}
+	sysVars := &systemVariables{
+		Display: DisplayVars{CLIFormat: enums.DisplayModeTable},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := &Result{
-				TableHeader:           toTableHeader("Name", "DDL"),
-				Rows:                  []Row{toRow("TestTable", "CREATE TABLE TestTable (id INT64)")},
-				HasSQLFormattedValues: tt.hasSQLFormatted,
-			}
+	var buf bytes.Buffer
+	if err := printResult(sysVars, 80, &buf, result, true, ""); err != nil {
+		t.Fatalf("printResult() error = %v", err)
+	}
 
-			sysVars := &systemVariables{
-				Display: DisplayVars{
-					CLIFormat:    tt.cliFormat,
-					SQLTableName: "TargetTable",
-					SQLBatchSize: 0,
-				},
-			}
-
-			var buf bytes.Buffer
-			err := printTableData(sysVars, 0, &buf, result)
-
-			output := buf.String()
-			containsInsert := strings.Contains(output, "INSERT")
-
-			if tt.expectSQLOutput {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if !containsInsert {
-					t.Errorf("Expected SQL INSERT output, got: %s", output)
-				}
-			} else {
-				// For metadata results, should fall back to table format
-				if containsInsert {
-					t.Errorf("Should not contain INSERT for metadata results, got: %s", output)
-				}
-				// Should see table format markers or be table output
-				if tt.hasSQLFormatted == false && output != "" {
-					// Verify it's table format (has column headers at minimum)
-					if !strings.Contains(output, "Name") || !strings.Contains(output, "DDL") {
-						t.Errorf("Expected table format with headers, got: %s", output)
-					}
-				}
-			}
-		})
+	got := buf.String()
+	if !strings.Contains(got, "rendered output\n") {
+		t.Fatalf("printResult() = %q, want rendered output", got)
+	}
+	if strings.Contains(got, "should not be formatted") {
+		t.Fatalf("printResult() formatted Rows despite HasRenderedOutput: %q", got)
 	}
 }
 

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -169,7 +169,7 @@ type spannerOptions struct {
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
 	Output          string  `name:"output" short:"o" help:"Redirect query/data output to file (overwrites existing file)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`
-	Streaming       string  `name:"streaming" help:"Streaming output mode: AUTO (format-dependent default), TRUE (always stream), FALSE (never stream)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`
+	Streaming       string  `name:"streaming" help:"Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams table output. Non-table formats always stream." enum:"AUTO,TRUE,FALSE" default:"AUTO"`
 	Color           string  `name:"color" help:"ANSI styling in output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`
 	Quiet           bool    `name:"quiet" short:"q" help:"Suppress result lines like 'rows in set' for clean output"`
 }

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -100,6 +100,8 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 		queryStats = updateResult.Stats
 		tableHeader = toTableHeader(updateResult.Metadata.GetRowType().GetFields())
 		if tableHeader != nil {
+			// Render inside the transaction callback so a formatting error
+			// aborts the implicit commit instead of committing without output.
 			renderedOutput, err = renderDMLReturnedRows(session.systemVariables, tableHeader, updateResult.Rows)
 			if err != nil {
 				return 0, nil, nil, err

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -1,6 +1,7 @@
 package mycli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"slices"
@@ -87,15 +88,24 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 		return nil, err
 	}
 
-	var rows []Row
+	var renderedOutput []byte
+	var hasRenderedOutput bool
 	var queryStats map[string]any
+	var tableHeader TableHeader
 	result, err := session.RunInNewOrExistRwTx(ctx, func(tx *spanner.ReadWriteStmtBasedTransaction, implicit bool) (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error) {
 		updateResult, err := session.runUpdateOnTransaction(ctx, tx, stmt, implicit)
 		if err != nil {
 			return 0, nil, nil, err
 		}
-		rows = updateResult.Rows
 		queryStats = updateResult.Stats
+		tableHeader = toTableHeader(updateResult.Metadata.GetRowType().GetFields())
+		if tableHeader != nil {
+			renderedOutput, err = renderDMLReturnedRows(session.systemVariables, tableHeader, updateResult.Rows)
+			if err != nil {
+				return 0, nil, nil, err
+			}
+			hasRenderedOutput = true
+		}
 		return updateResult.Count, updateResult.Plan, updateResult.Metadata, nil
 	})
 	if err != nil {
@@ -118,9 +128,23 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 		CommitTimestamp:       result.CommitResponse.CommitTs,
 		CommitStats:           result.CommitResponse.CommitStats,
 		Stats:                 stats,
-		TableHeader:           toTableHeader(result.Metadata.GetRowType().GetFields()),
-		Rows:                  rows,
+		TableHeader:           tableHeader,
+		RenderedOutput:        renderedOutput,
+		HasRenderedOutput:     hasRenderedOutput,
 		AffectedRows:          int(result.Affected),
 		HasSQLFormattedValues: false, // DML with THEN RETURN uses regular formatting, not SQL literals
 	}, nil
+}
+
+func renderDMLReturnedRows(sysVars *systemVariables, tableHeader TableHeader, rows []Row) ([]byte, error) {
+	var buf bytes.Buffer
+	result := &Result{
+		TableHeader:           tableHeader,
+		Rows:                  rows,
+		HasSQLFormattedValues: false,
+	}
+	if err := printTableData(sysVars, displayScreenWidth(sysVars), &buf, result); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -135,7 +135,13 @@ type queryExecution struct {
 
 // executeAndCollect runs the query iterator (streaming or buffered) and attaches metrics to the result.
 func executeAndCollect(ctx context.Context, qe *queryExecution) (*Result, error) {
-	useStreaming, processor := decideExecutionMode(qe.SysVars)
+	useStreaming, processor, err := decideExecutionMode(qe.SysVars)
+	if err != nil {
+		if qe.Iter != nil {
+			qe.Iter.Stop()
+		}
+		return nil, err
+	}
 	qe.Metrics.IsStreaming = useStreaming
 	qe.Processor = processor
 
@@ -145,7 +151,6 @@ func executeAndCollect(ctx context.Context, qe *queryExecution) (*Result, error)
 		"sqlTableName", qe.SysVars.Display.SQLTableName)
 
 	var result *Result
-	var err error
 	if useStreaming {
 		result, err = executeWithStreaming(ctx, qe)
 	} else {
@@ -241,14 +246,24 @@ func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, s
 
 // decideExecutionMode determines whether to use streaming or buffered mode.
 // Returns true and a processor if streaming should be used, false and nil otherwise.
-func decideExecutionMode(sysVars *systemVariables) (bool, RowProcessor) {
+func decideExecutionMode(sysVars *systemVariables) (bool, RowProcessor, error) {
 	// Get output writer from StreamManager (respects tee/redirect settings)
 	outStream := sysVars.StreamManager.GetWriter()
 	if outStream == nil {
-		return false, nil
+		return false, nil, nil
 	}
 
-	// Determine screen width based on system variables
+	screenWidth := displayScreenWidth(sysVars)
+
+	// Try to create streaming processor based on settings
+	processor, err := createStreamingProcessor(sysVars, outStream, screenWidth)
+	if err != nil {
+		return false, nil, err
+	}
+	return processor != nil, processor, nil
+}
+
+func displayScreenWidth(sysVars *systemVariables) int {
 	screenWidth := math.MaxInt
 	if sysVars.Display.AutoWrap {
 		if sysVars.Display.FixedWidth != nil {
@@ -264,10 +279,7 @@ func decideExecutionMode(sysVars *systemVariables) (bool, RowProcessor) {
 			}
 		}
 	}
-
-	// Try to create streaming processor based on settings
-	processor, _ := createStreamingProcessor(sysVars, outStream, screenWidth)
-	return processor != nil, processor
+	return screenWidth
 }
 
 // executeWithStreaming executes the query using streaming mode.
@@ -355,41 +367,27 @@ func executeStreamingSQL(ctx context.Context, qe *queryExecution) (*Result, erro
 }
 
 // createStreamingProcessor creates the appropriate streaming processor based on format and streaming mode.
-// Returns nil if streaming should not be used (based on StreamingMode setting and format).
+// Non-table formats are always streaming because they do not benefit from row buffering.
+// For table formats, CLI_STREAMING controls whether to trade layout quality for immediate output.
 func createStreamingProcessor(sysVars *systemVariables, out io.Writer, screenWidth int) (RowProcessor, error) {
-	// Check if streaming should be used based on mode
-	shouldStream := false
-	switch sysVars.Query.StreamingMode {
-	case enums.StreamingModeTrue:
-		// Always stream if format supports it
-		shouldStream = true
-	case enums.StreamingModeFalse:
-		// Never stream
-		return nil, nil
-	case enums.StreamingModeAuto:
-		// AUTO mode: decide based on format
-		switch sysVars.Display.CLIFormat {
-		case enums.DisplayModeTable, enums.DisplayModeTableComment, enums.DisplayModeTableDetailComment:
-			// Table formats: buffer by default for accurate column widths
-			shouldStream = false
-		case enums.DisplayModeCSV, enums.DisplayModeTab, enums.DisplayModeVertical, enums.DisplayModeHTML, enums.DisplayModeXML,
-			enums.DisplayModeJSONL,
-			enums.DisplayModeSQLInsert, enums.DisplayModeSQLInsertOrIgnore, enums.DisplayModeSQLInsertOrUpdate:
-			// Other formats: stream by default for better performance
-			shouldStream = true
+	fmtMode := format.Mode(sysVars.Display.CLIFormat.String())
+	if fmtMode.IsTableMode() || fmtMode == format.ModeUnspecified {
+		switch sysVars.Query.StreamingMode {
+		case enums.StreamingModeTrue:
+			return createStreamingProcessorForMode(sysVars.Display.CLIFormat, out, sysVars, screenWidth)
+		case enums.StreamingModeFalse, enums.StreamingModeAuto:
+			// Table formats buffer by default for accurate column widths.
+			return nil, nil
 		default:
-			// Unknown format: buffer for safety
-			shouldStream = false
+			return nil, nil
 		}
+	}
+
+	switch sysVars.Query.StreamingMode {
+	case enums.StreamingModeTrue, enums.StreamingModeFalse, enums.StreamingModeAuto:
 	default:
-		// Unknown mode: buffer for safety
 		return nil, nil
 	}
 
-	if !shouldStream {
-		return nil, nil
-	}
-
-	// Use the shared processor creation logic to avoid duplication
 	return createStreamingProcessorForMode(sysVars.Display.CLIFormat, out, sysVars, screenWidth)
 }

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -375,19 +375,18 @@ func createStreamingProcessor(sysVars *systemVariables, out io.Writer, screenWid
 		switch sysVars.Query.StreamingMode {
 		case enums.StreamingModeTrue:
 			return createStreamingProcessorForMode(sysVars.Display.CLIFormat, out, sysVars, screenWidth)
-		case enums.StreamingModeFalse, enums.StreamingModeAuto:
-			// Table formats buffer by default for accurate column widths.
-			return nil, nil
 		default:
+			// Table formats buffer by default for accurate column widths.
 			return nil, nil
 		}
 	}
 
+	// Non-table formats always stream regardless of CLI_STREAMING; only
+	// guard against an unexpected enum value.
 	switch sysVars.Query.StreamingMode {
 	case enums.StreamingModeTrue, enums.StreamingModeFalse, enums.StreamingModeAuto:
+		return createStreamingProcessorForMode(sysVars.Display.CLIFormat, out, sysVars, screenWidth)
 	default:
 		return nil, nil
 	}
-
-	return createStreamingProcessorForMode(sysVars.Display.CLIFormat, out, sysVars, screenWidth)
 }

--- a/internal/mycli/format/config.go
+++ b/internal/mycli/format/config.go
@@ -1,10 +1,6 @@
 package format
 
-import (
-	"io"
-
-	"github.com/apstndb/spanner-mycli/enums"
-)
+import "github.com/apstndb/spanner-mycli/enums"
 
 // Cell is the interface for a single formatted cell.
 // The format package is agnostic to the concrete type — it only calls these methods.
@@ -130,10 +126,6 @@ type FormatConfig struct {
 	WidthStrategy   enums.WidthStrategy // Column width allocation algorithm. Zero value = GreedyFrequency (default).
 	TabVisualize    bool                // When true, visualize tab characters with → symbol in table output.
 }
-
-// FormatFunc is a function type that formats and writes result data.
-// It takes an output writer, rows, column names, config, and screen width.
-type FormatFunc func(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error
 
 // StreamingFormatter defines the interface for format-specific streaming output.
 // Each format (CSV, TAB, etc.) implements this interface to handle streaming output.

--- a/internal/mycli/format/format.go
+++ b/internal/mycli/format/format.go
@@ -14,15 +14,6 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 )
 
-// formatTable formats output as an ASCII table.
-// No writeBuffered wrapping needed: non-streaming TableStreamingFormatter defers
-// all output to Render() in FinishFormat(), so no partial output on error.
-func formatTable(mode Mode) FormatFunc {
-	return func(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-		return WriteTable(out, rows, columnNames, config, screenWidth, mode)
-	}
-}
-
 // TableParams holds additional parameters for table formatting that are not
 // part of the standard FormatConfig (used only by table format).
 type TableParams struct {
@@ -44,37 +35,6 @@ func WriteTable(w io.Writer, rows []Row, columnNames []string, config FormatConf
 func WriteTableWithParams(w io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int, mode Mode, params TableParams) error {
 	formatter := NewTableFormatterForBuffered(w, config, screenWidth, mode, params)
 	return ExecuteWithFormatter(formatter, rows, columnNames, config)
-}
-
-// formatVertical formats output in vertical format where each row is displayed
-// with column names on the left and values on the right.
-func formatVertical(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-	return ExecuteWithFormatter(NewVerticalFormatter(out), rows, columnNames, config)
-}
-
-// formatTab formats output as tab-separated values.
-func formatTab(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-	return ExecuteWithFormatter(NewTabFormatter(out, config.SkipColumnNames), rows, columnNames, config)
-}
-
-// formatCSV formats output as comma-separated values following RFC 4180.
-func formatCSV(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-	return ExecuteWithFormatter(NewCSVFormatter(out, config.SkipColumnNames), rows, columnNames, config)
-}
-
-// formatHTML formats output as an HTML table.
-func formatHTML(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-	return ExecuteWithFormatter(NewHTMLFormatter(out, config.SkipColumnNames), rows, columnNames, config)
-}
-
-// formatXML formats output as XML.
-func formatXML(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-	return ExecuteWithFormatter(NewXMLFormatter(out, config.SkipColumnNames), rows, columnNames, config)
-}
-
-// formatJSONL formats output as JSON Lines (one JSON object per row).
-func formatJSONL(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-	return ExecuteWithFormatter(NewJSONLFormatter(out), rows, columnNames, config)
 }
 
 // wrapRowStyled wraps styled (ANSI-coded) cell text with ControlSequences-aware Wrap.
@@ -123,36 +83,6 @@ func wrapRowPreserving(row Row, widths []int, rw *tabwrap.Condition) Row {
 		}
 	}
 	return result
-}
-
-// NewFormatter creates a new formatter function based on the display mode.
-// Built-in modes (TABLE, CSV, etc.) are handled directly.
-// Custom modes are looked up in the registry (see RegisterFormatFunc).
-func NewFormatter(mode Mode) (FormatFunc, error) {
-	switch mode {
-	case ModeUnspecified, "":
-		return formatTable(ModeTable), nil
-	case ModeTable, ModeTableComment, ModeTableDetailComment:
-		return formatTable(mode), nil
-	case ModeVertical:
-		return formatVertical, nil
-	case ModeTab:
-		return formatTab, nil
-	case ModeCSV:
-		return formatCSV, nil
-	case ModeHTML:
-		return formatHTML, nil
-	case ModeXML:
-		return formatXML, nil
-	case ModeJSONL:
-		return formatJSONL, nil
-	default:
-		// Look up in registry for custom modes
-		if factory, ok := lookupFormatFunc(mode); ok {
-			return factory(mode)
-		}
-		return nil, errUnsupportedMode("display", mode)
-	}
 }
 
 // ExecuteWithFormatter executes buffered formatting using a streaming formatter.

--- a/internal/mycli/format/format_test.go
+++ b/internal/mycli/format/format_test.go
@@ -9,46 +9,28 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestNewFormatter(t *testing.T) {
-	t.Parallel()
+func formatVertical(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewVerticalFormatter(out), rows, columnNames, config)
+}
 
-	tests := []struct {
-		name    string
-		mode    Mode
-		wantErr bool
-	}{
-		{name: "unspecified", mode: "UNSPECIFIED"},
-		{name: "empty", mode: ""},
-		{name: "table", mode: ModeTable},
-		{name: "table_comment", mode: ModeTableComment},
-		{name: "table_detail_comment", mode: ModeTableDetailComment},
-		{name: "vertical", mode: ModeVertical},
-		{name: "tab", mode: ModeTab},
-		{name: "csv", mode: ModeCSV},
-		{name: "jsonl", mode: ModeJSONL},
-		{name: "html", mode: ModeHTML},
-		{name: "xml", mode: ModeXML},
-		{name: "invalid", mode: Mode("NONEXISTENT"), wantErr: true},
-	}
+func formatTab(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewTabFormatter(out, config.SkipColumnNames), rows, columnNames, config)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			fn, err := NewFormatter(tt.mode)
-			if tt.wantErr {
-				if err == nil {
-					t.Error("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if fn == nil {
-				t.Error("expected non-nil FormatFunc")
-			}
-		})
-	}
+func formatCSV(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewCSVFormatter(out, config.SkipColumnNames), rows, columnNames, config)
+}
+
+func formatHTML(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewHTMLFormatter(out, config.SkipColumnNames), rows, columnNames, config)
+}
+
+func formatXML(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewXMLFormatter(out, config.SkipColumnNames), rows, columnNames, config)
+}
+
+func formatJSONL(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewJSONLFormatter(out), rows, columnNames, config)
 }
 
 func TestNewStreamingFormatter(t *testing.T) {
@@ -91,25 +73,6 @@ func TestNewStreamingFormatter(t *testing.T) {
 				t.Error("expected non-nil StreamingFormatter")
 			}
 		})
-	}
-}
-
-func TestNewFormatter_RegisteredMode(t *testing.T) {
-	// No t.Parallel(): mutates global registry
-	testMode := Mode("TEST_CUSTOM")
-	RegisterFormatFunc(func(mode Mode) (FormatFunc, error) {
-		return func(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
-			return nil
-		}, nil
-	}, testMode)
-	t.Cleanup(func() { unregisterFormatFunc(testMode) })
-
-	fn, err := NewFormatter(testMode)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if fn == nil {
-		t.Error("expected non-nil FormatFunc from registered mode")
 	}
 }
 

--- a/internal/mycli/format/mode.go
+++ b/internal/mycli/format/mode.go
@@ -2,7 +2,7 @@ package format
 
 // Mode represents the output format mode as a string.
 // Built-in modes are defined as constants below.
-// Custom modes can be registered via RegisterFormatFunc and RegisterStreamingFormatter.
+// Custom streaming modes can be registered via RegisterStreamingFormatter.
 //
 // Mode values use UPPER_SNAKE_CASE to match the enumer-generated strings
 // of enums.DisplayMode, enabling conversion via format.Mode(dm.String()).

--- a/internal/mycli/format/registry.go
+++ b/internal/mycli/format/registry.go
@@ -6,31 +6,15 @@ import (
 	"sync"
 )
 
-// FormatFuncFactory creates a buffered FormatFunc for the given mode.
-// The mode parameter allows a single factory to handle multiple related modes.
-type FormatFuncFactory func(mode Mode) (FormatFunc, error)
-
 // StreamingFormatterFactory creates a StreamingFormatter for the given mode.
 // The mode parameter allows a single factory to handle multiple related modes.
 type StreamingFormatterFactory func(mode Mode, out io.Writer, config FormatConfig) (StreamingFormatter, error)
 
 var (
 	registryMu           sync.RWMutex
-	formatFuncRegistry   = map[Mode]FormatFuncFactory{}
 	streamingFmtRegistry = map[Mode]StreamingFormatterFactory{}
 	valueFormatRegistry  = map[Mode]ValueFormatMode{}
 )
-
-// RegisterFormatFunc registers a FormatFuncFactory for the given modes.
-// This allows external packages to add custom output formats (e.g., SQL export)
-// without the format package depending on their implementation.
-func RegisterFormatFunc(factory FormatFuncFactory, modes ...Mode) {
-	registryMu.Lock()
-	defer registryMu.Unlock()
-	for _, mode := range modes {
-		formatFuncRegistry[mode] = factory
-	}
-}
 
 // RegisterStreamingFormatter registers a StreamingFormatterFactory for the given modes.
 // This allows external packages to add custom streaming output formats
@@ -54,14 +38,6 @@ func RegisterValueFormatMode(vfm ValueFormatMode, modes ...Mode) {
 	}
 }
 
-// lookupFormatFunc looks up a registered FormatFuncFactory for the given mode.
-func lookupFormatFunc(mode Mode) (FormatFuncFactory, bool) {
-	registryMu.RLock()
-	defer registryMu.RUnlock()
-	f, ok := formatFuncRegistry[mode]
-	return f, ok
-}
-
 // lookupStreamingFormatter looks up a registered StreamingFormatterFactory for the given mode.
 func lookupStreamingFormatter(mode Mode) (StreamingFormatterFactory, bool) {
 	registryMu.RLock()
@@ -76,15 +52,6 @@ func lookupValueFormatMode(mode Mode) (ValueFormatMode, bool) {
 	defer registryMu.RUnlock()
 	vfm, ok := valueFormatRegistry[mode]
 	return vfm, ok
-}
-
-// unregisterFormatFunc removes a registered FormatFuncFactory. Used by tests to clean up.
-func unregisterFormatFunc(modes ...Mode) {
-	registryMu.Lock()
-	defer registryMu.Unlock()
-	for _, mode := range modes {
-		delete(formatFuncRegistry, mode)
-	}
 }
 
 // unregisterStreamingFormatter removes a registered StreamingFormatterFactory. Used by tests to clean up.

--- a/internal/mycli/formatsql/formatsql.go
+++ b/internal/mycli/formatsql/formatsql.go
@@ -2,8 +2,8 @@
 // It generates INSERT, INSERT OR IGNORE, and INSERT OR UPDATE statements
 // that can be used for database migration, backup/restore, and test data generation.
 //
-// This package registers its formatters with the format package's registry,
-// allowing it to be used as a plugin without the format package depending on memefish.
+// This package registers its streaming formatter with the format package's registry,
+// allowing it to be used without the format package depending on memefish.
 //
 // Current Design Constraints:
 // - Values are expected to be pre-formatted as SQL literals using spanvalue.LiteralFormatConfig
@@ -31,14 +31,8 @@ const (
 )
 
 func init() {
-	format.RegisterFormatFunc(newFormatSQL, ModeSQLInsert, ModeSQLInsertOrIgnore, ModeSQLInsertOrUpdate)
 	format.RegisterStreamingFormatter(newStreamingFormatterSQL, ModeSQLInsert, ModeSQLInsertOrIgnore, ModeSQLInsertOrUpdate)
 	format.RegisterValueFormatMode(format.SQLLiteralValues, ModeSQLInsert, ModeSQLInsertOrIgnore, ModeSQLInsertOrUpdate)
-}
-
-// newFormatSQL is the FormatFuncFactory for SQL export modes.
-func newFormatSQL(mode format.Mode) (format.FormatFunc, error) {
-	return FormatSQL(mode), nil
 }
 
 // newStreamingFormatterSQL is the StreamingFormatterFactory for SQL export modes.
@@ -452,37 +446,33 @@ func (s *SQLStreamingFormatter) FinishFormat() error {
 	return s.formatter.Finish()
 }
 
-// FormatSQL is the non-streaming formatter for SQL export.
-func FormatSQL(mode format.Mode) format.FormatFunc {
-	return func(out io.Writer, rows []format.Row, columnNames []string, config format.FormatConfig, screenWidth int) error {
-		tableName := config.SQLTableName
+// WriteSQL writes already-buffered SQL literal rows. This exists only for the
+// DUMP buffered fallback used when no real output stream is available.
+func WriteSQL(out io.Writer, rows []format.Row, columnNames []string, config format.FormatConfig, mode format.Mode) error {
+	tableName := config.SQLTableName
 
-		if tableName == "" {
-			return fmt.Errorf("SQL export requires a table name. Auto-detection failed (query may be too complex).\n" +
-				"Options:\n" +
-				"  1. Use DUMP TABLE for full table exports\n" +
-				"  2. Set CLI_SQL_TABLE_NAME explicitly for complex queries\n" +
-				"  3. Ensure your query matches: SELECT * FROM table_name [WHERE/ORDER BY/LIMIT]")
-		}
-
-		formatter, err := NewSQLFormatter(out, mode, tableName, config.SQLBatchSize)
-		if err != nil {
-			return err
-		}
-
-		// Write header (will validate column names)
-		if err := formatter.WriteHeader(columnNames); err != nil {
-			return err
-		}
-
-		// Write all rows
-		for _, row := range rows {
-			if err := formatter.WriteRow(format.Texts(row)); err != nil {
-				return err
-			}
-		}
-
-		// Finish and flush
-		return formatter.Finish()
+	if tableName == "" {
+		return fmt.Errorf("SQL export requires a table name. Auto-detection failed (query may be too complex).\n" +
+			"Options:\n" +
+			"  1. Use DUMP TABLE for full table exports\n" +
+			"  2. Set CLI_SQL_TABLE_NAME explicitly for complex queries\n" +
+			"  3. Ensure your query matches: SELECT * FROM table_name [WHERE/ORDER BY/LIMIT]")
 	}
+
+	formatter, err := NewSQLFormatter(out, mode, tableName, config.SQLBatchSize)
+	if err != nil {
+		return err
+	}
+
+	if err := formatter.WriteHeader(columnNames); err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		if err := formatter.WriteRow(format.Texts(row)); err != nil {
+			return err
+		}
+	}
+
+	return formatter.Finish()
 }

--- a/internal/mycli/formatsql/formatsql.go
+++ b/internal/mycli/formatsql/formatsql.go
@@ -445,34 +445,3 @@ func (s *SQLStreamingFormatter) WriteRow(row format.Row) error {
 func (s *SQLStreamingFormatter) FinishFormat() error {
 	return s.formatter.Finish()
 }
-
-// WriteSQL writes already-buffered SQL literal rows. This exists only for the
-// DUMP buffered fallback used when no real output stream is available.
-func WriteSQL(out io.Writer, rows []format.Row, columnNames []string, config format.FormatConfig, mode format.Mode) error {
-	tableName := config.SQLTableName
-
-	if tableName == "" {
-		return fmt.Errorf("SQL export requires a table name. Auto-detection failed (query may be too complex).\n" +
-			"Options:\n" +
-			"  1. Use DUMP TABLE for full table exports\n" +
-			"  2. Set CLI_SQL_TABLE_NAME explicitly for complex queries\n" +
-			"  3. Ensure your query matches: SELECT * FROM table_name [WHERE/ORDER BY/LIMIT]")
-	}
-
-	formatter, err := NewSQLFormatter(out, mode, tableName, config.SQLBatchSize)
-	if err != nil {
-		return err
-	}
-
-	if err := formatter.WriteHeader(columnNames); err != nil {
-		return err
-	}
-
-	for _, row := range rows {
-		if err := formatter.WriteRow(format.Texts(row)); err != nil {
-			return err
-		}
-	}
-
-	return formatter.Finish()
-}

--- a/internal/mycli/integration_dump_test.go
+++ b/internal/mycli/integration_dump_test.go
@@ -386,13 +386,13 @@ func TestDumpWithForeignKeys(t *testing.T) {
 	}
 
 	// Check INSERT statements
-	if strings.Count(outputStr, "INSERT INTO Venues") < 2 {
+	if strings.Count(outputStr, "INSERT INTO `Venues`") < 2 {
 		t.Errorf("Expected at least 2 INSERT statements for Venues")
 	}
-	if strings.Count(outputStr, "INSERT INTO Artists") < 2 {
+	if strings.Count(outputStr, "INSERT INTO `Artists`") < 2 {
 		t.Errorf("Expected at least 2 INSERT statements for Artists")
 	}
-	if strings.Count(outputStr, "INSERT INTO Concerts") < 2 {
+	if strings.Count(outputStr, "INSERT INTO `Concerts`") < 2 {
 		t.Errorf("Expected at least 2 INSERT statements for Concerts")
 	}
 }
@@ -560,10 +560,9 @@ func TestDumpWithGeneratedColumns(t *testing.T) {
 	// Expected output with only writable columns
 	// The generated INSERT should include: UserId, FirstName, LastName, Order, CreatedAt
 	// It should NOT include: FullName, SearchTokens, ComputedValue (all generated columns)
-	// Note: The formatter only quotes identifiers when necessary (e.g., reserved words like "Order")
 	expectedRows := []Row{
 		toRow("-- Data for table Users"),
-		toRow("INSERT INTO Users (UserId, FirstName, LastName, `Order`, CreatedAt) VALUES (1, \"John\", \"Doe\", 10, TIMESTAMP \"2024-01-01T12:00:00Z\");"),
+		toRow("INSERT INTO `Users` (`UserId`, `FirstName`, `LastName`, `Order`, `CreatedAt`) VALUES (1, \"John\", \"Doe\", 10, TIMESTAMP \"2024-01-01T12:00:00Z\");"),
 		toRow(""),
 	}
 

--- a/internal/mycli/integration_sql_export_test.go
+++ b/internal/mycli/integration_sql_export_test.go
@@ -20,6 +20,21 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+func executeSQLExportForTest(t *testing.T, ctx context.Context, session *Session, query string) (*Result, string, error) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	session.systemVariables.StreamManager = streamio.NewStreamManager(nil, &buf, &buf)
+
+	stmt, err := BuildStatement(query)
+	if err != nil {
+		t.Fatalf("Failed to build export statement: %v", err)
+	}
+
+	result, err := stmt.Execute(ctx, session)
+	return result, buf.String(), err
+}
+
 func TestSQLExportIntegration(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -140,16 +155,11 @@ CREATE TABLE DestTable (
 			session.systemVariables.Display.CLIFormat = tt.exportMode
 			session.systemVariables.Display.SQLTableName = tt.tableName
 			session.systemVariables.Display.SQLBatchSize = tt.batchSize
-			// Force buffered mode for testing
+			// SQL export is a non-table format, so it streams even when table streaming is disabled.
 			session.systemVariables.Query.StreamingMode = enums.StreamingModeFalse
 
-			// Execute the query - with SQL format set, it should use proper SQL literal formatting
-			stmt, err := BuildStatement(tt.query)
-			if err != nil {
-				t.Fatalf("Failed to build export statement: %v", err)
-			}
-
-			result, err := stmt.Execute(ctx, session)
+			// Execute the query - with SQL format set, it should use proper SQL literal formatting.
+			result, sqlOutput, err := executeSQLExportForTest(t, ctx, session, tt.query)
 			if err != nil {
 				t.Fatalf("Failed to execute export query: %v", err)
 			}
@@ -157,14 +167,6 @@ CREATE TABLE DestTable (
 			// Debug: Log result details
 			t.Logf("Query result: rows=%d, header=%v", len(result.Rows), result.TableHeader)
 
-			// Capture the SQL export output
-			var buf bytes.Buffer
-			err = printTableData(session.systemVariables, 0, &buf, result)
-			if err != nil {
-				t.Fatalf("Failed to format SQL export: %v", err)
-			}
-
-			sqlOutput := buf.String()
 			t.Logf("Generated SQL:\n%s", sqlOutput)
 
 			// Debug: Log if SQL output is empty
@@ -267,26 +269,13 @@ CREATE TABLE ComplexDest (
 	session.systemVariables.Display.CLIFormat = enums.DisplayModeSQLInsert
 	session.systemVariables.Display.SQLTableName = "ComplexDest"
 	session.systemVariables.Display.SQLBatchSize = 0
-	session.systemVariables.Query.StreamingMode = enums.StreamingModeFalse // Force buffered mode
+	session.systemVariables.Query.StreamingMode = enums.StreamingModeFalse
 
-	stmt, err := BuildStatement("SELECT * FROM ComplexSource ORDER BY id")
-	if err != nil {
-		t.Fatalf("Failed to build statement: %v", err)
-	}
-
-	result, err := stmt.Execute(ctx, session)
+	_, sqlOutput, err := executeSQLExportForTest(t, ctx, session, "SELECT * FROM ComplexSource ORDER BY id")
 	if err != nil {
 		t.Fatalf("Failed to execute query: %v", err)
 	}
 
-	// Generate SQL export
-	var buf bytes.Buffer
-	err = printTableData(session.systemVariables, 0, &buf, result)
-	if err != nil {
-		t.Fatalf("Failed to format SQL export: %v", err)
-	}
-
-	sqlOutput := buf.String()
 	t.Logf("SQL export with complex types:\n%s", sqlOutput)
 
 	// Execute the generated SQL to import data
@@ -589,36 +578,13 @@ func TestSQLExportWithUnnamedColumns(t *testing.T) {
 			session.systemVariables.Display.SQLBatchSize = 0
 			session.systemVariables.Query.StreamingMode = enums.StreamingModeFalse
 
-			stmt, err := BuildStatement(tc.query)
-			if err != nil {
-				t.Fatalf("Failed to build statement: %v", err)
-			}
-
-			result, err := stmt.Execute(ctx, session)
-			if err != nil {
-				t.Fatalf("Failed to execute query: %v", err)
-			}
-
-			// Extract column names using the same method as printTableData
-			columnNames := extractTableColumnNames(result.TableHeader)
+			result, sqlOutput, err := executeSQLExportForTest(t, ctx, session, tc.query)
 
 			t.Logf("Test: %s", tc.desc)
 			t.Logf("Query: %s", tc.query)
-			t.Logf("Column names: %v", columnNames)
-			t.Logf("Row count: %d", len(result.Rows))
-
-			// Check for unnamed columns (empty strings)
-			unnamedCount := 0
-			for i, name := range columnNames {
-				if name == "" {
-					t.Logf("  Column %d is unnamed", i)
-					unnamedCount++
-				}
+			if result != nil {
+				t.Logf("Row count: %d", len(result.Rows))
 			}
-
-			// Try to format as SQL
-			var buf bytes.Buffer
-			err = printTableData(session.systemVariables, 0, &buf, result)
 
 			if tc.expectErr {
 				if err == nil {
@@ -634,7 +600,6 @@ func TestSQLExportWithUnnamedColumns(t *testing.T) {
 				if err != nil {
 					t.Errorf("Unexpected error formatting SQL: %v", err)
 				} else {
-					sqlOutput := buf.String()
 					if sqlOutput == "" {
 						t.Errorf("Expected SQL output but got empty string")
 					} else {
@@ -870,40 +835,21 @@ CREATE TABLE TestTable (
 			t.Logf("Testing: %s", tt.description)
 			t.Logf("Query: %s", tt.query)
 
-			// Execute the query
-			stmt, err := BuildStatement(tt.query)
-			if err != nil {
-				t.Fatalf("Failed to build statement: %v", err)
-			}
-
-			result, err := stmt.Execute(ctx, session)
+			result, sqlOutput, err := executeSQLExportForTest(t, ctx, session, tt.query)
 
 			if tt.shouldAutoDetect {
 				if err != nil {
 					t.Fatalf("Expected successful execution with auto-detection, got error: %v", err)
 				}
 
-				// Check if we got valid result with rows
-				if result == nil || (len(result.Rows) == 0 && !result.Streamed) {
-					t.Fatalf("Expected result with data but got empty result")
+				if result == nil || !result.Streamed {
+					t.Fatalf("Expected streamed SQL export result, got %#v", result)
 				}
 
-				// Test buffered mode: format the result using printTableData
-				// This verifies that auto-detected table name is preserved in Result struct
-				var buf bytes.Buffer
-				session.systemVariables.StreamManager = streamio.NewStreamManager(nil, &buf, &buf)
-
-				// Format the buffered result
-				err = printTableData(session.systemVariables, 0, &buf, result)
-				if err != nil {
-					t.Fatalf("Failed to format buffered result: %v", err)
-				}
-
-				sqlOutput := buf.String()
 				t.Logf("Generated SQL with auto-detected table:\n%s", sqlOutput)
 
 				// Verify the output contains the expected table name
-				expectedPattern := fmt.Sprintf("INTO %s", tt.expectedTable)
+				expectedPattern := fmt.Sprintf("INTO `%s`", tt.expectedTable)
 				if !strings.Contains(sqlOutput, expectedPattern) {
 					t.Errorf("Expected table name %s in output, but got:\n%s", tt.expectedTable, sqlOutput)
 				}
@@ -929,22 +875,8 @@ CREATE TABLE TestTable (
 					// Error during execution is expected
 					t.Logf("Got expected error during execution: %v", err)
 				} else {
-					// If execution succeeded, formatting should fail
-					var buf bytes.Buffer
-					err = printTableData(session.systemVariables, 0, &buf, result)
-					if err == nil {
-						t.Errorf("Expected error without table name, but formatting succeeded")
-						t.Logf("Unexpected output: %s", buf.String())
-					} else {
-						t.Logf("Got expected error during formatting: %v", err)
-						// Check if error message is helpful
-						errStr := err.Error()
-						if !strings.Contains(errStr, "SQL export requires a table name") &&
-							!strings.Contains(errStr, "Auto-detection failed") &&
-							!strings.Contains(errStr, "CLI_SQL_TABLE_NAME") {
-							t.Logf("Warning: Error message could be more helpful: %v", err)
-						}
-					}
+					t.Errorf("Expected error without table name, but execution succeeded")
+					t.Logf("Unexpected output: %s", sqlOutput)
 				}
 			}
 		})
@@ -1026,51 +958,28 @@ func TestSQLExportAutoDetectionWithComplexQueries(t *testing.T) {
 			t.Logf("Testing: %s", tc.desc)
 			t.Logf("Query: %s", tc.query)
 
-			stmt, err := BuildStatement(tc.query)
-			if err != nil {
-				t.Fatalf("Failed to build statement: %v", err)
-			}
-
-			result, err := stmt.Execute(ctx, session)
+			_, sqlOutput, err := executeSQLExportForTest(t, ctx, session, tc.query)
 			if err != nil {
 				// Error during execution is acceptable
 				t.Logf("Error during execution (expected): %v", err)
 			} else {
-				// If execution succeeded, formatting should fail
-				var buf bytes.Buffer
-				err = printTableData(session.systemVariables, 0, &buf, result)
-				if err == nil {
-					t.Errorf("Expected error for complex query without table name, but succeeded")
-					t.Logf("Unexpected output: %s", buf.String())
-				} else {
-					t.Logf("Got expected error: %v", err)
-					// Verify error message mentions the need for explicit table name
-					if !strings.Contains(err.Error(), "CLI_SQL_TABLE_NAME") {
-						t.Logf("Error message should mention CLI_SQL_TABLE_NAME")
-					}
-				}
+				t.Errorf("Expected error for complex query without table name, but succeeded")
+				t.Logf("Unexpected output: %s", sqlOutput)
 			}
 
 			// Now test with explicit table name - should work
 			session.systemVariables.Display.SQLTableName = "ExportTable"
 
 			// Re-execute with explicit table name
-			result, err = stmt.Execute(ctx, session)
+			_, sqlOutput, err = executeSQLExportForTest(t, ctx, session, tc.query)
 			if err != nil {
 				t.Logf("Note: Query failed even with explicit table name: %v", err)
 				// Some queries like JOINs may still fail for other reasons
 			} else {
-				var buf bytes.Buffer
-				err = printTableData(session.systemVariables, 0, &buf, result)
-				if err != nil {
-					t.Logf("Note: Formatting failed even with explicit table name: %v", err)
+				if strings.Contains(sqlOutput, "INSERT INTO `ExportTable`") {
+					t.Logf("Success with explicit table name: Generated %d bytes of SQL", len(sqlOutput))
 				} else {
-					sqlOutput := buf.String()
-					if strings.Contains(sqlOutput, "INSERT INTO ExportTable") {
-						t.Logf("Success with explicit table name: Generated %d bytes of SQL", len(sqlOutput))
-					} else {
-						t.Errorf("Expected INSERT INTO ExportTable in output")
-					}
+					t.Errorf("Expected INSERT INTO `ExportTable` in output")
 				}
 			}
 		})

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -291,6 +291,11 @@ func compareResult[T any](t *testing.T, got T, expected T, customCmpOptions ...c
 		cmpopts.IgnoreFields(Result{}, "CommitStats"),
 		// Metrics are collected but not part of test expectations
 		cmpopts.IgnoreFields(Result{}, "Metrics"),
+		// DML THEN RETURN keeps output atomic by rendering rows before implicit
+		// commit and no longer exposes those rows through Result.Rows.
+		cmp.FilterValues(func(x, y Result) bool {
+			return x.HasRenderedOutput || y.HasRenderedOutput
+		}, cmpopts.IgnoreFields(Result{}, "Rows", "RenderedOutput", "HasRenderedOutput")),
 		cmpopts.EquateEmpty(),
 		protocmp.Transform(),
 	)

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -291,11 +291,9 @@ func compareResult[T any](t *testing.T, got T, expected T, customCmpOptions ...c
 		cmpopts.IgnoreFields(Result{}, "CommitStats"),
 		// Metrics are collected but not part of test expectations
 		cmpopts.IgnoreFields(Result{}, "Metrics"),
-		// DML THEN RETURN keeps output atomic by rendering rows before implicit
-		// commit and no longer exposes those rows through Result.Rows.
-		cmp.FilterValues(func(x, y Result) bool {
-			return x.HasRenderedOutput || y.HasRenderedOutput
-		}, cmpopts.IgnoreFields(Result{}, "Rows", "RenderedOutput", "HasRenderedOutput")),
+		// Rendered output is a display artifact. Tests assert the structural
+		// signal with HasRenderedOutput instead.
+		cmpopts.IgnoreFields(Result{}, "RenderedOutput"),
 		cmpopts.EquateEmpty(),
 		protocmp.Transform(),
 	)
@@ -715,13 +713,10 @@ func TestTransactionStatements(t *testing.T) {
 				{
 					"INSERT INTO TestTable (id, active) VALUES (1, true), (2, false) THEN RETURN *",
 					&Result{
-						IsExecutedDML: true,
-						AffectedRows:  2,
-						Rows: sliceOf(
-							toRow("1", "true"),
-							toRow("2", "false"),
-						),
-						TableHeader: toTableHeader(testTableRowType),
+						IsExecutedDML:     true,
+						AffectedRows:      2,
+						HasRenderedOutput: true,
+						TableHeader:       toTableHeader(testTableRowType),
 					},
 				},
 				srEmpty("ROLLBACK"),
@@ -787,10 +782,10 @@ func TestTransactionStatements(t *testing.T) {
 				{
 					"DELETE TestTable WHERE TRUE THEN RETURN *",
 					&Result{
-						IsExecutedDML: true,
-						AffectedRows:  2,
-						Rows:          sliceOf(toRow("1", "true"), toRow("2", "false")),
-						TableHeader:   toTableHeader(testTableRowType),
+						IsExecutedDML:     true,
+						AffectedRows:      2,
+						HasRenderedOutput: true,
+						TableHeader:       toTableHeader(testTableRowType),
 					},
 				},
 				srEmpty("ROLLBACK"),
@@ -799,10 +794,10 @@ func TestTransactionStatements(t *testing.T) {
 				{
 					"DELETE TestTable WHERE TRUE THEN RETURN *",
 					&Result{
-						IsExecutedDML: true,
-						AffectedRows:  2,
-						Rows:          sliceOf(toRow("1", "true"), toRow("2", "false")),
-						TableHeader:   toTableHeader(testTableRowType),
+						IsExecutedDML:     true,
+						AffectedRows:      2,
+						HasRenderedOutput: true,
+						TableHeader:       toTableHeader(testTableRowType),
 					},
 				},
 				srEmpty("ROLLBACK"),
@@ -810,10 +805,10 @@ func TestTransactionStatements(t *testing.T) {
 				{
 					"DELETE TestTable WHERE TRUE THEN RETURN *",
 					&Result{
-						IsExecutedDML: true,
-						AffectedRows:  2,
-						Rows:          sliceOf(toRow("1", "true"), toRow("2", "false")),
-						TableHeader:   toTableHeader(testTableRowType),
+						IsExecutedDML:     true,
+						AffectedRows:      2,
+						HasRenderedOutput: true,
+						TableHeader:       toTableHeader(testTableRowType),
 					},
 				},
 				srEmpty("COMMIT"),

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -173,13 +173,19 @@ type QueryIndexAdvice struct {
 }
 
 type Result struct {
-	ColumnAlign      []tw.Align // optional
-	Rows             []Row
-	Predicates       []string
-	Appendices       []ResultAppendix
-	AffectedRows     int
-	AffectedRowsType rowCountType
-	Stats            QueryStats
+	ColumnAlign []tw.Align // optional
+	Rows        []Row
+
+	// RenderedOutput holds pre-rendered table data that should be written before
+	// appendices and result lines. Used when output must stay atomic until after
+	// execution side effects such as implicit DML commit have succeeded.
+	RenderedOutput    []byte
+	HasRenderedOutput bool
+	Predicates        []string
+	Appendices        []ResultAppendix
+	AffectedRows      int
+	AffectedRowsType  rowCountType
+	Stats             QueryStats
 
 	// IsExecutedDML indicates this is an executed DML statement (INSERT/UPDATE/DELETE) that can report affected rows
 	IsExecutedDML bool

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -243,7 +243,7 @@ func writeResultRows(out io.Writer, rows []Row) error {
 func executeDumpTableIntoBuffer(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, selectQuery, table string) (*Result, string, error) {
 	var buf bytes.Buffer
 	originalStreamManager := session.systemVariables.StreamManager
-	session.systemVariables.StreamManager = streamio.NewStreamManager(nil, &buf, &buf)
+	session.systemVariables.StreamManager = streamio.NewStreamManager(nil, &buf, originalStreamManager.GetErrStream())
 	defer func() {
 		session.systemVariables.StreamManager = originalStreamManager
 	}()

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -10,7 +10,7 @@ import (
 	"cloud.google.com/go/spanner"
 	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/spanner-mycli/enums"
-	"github.com/apstndb/spanner-mycli/internal/mycli/formatsql"
+	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
 	"github.com/apstndb/spanvalue"
 )
 
@@ -200,27 +200,16 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 			// Build SELECT query with explicit column list
 			selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, columns, table)
 
-			// Execute query using the transaction variant since we're already within a transaction
-			dataResult, err := executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
-				enums.DisplayModeSQLInsert, enums.StreamingModeFalse, table)
+			dataResult, dumpOutput, err := executeDumpTableBuffered(ctx, session, txn, selectQuery, table)
 			if err != nil {
 				return fmt.Errorf("export table %s: %w", table, err)
 			}
 
-			// Format the result for buffered output
 			result.Rows = append(result.Rows, toRow(fmt.Sprintf("-- Data for table %s", table)))
 
-			if len(dataResult.Rows) > 0 {
-				var buf bytes.Buffer
-				config := session.systemVariables.toFormatConfig()
-				config.SQLTableName = table
-				if err := formatsql.WriteSQL(&buf, dataResult.Rows, extractTableColumnNames(dataResult.TableHeader), config, formatsql.ModeSQLInsert); err != nil {
-					return fmt.Errorf("failed to format SQL for table %s: %w", table, err)
-				}
-				if buf.Len() > 0 {
-					for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
-						result.Rows = append(result.Rows, toRow(line))
-					}
+			if dumpOutput != "" {
+				for _, line := range strings.Split(strings.TrimRight(dumpOutput, "\n"), "\n") {
+					result.Rows = append(result.Rows, toRow(line))
 				}
 			}
 
@@ -249,6 +238,19 @@ func writeResultRows(out io.Writer, rows []Row) error {
 		}
 	}
 	return nil
+}
+
+func executeDumpTableBuffered(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, selectQuery, table string) (*Result, string, error) {
+	var buf bytes.Buffer
+	originalStreamManager := session.systemVariables.StreamManager
+	session.systemVariables.StreamManager = streamio.NewStreamManager(nil, &buf, &buf)
+	defer func() {
+		session.systemVariables.StreamManager = originalStreamManager
+	}()
+
+	result, err := executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
+		enums.DisplayModeSQLInsert, enums.StreamingModeFalse, table)
+	return result, buf.String(), err
 }
 
 // executeDumpStreaming performs dump operation with streaming output.

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -64,8 +64,9 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 		return nil, fmt.Errorf("DUMP statements are not yet supported for PostgreSQL dialect databases")
 	}
 	outStream := session.systemVariables.StreamManager.GetWriter()
-	// Use streaming unless: output is nil/io.Discard (tests) or streaming explicitly disabled
-	if outStream != nil && outStream != io.Discard && session.systemVariables.Query.StreamingMode != enums.StreamingModeFalse {
+	// Use streaming whenever there is a real output stream. DUMP output is not a
+	// table layout, so CLI_STREAMING=false should not force row buffering here.
+	if outStream != nil && outStream != io.Discard {
 		return executeDumpStreaming(ctx, session, mode, specificTables, outStream)
 	}
 	return executeDumpBuffered(ctx, session, mode, specificTables)
@@ -213,7 +214,7 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 				var buf bytes.Buffer
 				config := session.systemVariables.toFormatConfig()
 				config.SQLTableName = table
-				if err := formatsql.FormatSQL(formatsql.ModeSQLInsert)(&buf, dataResult.Rows, extractTableColumnNames(dataResult.TableHeader), config, 0); err != nil {
+				if err := formatsql.WriteSQL(&buf, dataResult.Rows, extractTableColumnNames(dataResult.TableHeader), config, formatsql.ModeSQLInsert); err != nil {
 					return fmt.Errorf("failed to format SQL for table %s: %w", table, err)
 				}
 				if buf.Len() > 0 {

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -200,7 +200,7 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 			// Build SELECT query with explicit column list
 			selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, columns, table)
 
-			dataResult, dumpOutput, err := executeDumpTableBuffered(ctx, session, txn, selectQuery, table)
+			dataResult, dumpOutput, err := executeDumpTableIntoBuffer(ctx, session, txn, selectQuery, table)
 			if err != nil {
 				return fmt.Errorf("export table %s: %w", table, err)
 			}
@@ -240,7 +240,7 @@ func writeResultRows(out io.Writer, rows []Row) error {
 	return nil
 }
 
-func executeDumpTableBuffered(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, selectQuery, table string) (*Result, string, error) {
+func executeDumpTableIntoBuffer(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, selectQuery, table string) (*Result, string, error) {
 	var buf bytes.Buffer
 	originalStreamManager := session.systemVariables.StreamManager
 	session.systemVariables.StreamManager = streamio.NewStreamManager(nil, &buf, &buf)
@@ -248,8 +248,10 @@ func executeDumpTableBuffered(ctx context.Context, session *Session, txn *spanne
 		session.systemVariables.StreamManager = originalStreamManager
 	}()
 
+	// SQL export is a non-table format and streams into the temporary
+	// StreamManager above; that capture is what makes this DUMP path buffered.
 	result, err := executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
-		enums.DisplayModeSQLInsert, enums.StreamingModeFalse, table)
+		enums.DisplayModeSQLInsert, enums.StreamingModeTrue, table)
 	return result, buf.String(), err
 }
 

--- a/internal/mycli/streaming.go
+++ b/internal/mycli/streaming.go
@@ -10,7 +10,10 @@ import (
 // This delegates to createStreamingProcessor to maintain a single source of truth for the streaming decision logic.
 func shouldUseStreaming(sysVars *systemVariables) bool {
 	// Use a dummy writer to test if streaming would be enabled
-	processor, _ := createStreamingProcessor(sysVars, io.Discard, 80)
+	processor, err := createStreamingProcessor(sysVars, io.Discard, 80)
+	if err != nil {
+		return false
+	}
 	return processor != nil
 }
 

--- a/internal/mycli/streaming_integration_test.go
+++ b/internal/mycli/streaming_integration_test.go
@@ -15,7 +15,12 @@ func TestShouldUseStreaming(t *testing.T) {
 	}
 
 	if shouldUseStreaming(sysVars) {
-		t.Error("Streaming should be disabled when StreamingMode is FALSE")
+		t.Error("Streaming should be disabled for table output when StreamingMode is FALSE")
+	}
+
+	sysVars.Display.CLIFormat = enums.DisplayModeCSV
+	if !shouldUseStreaming(sysVars) {
+		t.Error("Streaming should stay enabled for non-table output when StreamingMode is FALSE")
 	}
 
 	sysVars.Query.StreamingMode = enums.StreamingModeTrue

--- a/internal/mycli/streaming_test.go
+++ b/internal/mycli/streaming_test.go
@@ -181,9 +181,7 @@ func TestBufferedVsStreaming(t *testing.T) {
 	// Buffered output
 	var bufBuffered bytes.Buffer
 	config := sysVars.toFormatConfig()
-	csvFormatter, err := format.NewFormatter(format.ModeCSV)
-	assert.NoError(t, err)
-	err = csvFormatter(&bufBuffered, rows, columnNames, config, 0)
+	err := format.ExecuteWithFormatter(format.NewCSVFormatter(&bufBuffered, sysVars.Display.SkipColumnNames), rows, columnNames, config)
 	assert.NoError(t, err)
 
 	// Streaming output

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -219,7 +219,7 @@ func (r *VarRegistry) registerAll() {
 	r.Register("CLI_FUZZY_FINDER_OPTIONS", StringVar(&sv.Feature.FuzzyFinderOptions,
 		"Additional fzf options passed to the fuzzy finder. Appended after built-in defaults, so user options take precedence. Example: --color=dark --no-select-1"))
 	r.Register("CLI_STREAMING", StreamingModeVar(&sv.Query.StreamingMode,
-		"Controls streaming output mode: AUTO (format-dependent), TRUE (always stream), FALSE (never stream). Default is AUTO."))
+		"Controls table streaming output mode: AUTO/FALSE buffer table output for layout quality, TRUE streams table output. Non-table formats always stream. Default is AUTO."))
 	r.Register("CLI_STYLED_OUTPUT", StyledModeVar(&sv.Display.StyledOutput,
 		"Controls ANSI styling in table output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled). Default is AUTO."))
 	r.Register("CLI_WIDTH_STRATEGY", WidthStrategyVar(&sv.Display.WidthStrategy,


### PR DESCRIPTION
## Summary

- Make `CLI_STREAMING` control only table layout streaming.
- Stream non-table query formats even when table streaming is disabled.
- Remove the old buffered formatter registry and route SQL export/DUMP fallback through the streaming SQL writer.
- Keep DML THEN RETURN output atomic by returning pre-rendered output instead of exposing returned rows.
- Update SQL export, DUMP, transaction, and formatter tests for the new output paths.

## Verification

- `make check`
- Fetched `origin/main`; this branch is 3 commits ahead and 0 commits behind.
