### PR TITLE
Move default history file from shared /tmp to ~/.spanner_mycli_history

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Flags:
       --prompt=PROMPT                          Set the prompt to the specified format (default: "spanner%t> ")
       --prompt2=PROMPT2                        Set the prompt2 to the specified format (default: "%P%R> ")
       --history=HISTORY                        Set the history file to the specified path (default:
-                                               /tmp/spanner_mycli_readline.tmp)
+                                               ~/.spanner_mycli_history)
       --priority=STRING                        Set default request priority (HIGH|MEDIUM|LOW)
       --role=STRING                            Use the specific database role. --database-role is an alias.
       --endpoint=STRING                        Set the Spanner API endpoint (host:port)
@@ -951,7 +951,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | CLI_DIRECT_READ            | READ_ONLY  | `"asia-northeast:READ_ONLY"`                   |
 | CLI_ENDPOINT               | READ_ONLY  | `"spanner.me-central2.rep.googleapis.com:443"` |
 | CLI_FORMAT                 | READ_WRITE | `"TABLE"` (`"TAB"` in batch mode)              |
-| CLI_HISTORY_FILE           | READ_ONLY  | `"/tmp/spanner_mycli_readline.tmp"`            |
+| CLI_HISTORY_FILE           | READ_ONLY  | `"~/.spanner_mycli_history"`                   |
 | CLI_PROMPT                 | READ_WRITE | `"spanner%t> "`                                |
 | CLI_PROMPT2                | READ_WRITE | `"%P%R> "`                                     |
 | CLI_ROLE                   | READ_ONLY  | `"spanner_info_reader"`                        |

--- a/internal/mycli/app.go
+++ b/internal/mycli/app.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 
@@ -42,13 +43,25 @@ import (
 const (
 	defaultPrompt           = "spanner%t> "
 	defaultPrompt2          = "%P%R> "
-	defaultHistoryFile      = "/tmp/spanner_mycli_readline.tmp"
 	defaultVertexAIModel    = "gemini-3-flash-preview"
 	defaultVertexAILocation = "global"
 	DefaultAnalyzeColumns   = "Rows:{{.Rows.Total}},Exec.:{{.ExecutionSummary.NumExecutions}},Total Latency:{{.Latency}}"
 )
 
 var DefaultParsedAnalyzeColumns = lo.Must(customListToTableRenderDefs(DefaultAnalyzeColumns))
+
+// defaultHistoryFile returns the default history file path,
+// ~/.spanner_mycli_history, following the mysql/psql client convention of a
+// per-user dotfile. The previous default was a predictable, shared path under
+// /tmp, which is a privacy footgun on multi-user systems (#593). Falls back
+// to a relative dotfile when the home directory cannot be determined.
+func defaultHistoryFile() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".spanner_mycli_history"
+	}
+	return filepath.Join(home, ".spanner_mycli_history")
+}
 
 // buildVersion is set by Main() from ldflags-injected values in the root main package.
 var buildVersion string

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -652,7 +652,7 @@ func newFlagParser(gopts *globalOptions, installFrom string, configFiles []strin
 			"installFrom":             installFrom,
 			"defaultPromptQuoted":     strconv.Quote(defaultPrompt),
 			"defaultPrompt2Quoted":    strconv.Quote(defaultPrompt2),
-			"defaultHistoryFile":      defaultHistoryFile,
+			"defaultHistoryFile":      "~/.spanner_mycli_history", // display-only; keep environment-independent for README sync
 			"defaultVertexAIModel":    defaultVertexAIModel,
 			"defaultVertexAILocation": defaultVertexAILocation,
 		},

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1919,7 +1919,7 @@ func TestHelpOutputDocumentsDefaultsAndAllowedValues(t *testing.T) {
 		"--system-command=ON|OFF",
 		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt)),
 		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt2)),
