### PR TITLE
Use rendered output for dump fallback

### DIFF
--- a/internal/mycli/cli_output.go
+++ b/internal/mycli/cli_output.go
@@ -37,16 +37,6 @@ func extractTableColumnNames(header TableHeader) []string {
 }
 
 func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result) error {
-	// Handle direct output - pre-formatted text that should be printed as-is
-	if result.IsDirectOutput {
-		for _, row := range result.Rows {
-			if len(row) > 0 {
-				fmt.Fprintln(out, row[0].RawText())
-			}
-		}
-		return nil
-	}
-
 	// screenWidth <= 0 means no limit.
 	if screenWidth <= 0 {
 		screenWidth = math.MaxInt

--- a/internal/mycli/integration_dump_test.go
+++ b/internal/mycli/integration_dump_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func dumpRenderedOutputForTest(t *testing.T, result *Result) string {
+	t.Helper()
+
+	if !result.HasRenderedOutput {
+		t.Fatalf("expected DUMP fallback to return pre-rendered output")
+	}
+	if len(result.Rows) > 0 {
+		t.Fatalf("expected DUMP fallback to return no rows, got %d", len(result.Rows))
+	}
+	return string(result.RenderedOutput)
+}
+
 func TestDumpStatements(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -115,19 +127,7 @@ func TestDumpStatements(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Execute failed: %v", err)
 			}
-			if !result.IsDirectOutput {
-				t.Errorf("Expected IsDirectOutput to be true")
-			}
-
-			// Convert rows to string for analysis
-			var output strings.Builder
-			for _, row := range result.Rows {
-				if len(row) > 0 {
-					output.WriteString(row[0].RawText())
-					output.WriteString("\n")
-				}
-			}
-			outputStr := output.String()
+			outputStr := dumpRenderedOutputForTest(t, result)
 
 			// Check for DDL presence
 			if tt.expectDDL {
@@ -208,18 +208,12 @@ func TestDumpEmptyDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if len(result.Rows) == 0 {
+	outputStr := dumpRenderedOutputForTest(t, result)
+	if outputStr == "" {
 		t.Errorf("Expected at least header comment in output")
 	}
 
-	hasHeader := false
-	for _, row := range result.Rows {
-		if len(row) > 0 && strings.Contains(row[0].RawText(), "-- Database DDL exported by spanner-mycli") {
-			hasHeader = true
-			break
-		}
-	}
-	if !hasHeader {
+	if !strings.Contains(outputStr, "-- Database DDL exported by spanner-mycli") {
 		t.Errorf("Expected DDL header comment")
 	}
 }
@@ -358,15 +352,7 @@ func TestDumpWithForeignKeys(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	// Convert rows to string for analysis
-	var output strings.Builder
-	for _, row := range result.Rows {
-		if len(row) > 0 {
-			output.WriteString(row[0].RawText())
-			output.WriteString("\n")
-		}
-	}
-	outputStr := output.String()
+	outputStr := dumpRenderedOutputForTest(t, result)
 
 	// Check table order - FK referenced tables should come before referencing tables
 	venueIndex := strings.Index(outputStr, "-- Data for table Venues")
@@ -475,15 +461,7 @@ func TestDumpWithMixedDependencies(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	// Convert rows to string for analysis
-	var output strings.Builder
-	for _, row := range result.Rows {
-		if len(row) > 0 {
-			output.WriteString(row[0].RawText())
-			output.WriteString("\n")
-		}
-	}
-	outputStr := output.String()
+	outputStr := dumpRenderedOutputForTest(t, result)
 
 	// Check table order
 	categoryIndex := strings.Index(outputStr, "-- Data for table Categories")
@@ -560,13 +538,13 @@ func TestDumpWithGeneratedColumns(t *testing.T) {
 	// Expected output with only writable columns
 	// The generated INSERT should include: UserId, FirstName, LastName, Order, CreatedAt
 	// It should NOT include: FullName, SearchTokens, ComputedValue (all generated columns)
-	expectedRows := []Row{
-		toRow("-- Data for table Users"),
-		toRow("INSERT INTO `Users` (`UserId`, `FirstName`, `LastName`, `Order`, `CreatedAt`) VALUES (1, \"John\", \"Doe\", 10, TIMESTAMP \"2024-01-01T12:00:00Z\");"),
-		toRow(""),
-	}
+	expectedOutput := strings.Join([]string{
+		"-- Data for table Users",
+		"INSERT INTO `Users` (`UserId`, `FirstName`, `LastName`, `Order`, `CreatedAt`) VALUES (1, \"John\", \"Doe\", 10, TIMESTAMP \"2024-01-01T12:00:00Z\");",
+		"",
+	}, "\n") + "\n"
 
-	if diff := cmp.Diff(expectedRows, result.Rows); diff != "" {
+	if diff := cmp.Diff(expectedOutput, dumpRenderedOutputForTest(t, result)); diff != "" {
 		t.Errorf("DUMP output mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -215,12 +215,6 @@ type Result struct {
 	// - DML with THEN RETURN (uses regular formatting)
 	HasSQLFormattedValues bool
 
-	// IsDirectOutput indicates that Rows contain pre-formatted text lines that should
-	// be printed directly without any table formatting. Used by DUMP statements and
-	// potentially other commands that produce pre-formatted output.
-	// When true, Rows bypass normal table formatting and are output as-is.
-	IsDirectOutput bool
-
 	// SQLTableNameForExport stores the auto-detected or explicitly set table name for SQL export.
 	// This field is populated during query execution when SQL export formats are used.
 	// It ensures the table name is available during the formatting phase, even in buffered mode.

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -249,12 +249,11 @@ func writeCapturedDumpOutput(out io.Writer, output string) error {
 	if output == "" {
 		return nil
 	}
-	for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
-		if _, err := fmt.Fprintln(out, line); err != nil {
-			return err
-		}
+	if _, err := io.WriteString(out, strings.TrimRight(output, "\n")); err != nil {
+		return err
 	}
-	return nil
+	_, err := io.WriteString(out, "\n")
+	return err
 }
 
 func executeDumpTableIntoBuffer(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, selectQuery, table string) (*Result, string, error) {

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -162,7 +162,8 @@ func getWritableColumnsWithTxn(ctx context.Context, txn *spanner.ReadOnlyTransac
 // executeDumpBuffered performs dump operation with buffering.
 // All output is collected in memory before being returned.
 func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, specificTables []string) (*Result, error) {
-	result := &Result{AffectedRows: 0, IsDirectOutput: true}
+	var out bytes.Buffer
+	var affectedRows int
 
 	// Export DDL first if requested (DDL doesn't need transaction consistency)
 	if mode.shouldExportDDL() {
@@ -170,7 +171,9 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 		if err != nil {
 			return nil, fmt.Errorf("export DDL: %w", err)
 		}
-		result.Rows = append(result.Rows, ddlResult.Rows...)
+		if err := writeResultRows(&out, ddlResult.Rows); err != nil {
+			return nil, fmt.Errorf("write DDL: %w", err)
+		}
 	}
 
 	// Execute all INFORMATION_SCHEMA queries and data export within a single transaction for consistency
@@ -193,7 +196,7 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 
 			// Skip tables with no writable columns (e.g., all generated columns)
 			if len(columns) == 0 {
-				result.Rows = append(result.Rows, toRow(fmt.Sprintf("-- Skipping table %s (no writable columns)", table)))
+				fmt.Fprintf(&out, "-- Skipping table %s (no writable columns)\n", table)
 				continue
 			}
 
@@ -205,19 +208,17 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 				return fmt.Errorf("export table %s: %w", table, err)
 			}
 
-			result.Rows = append(result.Rows, toRow(fmt.Sprintf("-- Data for table %s", table)))
+			fmt.Fprintf(&out, "-- Data for table %s\n", table)
 
-			if dumpOutput != "" {
-				for _, line := range strings.Split(strings.TrimRight(dumpOutput, "\n"), "\n") {
-					result.Rows = append(result.Rows, toRow(line))
-				}
+			if err := writeCapturedDumpOutput(&out, dumpOutput); err != nil {
+				return fmt.Errorf("write data for table %s: %w", table, err)
 			}
 
 			if dataResult.AffectedRows > 0 {
-				result.Rows = append(result.Rows, toRow(""))
+				fmt.Fprintln(&out)
 			}
 
-			result.AffectedRows += dataResult.AffectedRows
+			affectedRows += dataResult.AffectedRows
 		}
 		return nil
 	})
@@ -225,7 +226,11 @@ func executeDumpBuffered(ctx context.Context, session *Session, mode dumpMode, s
 		return nil, err
 	}
 
-	return result, nil
+	return &Result{
+		AffectedRows:      affectedRows,
+		RenderedOutput:    out.Bytes(),
+		HasRenderedOutput: true,
+	}, nil
 }
 
 // writeResultRows writes Result rows to an io.Writer
@@ -235,6 +240,18 @@ func writeResultRows(out io.Writer, rows []Row) error {
 			if _, err := fmt.Fprintln(out, row[0].RawText()); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func writeCapturedDumpOutput(out io.Writer, output string) error {
+	if output == "" {
+		return nil
+	}
+	for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -320,7 +337,7 @@ func executeDumpStreaming(ctx context.Context, session *Session, mode dumpMode, 
 		return nil, err
 	}
 
-	return &Result{AffectedRows: totalAffectedRows, Streamed: true, IsDirectOutput: false}, nil
+	return &Result{AffectedRows: totalAffectedRows, Streamed: true}, nil
 }
 
 // exportDDL exports database DDL statements

--- a/internal/mycli/statements_dump_test.go
+++ b/internal/mycli/statements_dump_test.go
@@ -1,6 +1,7 @@
 package mycli
 
 import (
+	"bytes"
 	"testing"
 
 	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
@@ -39,6 +40,59 @@ func TestBuildSelectQueryWithColumns(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := buildSelectQueryWithColumns(dbadminpb.DatabaseDialect_GOOGLE_STANDARD_SQL, tt.columns, tt.table); got != tt.wantSQL {
 				t.Fatalf("buildSelectQueryWithColumns() = %q, want %q", got, tt.wantSQL)
+			}
+		})
+	}
+}
+
+func TestWriteCapturedDumpOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "empty output stays empty",
+			output: "",
+			want:   "",
+		},
+		{
+			name:   "missing trailing newline is added",
+			output: "INSERT INTO Singers VALUES (1)",
+			want:   "INSERT INTO Singers VALUES (1)\n",
+		},
+		{
+			name:   "single trailing newline is preserved",
+			output: "INSERT INTO Singers VALUES (1)\n",
+			want:   "INSERT INTO Singers VALUES (1)\n",
+		},
+		{
+			name:   "extra trailing newlines are collapsed",
+			output: "INSERT INTO Singers VALUES (1)\n\n",
+			want:   "INSERT INTO Singers VALUES (1)\n",
+		},
+		{
+			name:   "internal blank lines are preserved",
+			output: "INSERT INTO Singers VALUES (1)\n\nINSERT INTO Singers VALUES (2)\n",
+			want:   "INSERT INTO Singers VALUES (1)\n\nINSERT INTO Singers VALUES (2)\n",
+		},
+		{
+			name:   "only newlines collapse to one newline",
+			output: "\n\n",
+			want:   "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := writeCapturedDumpOutput(&buf, tt.output); err != nil {
+				t.Fatalf("writeCapturedDumpOutput() error = %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Fatalf("writeCapturedDumpOutput() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- route buffered DUMP fallback output through `RenderedOutput` instead of `Result.Rows`
- remove the now-unused `IsDirectOutput` compatibility path from `Result` and `printTableData`
- update DUMP integration tests to assert the pre-rendered output contract

## Why

This keeps DUMP's current output unchanged while avoiding the legacy path that split spanvalue-generated SQL dump text into formatted rows only to print it directly again.

Fixes #649.

## Verification

- `go test ./internal/mycli -run 'TestDump'`
- `make check`
