### PR TITLE
Remove unused row-buffering RunUpdate APIs

### DIFF
--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -577,10 +577,6 @@ func (s *Session) RunAnalyzeQuery(ctx context.Context, stmt spanner.Statement) (
 	return s.txn.RunAnalyzeQuery(ctx, stmt)
 }
 
-func (s *Session) RunUpdate(ctx context.Context, stmt spanner.Statement, implicit bool) ([]Row, map[string]any, int64, *sppb.ResultSetMetadata, *sppb.QueryPlan, error) {
-	return s.txn.RunUpdate(ctx, stmt, implicit)
-}
-
 func (s *Session) RunInNewOrExistRwTxLocked(ctx context.Context,
 	f func(tx *spanner.ReadWriteStmtBasedTransaction, implicit bool) (affected int64, plan *sppb.QueryPlan, metadata *sppb.ResultSetMetadata, err error),
 ) (*DMLResult, error) {

--- a/internal/mycli/session_slow_test.go
+++ b/internal/mycli/session_slow_test.go
@@ -118,7 +118,11 @@ func TestRequestPriority(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("failed to run query: %v", err)
 			}
-			if _, _, _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), true); err != nil {
+			if _, err := session.RunInNewOrExistRwTx(ctx, func(tx *spanner.ReadWriteStmtBasedTransaction, implicit bool) (int64, *sppb.QueryPlan, *sppb.ResultSetMetadata, error) {
+				iter := session.runQueryWithStatsOnTransaction(ctx, tx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), implicit)
+				_, count, metadata, plan, err := consumeRowIterDiscard(iter)
+				return count, plan, metadata, err
+			}); err != nil {
 				t.Fatalf("failed to run update: %v", err)
 			}
 			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -825,8 +825,8 @@ func (tm *TransactionManager) runAnalyzeQueryOnTransaction(ctx context.Context, 
 //
 //	RunInNewOrExistRwTx -> withReadWriteTransactionContext -> withTransactionLocked -> callback -> runUpdateOnTransaction
 //
-// Using non-locked versions of methods like TransactionAttrsWithLock(), currentPriorityWithLock(),
-// or queryOptionsWithLock() here will cause a deadlock. Always use the *Locked variants.
+// Using non-locked versions of methods like TransactionAttrsWithLock() or currentPriorityWithLock()
+// here will cause a deadlock. Always use the *Locked variants.
 func (tm *TransactionManager) runUpdateOnTransaction(ctx context.Context, tx *spanner.ReadWriteStmtBasedTransaction, stmt spanner.Statement, implicit bool) (*UpdateResult, error) {
 	fc, err := decoder.FormatConfigWithProto(tm.sysVars.Internal.ProtoDescriptor, tm.sysVars.Display.MultilineProtoText)
 	if err != nil {
@@ -1000,62 +1000,6 @@ func (tm *TransactionManager) runSingleUseQuery(ctx context.Context, stmt spanne
 		txn = txn.WithTimestampBound(*tm.sysVars.Query.ReadOnlyStaleness)
 	}
 	return txn.QueryWithOptions(ctx, stmt, opts), txn
-}
-
-// RunUpdate executes a DML statement on the running read-write transaction.
-// It returns error if there is no running read-write transaction.
-func (tm *TransactionManager) RunUpdate(ctx context.Context, stmt spanner.Statement, implicit bool) ([]Row, map[string]any, int64,
-	*sppb.ResultSetMetadata, *sppb.QueryPlan, error,
-) {
-	fc, err := decoder.FormatConfigWithProto(tm.sysVars.Internal.ProtoDescriptor, tm.sysVars.Display.MultilineProtoText)
-	if err != nil {
-		return nil, nil, 0, nil, nil, err
-	}
-
-	opts := tm.queryOptionsWithLock(sppb.ExecuteSqlRequest_PROFILE.Enum())
-	opts.LastStatement = implicit
-
-	// Reset STATEMENT_TAG
-	tm.sysVars.Transaction.RequestTag = ""
-
-	var rows []Row
-	var stats map[string]any
-	var count int64
-	var metadata *sppb.ResultSetMetadata
-	var plan *sppb.QueryPlan
-
-	err = tm.withReadWriteTransactionContext(func(txn *spanner.ReadWriteStmtBasedTransaction, tc *transactionContext) error {
-		var err error
-		rows, stats, count, metadata, plan, err = consumeRowIterCollect(
-			txn.QueryWithOptions(ctx, stmt, opts),
-			spannerRowToRow(fc, tm.sysVars.typeStyles, tm.sysVars.nullStyle),
-		)
-		// Enable heartbeat after any operation (success or failure)
-		// Even failed operations start the abort countdown
-		tc.EnableHeartbeat()
-		return err
-	})
-
-	if err == ErrNotInReadWriteTransaction {
-		return nil, nil, 0, nil, nil, ErrNotInReadWriteTransaction
-	}
-	if err != nil {
-		return nil, nil, 0, nil, nil, err
-	}
-
-	return rows, stats, count, metadata, plan, nil
-}
-
-func (tm *TransactionManager) queryOptionsWithLock(mode *sppb.ExecuteSqlRequest_QueryMode) spanner.QueryOptions {
-	return spanner.QueryOptions{
-		Mode:       mode,
-		Priority:   tm.currentPriorityWithLock(),
-		RequestTag: tm.sysVars.Transaction.RequestTag,
-		Options: &sppb.ExecuteSqlRequest_QueryOptions{
-			OptimizerVersion:           tm.sysVars.Query.OptimizerVersion,
-			OptimizerStatisticsPackage: tm.sysVars.Query.OptimizerStatisticsPackage,
-		},
-	}
 }
 
 // queryOptionsLocked returns query options without locking.


### PR DESCRIPTION
## Summary

Audit result for #650: `Session.RunUpdate` / `TransactionManager.RunUpdate` — the row-buffering DML API left behind by #648 — had exactly one caller, a slow test exercising request priority. This PR:

- Rewrites that test on the production DML shape (`RunInNewOrExistRwTx` + `runQueryWithStatsOnTransaction` + `consumeRowIterDiscard`), which also makes the test exercise the code path real DML uses.
- Deletes both `RunUpdate` methods and the now-orphaned `queryOptionsWithLock` helper (its only caller was `RunUpdate`); the deadlock-guidance comment referencing it is updated.

## Scope note

`UpdateResult.Rows` is intentionally kept: `renderDMLReturnedRows` needs the rows inside the transaction callback so that formatting errors still abort implicit DML commits (the issue's acceptance criterion). The "internal rendering/capture hook" idea from the issue body is therefore not implemented — it would add a layer for no behavior change. Batch DML summary output is untouched, per the issue's scope guard.

Fixes #650

## Test plan

- [x] `make check` (test + lint + fmt-check)
- [x] The rewritten priority test still covers DML on an explicit read-write transaction (ExecuteSqlRequest / CommitRequest priority assertions unchanged); it runs in the non-short suite
