### PR TITLE
Harden proto descriptor reads via shared loadFromHTTP and SafeReadFile

### DIFF
--- a/internal/mycli/sample_databases.go
+++ b/internal/mycli/sample_databases.go
@@ -349,6 +349,13 @@ func loadFromGCSWithClient(ctx context.Context, client *storage.Client, uri stri
 
 // loadFromHTTP loads content from HTTP/HTTPS URLs
 func loadFromHTTP(ctx context.Context, uri string) ([]byte, error) {
+	return loadFromHTTPWithLimit(ctx, uri, filesafety.SampleDatabaseMaxFileSize)
+}
+
+// loadFromHTTPWithLimit loads content from HTTP/HTTPS URLs with a request
+// timeout, status check, and a response size cap (Content-Length when
+// available, enforced by io.LimitReader regardless).
+func loadFromHTTPWithLimit(ctx context.Context, uri string, maxSize int64) ([]byte, error) {
 	// Add timeout to prevent hanging indefinitely
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -369,20 +376,20 @@ func loadFromHTTP(ctx context.Context, uri string) ([]byte, error) {
 	}
 
 	// Check Content-Length header if present
-	if resp.ContentLength > 0 && resp.ContentLength > filesafety.SampleDatabaseMaxFileSize {
-		return nil, fmt.Errorf("HTTP response from %s too large: %d bytes (max %d)", uri, resp.ContentLength, filesafety.SampleDatabaseMaxFileSize)
+	if resp.ContentLength > 0 && resp.ContentLength > maxSize {
+		return nil, fmt.Errorf("HTTP response from %s too large: %d bytes (max %d)", uri, resp.ContentLength, maxSize)
 	}
 
 	// Use io.LimitReader as a safety measure even if Content-Length is not set
-	limitedReader := io.LimitReader(resp.Body, filesafety.SampleDatabaseMaxFileSize+1)
+	limitedReader := io.LimitReader(resp.Body, maxSize+1)
 	data, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read HTTP response from %s: %w", uri, err)
 	}
 
 	// Check if we hit the limit
-	if len(data) > filesafety.SampleDatabaseMaxFileSize {
-		return nil, fmt.Errorf("HTTP response from %s too large: exceeded %d bytes", uri, filesafety.SampleDatabaseMaxFileSize)
+	if int64(len(data)) > maxSize {
+		return nil, fmt.Errorf("HTTP response from %s too large: exceeded %d bytes", uri, maxSize)
 	}
 
 	return data, nil

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -9,10 +9,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,6 +22,7 @@ import (
 
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/filesafety"
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 	planref "github.com/apstndb/spannerplan/plantree/reference"
 	"github.com/bufbuild/protocompile"
@@ -482,19 +481,12 @@ func httpResolveFunc(path string) (protocompile.SearchResult, error) {
 		return protocompile.SearchResult{}, protoregistry.NotFound
 	}
 
-	resp, err := http.Get(path)
-	if err != nil {
-		return protocompile.SearchResult{}, err
-	}
-	defer resp.Body.Close()
-
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, resp.Body)
+	b, err := loadFromHTTPWithLimit(context.Background(), path, filesafety.DefaultMaxFileSize)
 	if err != nil {
 		return protocompile.SearchResult{}, err
 	}
 
-	return protocompile.SearchResult{Source: &buf}, nil
+	return protocompile.SearchResult{Source: bytes.NewReader(b)}, nil
 }
 
 var resolver = protocompile.CompositeResolver{&protocompile.SourceResolver{}, httpResolver}
@@ -518,22 +510,13 @@ func readFileDescriptorProtoFromFile(filename string) (*descriptorpb.FileDescrip
 	var b []byte
 	var err error
 	if httpOrHTTPSRe.MatchString(filename) {
-		resp, err := http.Get(filename)
+		b, err = loadFromHTTPWithLimit(context.Background(), filename, filesafety.DefaultMaxFileSize)
 		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("failed to fetch proto descriptor from %v: HTTP %d", filename, resp.StatusCode)
-		}
-
-		b, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error on fetch proto descriptor from %v: %w", filename, err)
 		}
 	} else {
-		b, err = os.ReadFile(filename)
+		// nil options = regular-file check with the 100MB default cap.
+		b, err = filesafety.SafeReadFile(filename, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error on read proto descriptor-file %v: %w", filename, err)
 		}

--- a/internal/mycli/system_variables_test.go
+++ b/internal/mycli/system_variables_test.go
@@ -362,7 +362,7 @@ func TestSystemVariables_ProtoDescriptorFiles(t *testing.T) {
 			{
 				desc:     "directory instead of file",
 				filename: "testdata/protos/",
-				errorMsg: "is a directory",
+				errorMsg: "cannot read special file",
 			},
 			{
 				desc:     "large invalid binary file",
@@ -377,7 +377,7 @@ func TestSystemVariables_ProtoDescriptorFiles(t *testing.T) {
 			{
 				desc:     "HTTP URL - non-existent (404)",
 				filename: httpServer.URL + "/non_existent.pb",
-				errorMsg: "failed to fetch proto descriptor",
+				errorMsg: "error on fetch proto descriptor",
 			},
 		}
 


### PR DESCRIPTION
## Summary

Per the assessment on #597, this reuses the existing hardened helper instead of writing a third bespoke HTTP path:

- `loadFromHTTP` (sample databases) is generalized into `loadFromHTTPWithLimit(ctx, uri, maxSize)` — 30s timeout, status check, Content-Length check, `io.LimitReader` cap — with the sample-database wrapper unchanged.
- `httpResolveFunc` (the protocompile import resolver, which previously had **no timeout, no status check, and unbounded reads**) and the descriptor-URL branch of `readFileDescriptorProtoFromFile` (no timeout, unbounded reads) now call the shared helper with the 100MB default cap.
- The local-file branch reads through `filesafety.SafeReadFile` (regular-file check + size cap) instead of bare `os.ReadFile`.

Two error-message expectations updated in tests (`cannot read special file` from filesafety; `error on fetch proto descriptor` prefix).

Fixes #597

## Test plan

- [x] `make check` (test + lint + fmt-check), including the proto descriptor file/URL test suite (404, compile-from-URL, directory rejection)
