### PR TITLE
Return explicit errors from RunQuery/RunQueryWithStats; stop logging raw SQL

### DIFF
--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -213,7 +213,10 @@ func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, s
 		return nil, err
 	}
 
-	iter, roTxn := session.RunQueryWithStats(ctx, stmt, false)
+	iter, roTxn, err := session.RunQueryWithStats(ctx, stmt, false)
+	if err != nil {
+		return nil, err
+	}
 
 	result, err := executeAndCollect(ctx, &queryExecution{
 		Session:      session,

--- a/internal/mycli/meta_commands.go
+++ b/internal/mycli/meta_commands.go
@@ -46,9 +46,12 @@ func (s *ShellMetaCommand) Execute(ctx context.Context, session *Session) (*Resu
 		shellCmd = exec.CommandContext(ctx, "sh", "-c", s.Command)
 	}
 
-	// Check if StreamManager is configured
+	// Check if StreamManager is configured.
+	// The raw command text is intentionally not logged: it can contain
+	// sensitive data, and this is an internal invariant violation where the
+	// command content is irrelevant to diagnosis.
 	if session.systemVariables.StreamManager == nil {
-		slog.Error("StreamManager is nil, cannot execute shell command", "command", s.Command)
+		slog.Error("StreamManager is nil, cannot execute shell command")
 		return nil, errors.New("internal error: StreamManager not configured")
 	}
 

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -565,11 +565,11 @@ func (s *Session) ClosePendingTransaction() error {
 	return s.txn.ClosePendingTransaction()
 }
 
-func (s *Session) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+func (s *Session) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
 	return s.txn.RunQueryWithStats(ctx, stmt, implicit)
 }
 
-func (s *Session) RunQuery(ctx context.Context, stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+func (s *Session) RunQuery(ctx context.Context, stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
 	return s.txn.RunQuery(ctx, stmt)
 }
 

--- a/internal/mycli/session_slow_test.go
+++ b/internal/mycli/session_slow_test.go
@@ -109,7 +109,10 @@ func TestRequestPriority(t *testing.T) {
 			if err := session.BeginReadWriteTransaction(ctx, 0, test.transactionPriority); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
-			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
+			iter, _, err := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
+			if err != nil {
+				t.Fatalf("failed to run query: %v", err)
+			}
 			if err := iter.Do(func(r *spanner.Row) error {
 				return nil
 			}); err != nil {
@@ -126,7 +129,10 @@ func TestRequestPriority(t *testing.T) {
 			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority); err != nil {
 				t.Fatalf("failed to begin read only transaction: %v", err)
 			}
-			iter, _ = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"), false)
+			iter, _, err = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"), false)
+			if err != nil {
+				t.Fatalf("failed to run query with stats: %v", err)
+			}
 			if err := iter.Do(func(r *spanner.Row) error {
 				return nil
 			}); err != nil {
@@ -243,7 +249,10 @@ func TestIsolationLevel(t *testing.T) {
 			if err := session.BeginReadWriteTransaction(ctx, test.transactionIsolationLevel, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
-			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT 1"))
+			iter, _, err := session.RunQuery(ctx, spanner.NewStatement("SELECT 1"))
+			if err != nil {
+				t.Fatalf("failed to run query: %v", err)
+			}
 			if err := iter.Do(func(r *spanner.Row) error {
 				return nil
 			}); err != nil {

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -285,7 +285,10 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		return nil, err
 	}
 
-	iter, roTxn := session.RunQueryWithStats(ctx, stmt, false)
+	iter, roTxn, err := session.RunQueryWithStats(ctx, stmt, false)
+	if err != nil {
+		return nil, err
+	}
 
 	stats, _, _, plan, err := consumeRowIterDiscard(iter)
 	if err != nil {

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -66,7 +66,10 @@ func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Sessi
 		SQL: `SELECT INTERVAL_END, TEXT_FINGERPRINT, LATENCY_SECONDS, PARSE_JSON(QUERY_PROFILE) AS QUERY_PROFILE FROM SPANNER_SYS.QUERY_PROFILES_TOP_HOUR`,
 	}
 
-	iter, _ := session.RunQuery(ctx, stmt)
+	iter, _, err := session.RunQuery(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
 
 	rows, _, _, _, _, err := consumeRowIterCollect(iter, toQpr)
 	if err != nil {
@@ -149,7 +152,10 @@ ORDER BY INTERVAL_END DESC`,
 		Params: map[string]interface{}{"fprint": s.Fprint},
 	}
 
-	iter, _ := session.RunQuery(ctx, stmt)
+	iter, _, err := session.RunQuery(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
 
 	qprs, _, _, _, _, err := consumeRowIterCollect(iter, toQpr)
 	if err != nil {

--- a/internal/mycli/statements_schema.go
+++ b/internal/mycli/statements_schema.go
@@ -158,7 +158,10 @@ func executeInformationSchemaBasedStatementImpl(ctx context.Context, session *Se
 		return nil, err
 	}
 
-	iter, _ := session.RunQuery(ctx, stmt)
+	iter, _, err := session.RunQuery(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
 
 	rows, _, _, metadata, _, err := consumeRowIterCollect(iter, spannerRowToRow(fc, session.systemVariables.typeStyles, session.systemVariables.nullStyle))
 	if err != nil {

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -858,36 +858,34 @@ func (tm *TransactionManager) runUpdateOnTransaction(ctx context.Context, tx *sp
 
 // RunQueryWithStats executes a statement with stats either on the running transaction or on the temporal read-only transaction.
 // It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
-func (tm *TransactionManager) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+// An error is returned when no database connection is available; this should not
+// happen if DetachedCompatible interface validation is working correctly.
+func (tm *TransactionManager) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
 	// Validate that we have a database client for query operations
 	if err := tm.ValidateDatabaseOperation(); err != nil {
-		// This should not happen if DetachedCompatible interface validation is working correctly
-		// Log the error for debugging since we can't return it directly
-		slog.Error("RunQueryWithStats called without database connection", "error", err, "statement", stmt.SQL)
-		// Return nil to indicate error - caller should check for nil
-		return nil, nil
+		return nil, nil, err
 	}
 
 	mode := sppb.ExecuteSqlRequest_PROFILE
 	opts := tm.buildQueryOptions(&mode)
 	opts.LastStatement = implicit
-	return tm.runQueryWithOptions(ctx, stmt, opts)
+	iter, roTxn := tm.runQueryWithOptions(ctx, stmt, opts)
+	return iter, roTxn, nil
 }
 
 // RunQuery executes a statement either on the running transaction or on the temporal read-only transaction.
 // It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
-func (tm *TransactionManager) RunQuery(ctx context.Context, stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+// An error is returned when no database connection is available; this should not
+// happen if DetachedCompatible interface validation is working correctly.
+func (tm *TransactionManager) RunQuery(ctx context.Context, stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
 	// Validate that we have a database client for query operations
 	if err := tm.ValidateDatabaseOperation(); err != nil {
-		// This should not happen if DetachedCompatible interface validation is working correctly
-		// Log the error for debugging since we can't return it directly
-		slog.Error("RunQuery called without database connection", "error", err, "statement", stmt.SQL)
-		// Return nil to indicate error - caller should check for nil
-		return nil, nil
+		return nil, nil, err
 	}
 
 	opts := tm.buildQueryOptions(nil)
-	return tm.runQueryWithOptions(ctx, stmt, opts)
+	iter, roTxn := tm.runQueryWithOptions(ctx, stmt, opts)
+	return iter, roTxn, nil
 }
 
 // RunAnalyzeQuery analyzes a statement either on the running transaction or on the temporal read-only transaction.


### PR DESCRIPTION
## Summary

- `TransactionManager.RunQuery` / `RunQueryWithStats` (and the `Session` wrappers) now return an error instead of `(nil, nil)` when no database connection is available. All five call sites (`execute_sql.go`, `statements_explain_describe.go`, `statements_schema.go`, `statements_query_profile.go` ×2) propagate it.
- The shell meta-command invariant log drops its `"command"` attribute.

## Why

The `(nil, nil)` contract pushed an internal invariant violation into a delayed panic: callers passed the nil `*spanner.RowIterator` straight into `consumeRowIter*`, whose `defer iter.Stop()` dereferences nil. None of the call sites checked for nil. Returning the error keeps the failure at the API boundary with a meaningful message (`ValidateDatabaseOperation`'s detached-mode explanation) instead of a stack trace.

This is also the root-cause fix for most of #600: the two `slog.Error(..., "statement", stmt.SQL)` calls existed only because the old signature could not return the error — they disappear together with the workaround. The remaining log site (`meta_commands.go`) keeps reporting the invariant violation but no longer records the raw command text, which can contain sensitive data and is irrelevant to diagnosing a nil StreamManager.

Fixes #598
Fixes #600

## Test plan

- [x] `make check` (test + lint + fmt-check), including emulator integration tests
- [x] `session_slow_test.go` call sites updated to the new signatures with explicit error checks
