### PR TITLE
Stream partitioned query output through spanvalue writers

### DIFF
--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -3,21 +3,27 @@ package mycli
 import (
 	"cmp"
 	"context"
+	"errors"
+	"iter"
 	"runtime"
+	"sync/atomic"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
+	"github.com/apstndb/spanner-mycli/internal/mycli/format"
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/writer"
 	"github.com/sourcegraph/conc/pool"
+	"google.golang.org/api/iterator"
 )
 
 func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Result, error) {
-	fc, err := decoder.FormatConfigWithProto(session.systemVariables.Internal.ProtoDescriptor, session.systemVariables.Display.MultilineProtoText)
+	fc, vfm, sysVars, err := prepareFormatConfig(sql, session.systemVariables)
 	if err != nil {
 		return nil, err
 	}
 
-	stmt, err := newStatement(sql, session.systemVariables.Params, false)
+	stmt, err := newStatement(sql, sysVars.Params, false)
 	if err != nil {
 		return nil, err
 	}
@@ -31,21 +37,96 @@ func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Re
 		batchROTx.Close()
 	}()
 
+	// Go 1.25+ automatically detects container CPU limits on Linux through container-aware GOMAXPROCS.
+	// This ensures optimal parallelism in containerized environments (Docker, Kubernetes) without manual configuration.
+	parallelism := cmp.Or(int(sysVars.Query.MaxPartitionedParallelism), runtime.GOMAXPROCS(0))
+
+	// Formats backed by a spanvalue RowIteratorWriter (CSV, JSONL, SQL_INSERT*)
+	// stream merged partition rows without buffering, like the query path.
+	result, handled, err := streamPartitionedQuery(ctx, batchROTx, partitions, parallelism, sysVars, fc, vfm)
+	if err != nil {
+		return nil, err
+	}
+	if handled {
+		return result, nil
+	}
+
+	return bufferPartitionedQuery(ctx, batchROTx, partitions, parallelism, sysVars, fc, vfm)
+}
+
+// streamPartitionedQuery streams merged partition rows through the same
+// spanvalue RowIteratorWriter as the query streaming path, via
+// writer.RunRowSeq. Returns handled=false when the current format has no
+// spanvalue writer (table and processor-based formats keep the buffered path).
+func streamPartitionedQuery(
+	ctx context.Context,
+	batchROTx *spanner.BatchReadOnlyTransaction,
+	partitions []*spanner.Partition,
+	parallelism int,
+	sysVars *systemVariables,
+	fc *spanvalue.FormatConfig,
+	vfm format.ValueFormatMode,
+) (*Result, bool, error) {
+	w, handled, err := newSpanvalueRowIteratorWriterFor(sysVars, fc)
+	if err != nil || !handled {
+		return nil, handled, err
+	}
+
+	hooks := writer.AfterEachSuccessfulWriteRow(
+		writer.RowIteratorHooksFromWriter(w),
+		func() error { return flushSpanvalueStreamingRow(w) },
+	)
+
+	var runResult *writer.RowIteratorResult
+	err = runPartitionedRowSeq(ctx, batchROTx, partitions, parallelism,
+		func(md *sppb.ResultSetMetadata, rows iter.Seq2[*spanner.Row, error]) error {
+			res, err := writer.RunRowSeq(md, rows, hooks)
+			runResult = res
+			return err
+		})
+	if err != nil {
+		return nil, true, normalizeSpanvalueWriterError(err)
+	}
+
+	return &Result{
+		TableHeader:           toTableHeader(runResult.Metadata.GetRowType().GetFields()),
+		AffectedRows:          runResult.RowsRead,
+		PartitionCount:        len(partitions),
+		Streamed:              true,
+		HasSQLFormattedValues: vfm == format.SQLLiteralValues,
+	}, true, nil
+}
+
+// bufferPartitionedQuery collects all partition rows into memory for formats
+// that need the full result set (table width calculation) or have no
+// streaming writer.
+func bufferPartitionedQuery(
+	ctx context.Context,
+	batchROTx *spanner.BatchReadOnlyTransaction,
+	partitions []*spanner.Partition,
+	parallelism int,
+	sysVars *systemVariables,
+	fc *spanvalue.FormatConfig,
+	vfm format.ValueFormatMode,
+) (*Result, error) {
+	transform := spannerRowToRow(fc, sysVars.typeStyles, sysVars.nullStyle)
+	if vfm == format.JSONValues {
+		transform = withRawJSONMarker(transform)
+	}
+
 	type partitionQueryResult struct {
 		Metadata *sppb.ResultSetMetadata
 		Rows     []Row
 	}
 
-	// Go 1.25+ automatically detects container CPU limits on Linux through container-aware GOMAXPROCS.
-	// This ensures optimal parallelism in containerized environments (Docker, Kubernetes) without manual configuration.
 	p := pool.NewWithResults[*partitionQueryResult]().
 		WithContext(ctx).
-		WithMaxGoroutines(cmp.Or(int(session.systemVariables.Query.MaxPartitionedParallelism), runtime.GOMAXPROCS(0)))
+		WithMaxGoroutines(parallelism)
 
 	for _, partition := range partitions {
 		p.Go(func(ctx context.Context) (*partitionQueryResult, error) {
 			iter := batchROTx.Execute(ctx, partition)
-			rows, _, _, md, _, err := consumeRowIterCollect(iter, spannerRowToRow(fc, session.systemVariables.typeStyles, session.systemVariables.nullStyle))
+			rows, _, _, md, _, err := consumeRowIterCollect(iter, transform)
 			if err != nil {
 				return nil, err
 			}
@@ -68,13 +149,115 @@ func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Re
 		}
 	}
 
-	result := &Result{
+	return &Result{
 		Rows:           allRows,
 		TableHeader:    toTableHeader(rowType.GetFields()),
 		AffectedRows:   len(allRows),
 		PartitionCount: len(partitions),
+	}, nil
+}
+
+// partitionedRow is one fan-in item: a data row or a terminal partition error.
+type partitionedRow struct {
+	row *spanner.Row
+	err error
+}
+
+// runPartitionedRowSeq executes all partitions with bounded concurrency and
+// hands consume the row-type metadata plus a merged, fallible row sequence.
+// The single consumer serializes output, so sinks need no locking. Metadata is
+// captured from whichever partition responds first (every partition of one
+// query shares the same row type) and is available before the first row is
+// yielded; it is nil only when no partition reported metadata.
+//
+// consume aborting early (including on a yielded error) cancels the remaining
+// partition work; partition errors are surfaced through the sequence itself.
+func runPartitionedRowSeq(
+	ctx context.Context,
+	batchROTx *spanner.BatchReadOnlyTransaction,
+	partitions []*spanner.Partition,
+	parallelism int,
+	consume func(md *sppb.ResultSetMetadata, rows iter.Seq2[*spanner.Row, error]) error,
+) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ch := make(chan partitionedRow)
+	var capturedMD atomic.Pointer[sppb.ResultSetMetadata]
+
+	p := pool.New().WithContext(ctx).WithMaxGoroutines(parallelism)
+	for _, partition := range partitions {
+		p.Go(func(ctx context.Context) error {
+			rowIter := batchROTx.Execute(ctx, partition)
+			defer rowIter.Stop()
+			for {
+				row, err := rowIter.Next()
+				// Metadata is populated after the first Next, including when it
+				// returns iterator.Done; store it before sending the row so the
+				// consumer always sees metadata no later than the first row.
+				if md := rowIter.Metadata; md != nil {
+					capturedMD.CompareAndSwap(nil, md)
+				}
+				if err == iterator.Done {
+					return nil
+				}
+				if err != nil {
+					select {
+					case ch <- partitionedRow{err: err}:
+					case <-ctx.Done():
+					}
+					return err
+				}
+				select {
+				case ch <- partitionedRow{row: row}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		})
 	}
-	return result, nil
+
+	producersDone := make(chan error, 1)
+	go func() {
+		producersDone <- p.Wait()
+		close(ch)
+	}()
+
+	// Hold the first item back until metadata is known: its producer stored
+	// metadata before sending, and a closed channel means all producers
+	// finished (zero data rows) after storing whatever metadata they saw.
+	first, hasFirst := <-ch
+
+	rows := func(yield func(*spanner.Row, error) bool) {
+		if hasFirst {
+			if !yield(first.row, first.err) || first.err != nil {
+				return
+			}
+		}
+		for item := range ch {
+			if !yield(item.row, item.err) || item.err != nil {
+				return
+			}
+		}
+	}
+
+	consumeErr := consume(capturedMD.Load(), rows)
+
+	// Release any producers blocked on send, then wait for them to finish.
+	cancel()
+	for range ch {
+	}
+	producerErr := <-producersDone
+
+	if consumeErr != nil {
+		return consumeErr
+	}
+	// A partition error is normally surfaced through the sequence and returned
+	// by consume above; this covers errors raised after consume stopped reading.
+	if producerErr != nil && !errors.Is(producerErr, context.Canceled) {
+		return producerErr
+	}
+	return nil
 }
 
 func executePDML(ctx context.Context, session *Session, sql string) (*Result, error) {

--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -179,13 +179,15 @@ func runPartitionedRowSeq(
 	parallelism int,
 	consume func(md *sppb.ResultSetMetadata, rows iter.Seq2[*spanner.Row, error]) error,
 ) error {
-	ctx, cancel := context.WithCancel(ctx)
+	// Do not shadow the parent context: it must stay observable below to
+	// distinguish external cancellation from our own consumer-driven cancel.
+	childCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	ch := make(chan partitionedRow)
 	var capturedMD atomic.Pointer[sppb.ResultSetMetadata]
 
-	p := pool.New().WithContext(ctx).WithMaxGoroutines(parallelism)
+	p := pool.New().WithContext(childCtx).WithMaxGoroutines(parallelism)
 	for _, partition := range partitions {
 		p.Go(func(ctx context.Context) error {
 			rowIter := batchROTx.Execute(ctx, partition)
@@ -256,6 +258,13 @@ func runPartitionedRowSeq(
 	// by consume above; this covers errors raised after consume stopped reading.
 	if producerErr != nil && !errors.Is(producerErr, context.Canceled) {
 		return producerErr
+	}
+	// External cancellation (timeout, interrupt) makes producers exit with
+	// context.Canceled and the sequence end early, which would otherwise be
+	// indistinguishable from a successful run with fewer rows. Report it so a
+	// truncated result is never treated as success.
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

`RUN PARTITIONED QUERY` buffered every partition's rows into memory and concatenated them regardless of output format. Formats backed by a spanvalue `RowIteratorWriter` (CSV, JSONL, `SQL_INSERT*`) now stream merged partition rows without buffering, reusing the query streaming path's writer construction unchanged.

## Design

The open design question in #651 — "decide how to handle concurrent writes" — dissolves at the sequence boundary:

- **`runPartitionedRowSeq`** merges per-partition iterators into a single `iter.Seq2[*spanner.Row, error]`. Fetch concurrency is preserved (`conc/pool` bounded by `MAX_PARTITIONED_PARALLELISM`, as before), but the single sequence consumer serializes output, so sinks need no locking. Early abort (yielded error, consumer stop) cancels remaining partition work; partition errors surface through the sequence.
- Row-type metadata is captured from whichever partition responds first (all partitions of one query share a row type) and is guaranteed available before the first row is yielded, so header-emitting writers work, including the zero-row case.
- **`streamPartitionedQuery`** drives `writer.RunRowSeq` (spanvalue v0.7.4) with `RowIteratorHooksFromWriter` + per-row flush for delimited output — the same shape as `streamStructRows` for client-side virtual result sets (#661).

## Behavior changes

- CSV/JSONL/SQL partitioned query output streams instead of buffering (memory win proportional to result size; `AffectedRows` comes from `RowsRead`).
- Format derivation now goes through `prepareFormatConfig`: JSONL gets JSON value formatting (native numbers/booleans/null), and SQL export modes now actually work for partitioned queries (with table-name auto-detection; previously they silently fell back to table rendering). Buffered JSONL (no stream writer) also gains the `RawJSONCell` marker for parity with buffered queries.
- Table formats keep the buffered path (width calculation); processor-based formats (VERTICAL, HTML, XML, TAB) also remain buffered for now — they need a seq-driven counterpart of `runSpanvalueRowIteratorWithProcessor` and can migrate in a follow-up.

Fixes #651

## Test plan

- [x] `make check` (test + lint + fmt-check), including emulator integration tests covering RUN PARTITIONED QUERY (buffered table path)
- [x] Manual against embedded emulator + banking sample: `RUN PARTITIONED QUERY SELECT ...` in CSV (streamed, header + rows), JSONL (native JSON values), TABLE (buffered, unchanged)