-		fmt.Sprintf("default: %s", defaultHistoryFile),
+		"default: ~/.spanner_mycli_history",
 		"Allowed values: NORMAL, PLAN, PROFILE.",
 		fmt.Sprintf("default: %s", defaultVertexAIModel),
 		fmt.Sprintf("default: %s", defaultVertexAILocation),

--- a/internal/mycli/main_test.go
+++ b/internal/mycli/main_test.go
@@ -184,7 +184,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -239,7 +239,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -280,7 +280,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -319,7 +319,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -357,7 +357,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -402,7 +402,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -479,7 +479,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -520,7 +520,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -562,7 +562,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -603,7 +603,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -645,7 +645,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -684,7 +684,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       "Col1:{{.Col1}},Col2:{{.Col2}}",
 					ParsedAnalyzeColumns: lo.Must(customListToTableRenderDefs("Col1:{{.Col1}},Col2:{{.Col2}}")),
@@ -721,7 +721,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:             defaultPrompt,
 					Prompt2:            defaultPrompt2,
-					HistoryFile:        defaultHistoryFile,
+					HistoryFile:        defaultHistoryFile(),
 					CLIFormat:          enums.DisplayModeTable,
 					AnalyzeColumns:     DefaultAnalyzeColumns,
 					OutputTemplateFile: "output_full.tmpl",
@@ -760,7 +760,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -799,7 +799,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Display: DisplayVars{
 					Prompt:               defaultPrompt,
 					Prompt2:              defaultPrompt2,
-					HistoryFile:          defaultHistoryFile,
+					HistoryFile:          defaultHistoryFile(),
 					CLIFormat:            enums.DisplayModeTable,
 					AnalyzeColumns:       DefaultAnalyzeColumns,
 					ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,
@@ -915,7 +915,7 @@ func Test_newSystemVariablesWithDefaults(t *testing.T) {
 		Display: DisplayVars{
 			Prompt:               defaultPrompt,
 			Prompt2:              defaultPrompt2,
-			HistoryFile:          defaultHistoryFile,
+			HistoryFile:          defaultHistoryFile(),
 			CLIFormat:            enums.DisplayModeTable,
 			AnalyzeColumns:       DefaultAnalyzeColumns,
 			ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns,

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -301,7 +301,7 @@ func newSystemVariablesWithDefaults() systemVariables {
 			ParsedExplainPrintSections: DefaultParsedExplainPrintSections,
 			Prompt:                     defaultPrompt,
 			Prompt2:                    defaultPrompt2,
-			HistoryFile:                defaultHistoryFile,
+			HistoryFile:                defaultHistoryFile(),
 			OutputTemplate:             defaultOutputFormat,
 			TypeStylesRaw:              defaultTypeStyles,
 		},


### PR DESCRIPTION
## Summary

The default readline history path was `/tmp/spanner_mycli_readline.tmp` — a predictable, shared-temp location. SQL history can contain sensitive literals, so that is a privacy footgun on multi-user systems, and `/tmp` is awkward for persistence (#593).

- New default: `~/.spanner_mycli_history`, following the mysql/psql per-user dotfile convention (`~/.mysql_history`, `~/.psql_history`). No parent directory creation is needed, and history writes already open with `0o600`, satisfying the hardening criteria.
- `defaultHistoryFile` becomes a runtime function (home lookup with a relative-dotfile fallback).
- The `--history` help text and the README variable table show the environment-independent `~/.spanner_mycli_history` rather than interpolating the resolved path, keeping the `readme-sync` CI job machine-independent.

## Notes

- Existing history under `/tmp` is intentionally not auto-migrated (one-shot copy felt like more magic than it is worth for this tool); `--history /tmp/spanner_mycli_readline.tmp` keeps the old file working.
- Full XDG state-dir support was considered and skipped per the issue discussion — Go has no `os.UserStateDir`, and the home dotfile is the established convention for SQL client history.

Fixes #593

## Test plan

- [x] `make check` (test + lint + fmt-check); flag-help and system-variable default tests updated to the new path
- [x] `make docs-update` regenerated the README help section
