### PR TITLE
EXPLAIN ANALYZE: report actual returned rows instead of plan-node count

### DIFF
--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -290,7 +290,13 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		return nil, err
 	}
 
-	stats, _, _, plan, err := consumeRowIterDiscard(iter)
+	// Count the actual data rows while draining the iterator;
+	// RowIterator.RowCount is only populated for DML.
+	var actualRows int64
+	stats, _, _, plan, err := consumeRowIter(iter, func(*spanner.Row) error {
+		actualRows++
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -305,6 +311,11 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 	if err != nil {
 		return nil, err
 	}
+
+	// Report the rows the query actually returned, not the number of rendered
+	// plan-node rows, mirroring executeExplainAnalyzeDML's affected-rows
+	// override (#417).
+	result.AffectedRows = int(actualRows)
 
 	if roTxn != nil {
 		ts, err := roTxn.Timestamp()


### PR DESCRIPTION
## Summary

`EXPLAIN ANALYZE <SELECT>` printed `X rows in set` where X was the number of rendered plan-node rows. The DML half of #417 was already fixed (`executeExplainAnalyzeDML` overrides with actual affected rows); this applies the mirrored fix to the SELECT path: count data rows while draining the iterator and override `AffectedRows` after building the plan table.

Note `RowIterator.RowCount` is populated only for DML, so the count comes from the drain callback rather than the discarded `consumeRowIterDiscard` return.

Fixes #417

## Test plan

- [x] `make check` (test + lint + fmt-check; the emulator does not support EXPLAIN ANALYZE query plans, so this path is exercised by unit tests and the plan-rendering suite)
