### PR TITLE
Reject whitespace-only PAGER instead of panicking

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -386,6 +386,11 @@ func (c *Cli) PrintResult(screenWidth int, result *Result, interactive bool, inp
 		if err != nil {
 			return fmt.Errorf("failed to parse pager command: %w", err)
 		}
+		// A whitespace-only PAGER yields an empty slice; reject it instead of
+		// panicking on split[0].
+		if len(split) == 0 {
+			return fmt.Errorf("invalid pager command: %q", pagerpath)
+		}
 		cmd = exec.CommandContext(context.Background(), split[0], split[1:]...)
 
 		pr, pw := io.Pipe()

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -1671,3 +1671,26 @@ func TestCli_executeSourceFile_FileTooLarge(t *testing.T) {
 		t.Errorf("Expected error to contain 'too large', got: %v", err)
 	}
 }
+
+// TestCli_PrintResult_invalidPagerCommand verifies that a whitespace-only
+// PAGER value is rejected with an error instead of panicking on an empty
+// shellquote.Split result.
+func TestCli_PrintResult_invalidPagerCommand(t *testing.T) {
+	t.Setenv("PAGER", "   ")
+
+	outBuf := &bytes.Buffer{}
+	sysVars := &systemVariables{
+		Display: DisplayVars{
+			UsePager:  true,
+			CLIFormat: enums.DisplayModeTab,
+		},
+		StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), outBuf, outBuf),
+	}
+	cli := &Cli{SystemVariables: sysVars}
+
+	result := &Result{TableHeader: toTableHeader("col1"), Rows: []Row{toRow("foo")}}
+	err := cli.PrintResult(80, result, false, "", outBuf)
+	if err == nil || !strings.Contains(err.Error(), "invalid pager command") {
+		t.Fatalf("error = %v, want invalid pager command error", err)
+	}
+}


### PR DESCRIPTION
## Summary

`shellquote.Split` of a whitespace-only `PAGER` value (e.g. `PAGER=" "`) yields an empty slice, and `split[0]` panicked. Add a guard returning an explicit `invalid pager command` error, with a regression test.

## Scope note

Per the assessment on #599, the pager-cancellation half of the issue is deliberately not implemented: pager lifetime is already structurally bounded (`pw.Close()` + `cmd.Wait()` run in a defer inside `PrintResult`), and killing the pager on statement cancellation would destroy partial output the user is actively reading (psql keeps the pager alive too). Threading a context through the render path would add complexity for negative UX value.

Fixes #599

## Test plan

- [x] `make check`
- [x] New regression test: `PAGER="   "` + `CLI_USE_PAGER=TRUE` returns an error instead of panicking
