### PR TITLE
Use spanvalue protofmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spantype v0.3.11
-	github.com/apstndb/spanvalue v0.5.0
+	github.com/apstndb/spanvalue v0.5.1
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -2501,8 +2501,8 @@ github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.5.0 h1:91RfaKX6WRDNDQrNmo9lO6O0sUS0x+4YxRBylDfS0xM=
-github.com/apstndb/spanvalue v0.5.0/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
+github.com/apstndb/spanvalue v0.5.1 h1:+XvHy9YSXAtvlr5LNUWR68YTIg/mCEbQzeQcjxPcaT4=
+github.com/apstndb/spanvalue v0.5.1/go.mod h1:xKnvCW0eC+EtZfICvyesMpr/PJTY8tXjcWR+i0x0dZw=
 github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
 github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=

--- a/internal/mycli/decoder/decoder.go
+++ b/internal/mycli/decoder/decoder.go
@@ -35,6 +35,8 @@ func DecodeRow(row *spanner.Row) ([]string, error) {
 // If fds is nil, it returns a config without custom proto/enum support.
 // The multiline parameter controls the formatting of protobuf messages.
 func FormatConfigWithProto(fds *descriptorpb.FileDescriptorSet, multiline bool) (*spanvalue.FormatConfig, error) {
+	// protofmt preserves the old nil descriptor behavior: nil builds an empty
+	// resolver, so PROTO/ENUM plugins fall through to the default formatter.
 	resolver, err := protofmt.ProtoEnumResolverFromFileDescriptorSet(fds)
 	if err != nil {
 		return nil, err

--- a/internal/mycli/decoder/decoder.go
+++ b/internal/mycli/decoder/decoder.go
@@ -17,23 +17,13 @@
 package decoder
 
 import (
-	"cmp"
-	"encoding/base64"
-	"errors"
-	"strconv"
-	"strings"
-
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spantype"
 	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/protofmt"
 	"google.golang.org/protobuf/encoding/prototext"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protodesc"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
-	"google.golang.org/protobuf/types/dynamicpb"
 )
 
 func DecodeRow(row *spanner.Row) ([]string, error) {
@@ -45,7 +35,7 @@ func DecodeRow(row *spanner.Row) ([]string, error) {
 // If fds is nil, it returns a config without custom proto/enum support.
 // The multiline parameter controls the formatting of protobuf messages.
 func FormatConfigWithProto(fds *descriptorpb.FileDescriptorSet, multiline bool) (*spanvalue.FormatConfig, error) {
-	types, err := dynamicTypesByFDS(fds)
+	resolver, err := protofmt.ProtoEnumResolverFromFileDescriptorSet(fds)
 	if err != nil {
 		return nil, err
 	}
@@ -53,85 +43,15 @@ func FormatConfigWithProto(fds *descriptorpb.FileDescriptorSet, multiline bool) 
 	fc := spanvalue.SpannerCLICompatibleFormatConfig().Clone()
 	fc.FormatComplexPlugins = append(
 		[]spanvalue.FormatComplexFunc{
-			formatProto(types, multiline),
-			formatEnum(types),
+			protofmt.FormatProtoTextValue(protofmt.ProtoTextValueOptions{
+				Resolver: resolver,
+				Marshal:  prototext.MarshalOptions{Multiline: multiline},
+			}),
+			protofmt.FormatEnumNameValue(protofmt.EnumNameValueOptions{Resolver: resolver}),
 		},
 		fc.FormatComplexPlugins...,
 	)
 	return fc, nil
-}
-
-func dynamicTypesByFDS(fds *descriptorpb.FileDescriptorSet) (*dynamicpb.Types, error) {
-	if fds == nil {
-		return dynamicpb.NewTypes(nil), nil
-	}
-
-	files, err := protodesc.NewFiles(fds)
-	if err != nil {
-		return nil, err
-	}
-
-	return dynamicpb.NewTypes(files), nil
-}
-
-type protoEnumResolver interface {
-	protoregistry.MessageTypeResolver
-	FindEnumByName(protoreflect.FullName) (protoreflect.EnumType, error)
-}
-
-var (
-	_ protoEnumResolver = (*dynamicpb.Types)(nil)
-	_ protoEnumResolver = (*protoregistry.Types)(nil)
-)
-
-func formatProto(types protoEnumResolver, multiline bool) func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
-	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
-		if value.Type.GetCode() != sppb.TypeCode_PROTO {
-			return "", spanvalue.ErrFallthrough
-		}
-
-		messageType, err := types.FindMessageByName(protoreflect.FullName(value.Type.GetProtoTypeFqn()))
-		if errors.Is(err, protoregistry.NotFound) {
-			return "", spanvalue.ErrFallthrough
-		} else if err != nil {
-			return "", err
-		}
-
-		b, err := base64.StdEncoding.DecodeString(value.Value.GetStringValue())
-		if err != nil {
-			return "", err
-		}
-
-		m := messageType.New()
-		if err = proto.Unmarshal(b, m.Interface()); err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(prototext.MarshalOptions{Multiline: multiline}.Format(m.Interface())), nil
-	}
-}
-
-func formatEnum(types protoEnumResolver) func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
-	return func(formatter spanvalue.Formatter, value spanner.GenericColumnValue, toplevel bool) (string, error) {
-		if value.Type.GetCode() != sppb.TypeCode_ENUM {
-			return "", spanvalue.ErrFallthrough
-		}
-
-		enumType, err := types.FindEnumByName(protoreflect.FullName(value.Type.GetProtoTypeFqn()))
-		if errors.Is(err, protoregistry.NotFound) {
-			return "", spanvalue.ErrFallthrough
-		} else if err != nil {
-			return "", err
-		}
-
-		n, err := strconv.ParseInt(value.Value.GetStringValue(), 10, 64)
-		if err != nil {
-			return "", err
-		}
-
-		return cmp.Or(
-			string(enumType.Descriptor().Values().ByNumber(protoreflect.EnumNumber(n)).Name()),
-			value.Value.GetStringValue()), nil
-	}
 }
 
 // FormatTypeSimple is format type for headers.


### PR DESCRIPTION
## Summary

- update `github.com/apstndb/spanvalue` from `v0.5.0` to `v0.5.1`
- replace spanner-mycli's local PROTO/ENUM display plugins with `spanvalue/protofmt`
- remove local descriptor resolver construction, base64 decoding, proto unmarshalling, and enum lookup code now covered by spanvalue

## Verification

- `go test ./internal/mycli/decoder`
- `make check`
