### PR TITLE
Add leftover pending-review check to review commands

### DIFF
--- a/.claude/commands/review-respond.md
+++ b/.claude/commands/review-respond.md
@@ -53,5 +53,23 @@ go tool gh-helper threads reply THREAD_ID --resolve \
 
 Note: Even threads marked as "outdated" should be replied to and resolved, as they may contain valuable feedback that was addressed.
 
-3. After all threads are resolved, request a new review:
+3. Verify nothing was left as an unsubmitted (PENDING) review:
+
+`gh-helper threads reply --resolve` resolves the thread, but if a reply ends up batched into a *pending* review (e.g., an interrupted submit) instead of being posted directly, the reply stays invisible until that review is submitted — leaving "resolved threads with no visible reply." Check for leftover pending reviews (GitHub only lists your own):
+
+!PR=$(gh pr view --json number -q .number) && gh api --paginate "repos/{owner}/{repo}/pulls/$PR/reviews" --jq '[.[] | select(.state=="PENDING")] | {pendingReviews: map({id, html_url})}'
+
+If `pendingReviews` is non-empty, inspect each review's drafted comments, then submit it so the replies become visible:
+
+```bash
+# inspect what would be published first
+gh api "repos/{owner}/{repo}/pulls/$PR/reviews/<REVIEW_ID>/comments" \
+  --jq '.[] | {in_reply_to_id, body_head: (.body[0:80])}'
+# then submit (publishes the drafted replies; does not change resolution)
+gh api -X POST "repos/{owner}/{repo}/pulls/$PR/reviews/<REVIEW_ID>/events" -f event=COMMENT
+```
+
+Proceed only once `pendingReviews` is empty (`[]`).
+
+4. After all threads are resolved, request a new review:
 !go tool gh-helper reviews wait --request-review

--- a/.claude/commands/review-status.md
+++ b/.claude/commands/review-status.md
@@ -13,4 +13,7 @@ Please show me:
 2. PR merge status:
 !gh pr status --json "number,title,state,mergeable,statusCheckRollup"
 
-3. Summary of what needs to be done before merging.
+3. Leftover unsubmitted (PENDING) reviews — these hide drafted replies until submitted, so threads can look resolved with no visible reply (GitHub only lists your own):
+!PR=$(gh pr view --json number -q .number) && gh api --paginate "repos/{owner}/{repo}/pulls/$PR/reviews" --jq '[.[] | select(.state=="PENDING")] | {pendingReviews: map({id, html_url})}'
+
+4. Summary of what needs to be done before merging.


### PR DESCRIPTION
## Summary

- `/review-respond` resolves review threads via `gh-helper threads reply --resolve`, but if a reply is left in an unsubmitted (PENDING) review, the thread is resolved while the reply stays invisible (pending reviews are only visible to their author). This produced "resolved threads with no visible reply" on PR #648.
- Add a guard to catch the missing submit:
  - **review-respond.md**: new verification step that detects leftover PENDING reviews after replying/resolving and submits them before requesting a new review.
  - **review-status.md**: surfaces PENDING reviews in the status output so the situation is visible during monitoring.

## Detection command

```bash
PR=$(gh pr view --json number -q .number) && \
gh api --paginate "repos/{owner}/{repo}/pulls/$PR/reviews" \
  --jq '[.[] | select(.state=="PENDING")] | {pendingReviews: map({id, html_url})}'
```

`gh-helper reviews` has no equivalent subcommand (only `fetch`/`wait`), so this uses `gh api`. GitHub only returns the caller's own pending reviews, so the `state == "PENDING"` filter is sufficient.

## Validation

- `make check` (test + lint + fmt-check) — pass
- Detection command verified against PR #648 (now clean: `{"pendingReviews":[]}`) and on a live branch (auto-resolves the PR number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
