### PR TITLE
Remove dead multiplexed-session emulator workaround

### DIFF
--- a/internal/mycli/app.go
+++ b/internal/mycli/app.go
@@ -69,12 +69,6 @@ func init() {
 		Level: slog.LevelWarn,
 	}))
 	slog.SetDefault(h)
-
-	// Disable multiplexed session for r/w transaction,
-	// workaround for https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/282
-	if err := os.Setenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW", "false"); err != nil {
-		slog.Error("failed to set required environment variable for spanner emulator workaround", "error", err)
-	}
 }
 
 func SetLogLevel(logLevel string) (slog.Level, error) {


### PR DESCRIPTION
## Summary

Delete the `init()` block in `internal/mycli/app.go` that set `GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW=false` as a workaround for GoogleCloudPlatform/cloud-spanner-emulator#282.

## Why

The environment variable is no longer read anywhere in `cloud.google.com/go/spanner` v1.91.0 non-test code (verified by grep over the module). The pre-multiplexed session implementation was removed from the client library, making multiplexed sessions the only behavior — the opt-out knob was deleted along with it. The `os.Setenv` has therefore been a no-op since that upgrade, and emulator integration tests already pass on `main` with multiplexed sessions in effect, confirming the underlying emulator issue no longer bites.

Deleting the dead code is preferable to the scoping/precedence logic originally envisioned in #595: there is nothing left to scope.

Fixes #595

## Test plan

- [x] `make check` (test + lint + fmt-check), including emulator integration tests, which exercise read-write transactions under multiplexed sessions
