### PR TITLE
Bound batch file reads while keeping process substitution working

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -265,7 +265,9 @@ func (c *Cli) updateSystemVariables(result *Result) {
 // executeSourceFile executes SQL statements from a file
 func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 	// Use common file safety checks (nil uses DefaultMaxFileSize - 100MB)
-	contents, err := filesafety.SafeReadFile(filePath, nil)
+	// AllowNonRegular keeps process substitution working for SOURCE / \.;
+	// SafeReadFile still bounds the read for pipe-like inputs.
+	contents, err := filesafety.SafeReadFile(filePath, &filesafety.FileSafetyOptions{AllowNonRegular: true})
 	if err != nil {
 		return err
 	}

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -1614,7 +1614,9 @@ func TestCli_executeSourceFile_NonExistentFile(t *testing.T) {
 	}
 }
 
-// TestCli_executeSourceFile_NonRegularFile tests executeSourceFile with a non-regular file
+// TestCli_executeSourceFile_NonRegularFile verifies that non-regular files
+// (process substitution FIFOs, /dev/null) are accepted by SOURCE since #596:
+// reads are bounded by SafeReadFile instead of rejected outright.
 func TestCli_executeSourceFile_NonRegularFile(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -1626,12 +1628,9 @@ func TestCli_executeSourceFile_NonRegularFile(t *testing.T) {
 		SystemVariables: &systemVariables{},
 	}
 
-	// Try to source from /dev/null (a special file)
-	err := cli.executeSourceFile(context.Background(), "/dev/null")
-	if err == nil {
-		t.Error("Expected error for non-regular file")
-	} else if !strings.Contains(err.Error(), "cannot read") {
-		t.Errorf("Expected error to contain 'cannot read', got: %v", err)
+	// /dev/null is a special file; it sources successfully as empty input.
+	if err := cli.executeSourceFile(context.Background(), "/dev/null"); err != nil {
+		t.Errorf("expected /dev/null to source as empty input, got: %v", err)
 	}
 }
 

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/filesafety"
 )
 
 type globalOptions struct {
@@ -736,7 +737,9 @@ func determineInputAndMode(opts *spannerOptions, stdin io.Reader) (input string,
 		}
 		return string(b), false, nil
 	case fileToRead != "":
-		b, err := os.ReadFile(fileToRead)
+		// AllowNonRegular keeps process substitution (--file <(...)) working;
+		// SafeReadFile still bounds the read for pipe-like inputs.
+		b, err := filesafety.SafeReadFile(fileToRead, &filesafety.FileSafetyOptions{AllowNonRegular: true})
 		if err != nil {
 			return "", false, fmt.Errorf("read from file %v failed: %w", fileToRead, err)
 		}

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -50,6 +50,13 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 		maxSize = DefaultMaxFileSize
 	}
 
+	// Directories are never readable as files, regardless of AllowNonRegular;
+	// reject them here for a clear error instead of a system-dependent
+	// os.ReadFile failure (EISDIR etc.).
+	if fi.IsDir() {
+		return fmt.Errorf("cannot read directory %s", path)
+	}
+
 	// Check for special files (devices, named pipes, sockets, etc.)
 	if !opts.AllowNonRegular {
 		if !fi.Mode().IsRegular() {

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -18,6 +18,7 @@ package filesafety
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -77,7 +78,11 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 	return nil
 }
 
-// SafeReadFile reads a file after performing safety checks
+// SafeReadFile reads a file after performing safety checks. For regular files
+// the size limit is enforced up front from Stat. Non-regular inputs (only
+// reachable with AllowNonRegular, e.g. process substitution FIFOs) report a
+// meaningless Stat size, so the read itself is capped at the size limit and
+// exceeding it is an error rather than a truncation.
 func SafeReadFile(path string, opts *FileSafetyOptions) ([]byte, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
@@ -88,5 +93,27 @@ func SafeReadFile(path string, opts *FileSafetyOptions) ([]byte, error) {
 		return nil, err
 	}
 
-	return os.ReadFile(path)
+	if fi.Mode().IsRegular() {
+		return os.ReadFile(path)
+	}
+
+	maxSize := int64(DefaultMaxFileSize)
+	if opts != nil && opts.MaxSize != 0 {
+		maxSize = opts.MaxSize
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	if int64(len(data)) > maxSize {
+		return nil, fmt.Errorf("file %s too large: exceeded %d bytes", path, maxSize)
+	}
+	return data, nil
 }

--- a/internal/mycli/filesafety/file_safety_test.go
+++ b/internal/mycli/filesafety/file_safety_test.go
@@ -208,3 +208,48 @@ func TestFileSafetyConstants(t *testing.T) {
 		t.Errorf("SampleDatabaseMaxFileSize = %d, want %d", SampleDatabaseMaxFileSize, 10*1024*1024)
 	}
 }
+
+// TestSafeReadFile_nonRegularBoundedRead verifies that AllowNonRegular inputs
+// (e.g. process substitution FIFOs) are read through a size-capped reader:
+// Stat size is meaningless for pipes, so the cap must apply to the read itself.
+func TestSafeReadFile_nonRegularBoundedRead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	makeFIFO := func(t *testing.T, payload []byte) string {
+		t.Helper()
+		fifo := filepath.Join(t.TempDir(), "fifo")
+		if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+			t.Fatalf("mkfifo: %v", err)
+		}
+		go func() {
+			f, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+			if err != nil {
+				return
+			}
+			defer f.Close()
+			_, _ = f.Write(payload)
+		}()
+		return fifo
+	}
+
+	t.Run("within limit", func(t *testing.T) {
+		fifo := makeFIFO(t, []byte("SELECT 1;"))
+		got, err := SafeReadFile(fifo, &FileSafetyOptions{AllowNonRegular: true, MaxSize: 64})
+		if err != nil {
+			t.Fatalf("SafeReadFile: %v", err)
+		}
+		if string(got) != "SELECT 1;" {
+			t.Errorf("got %q, want %q", got, "SELECT 1;")
+		}
+	})
+
+	t.Run("exceeds limit", func(t *testing.T) {
+		fifo := makeFIFO(t, []byte("0123456789"))
+		_, err := SafeReadFile(fifo, &FileSafetyOptions{AllowNonRegular: true, MaxSize: 4})
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("error = %v, want too-large error", err)
+		}
+	})
+}

--- a/internal/mycli/filesafety/file_safety_test.go
+++ b/internal/mycli/filesafety/file_safety_test.go
@@ -78,7 +78,7 @@ func TestValidateFileSafety(t *testing.T) {
 			path:    tmpDir,
 			opts:    nil,
 			wantErr: true,
-			errMsg:  "cannot read special file",
+			errMsg:  "cannot read directory",
 		},
 	}
 
@@ -252,4 +252,15 @@ func TestSafeReadFile_nonRegularBoundedRead(t *testing.T) {
 			t.Fatalf("error = %v, want too-large error", err)
 		}
 	})
+}
+
+// TestSafeReadFile_directoryRejectedEvenWithAllowNonRegular verifies that
+// directories are rejected with a clear error regardless of AllowNonRegular.
+func TestSafeReadFile_directoryRejectedEvenWithAllowNonRegular(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := SafeReadFile(dir, &FileSafetyOptions{AllowNonRegular: true})
+	if err == nil || !strings.Contains(err.Error(), "cannot read directory") {
+		t.Fatalf("error = %v, want cannot-read-directory error", err)
+	}
 }

--- a/internal/mycli/system_variables_test.go
+++ b/internal/mycli/system_variables_test.go
@@ -362,7 +362,7 @@ func TestSystemVariables_ProtoDescriptorFiles(t *testing.T) {
 			{
 				desc:     "directory instead of file",
 				filename: "testdata/protos/",
-				errorMsg: "cannot read special file",
+				errorMsg: "cannot read directory",
 			},
 			{
 				desc:     "large invalid binary file",


### PR DESCRIPTION
## Summary

Resolution of the open decision in #596: process substitution should keep working (per maintainer direction), so `--file` inputs go through `filesafety.SafeReadFile` with `AllowNonRegular: true` rather than rejecting FIFOs.

That made a latent gap in the helper matter: for non-regular files, `Stat().Size()` is meaningless (FIFOs report 0), and `SafeReadFile` then fell through to an **unbounded** `os.ReadFile`. Non-regular reads (only reachable with `AllowNonRegular`) now stream through `io.LimitReader` with the configured cap, and exceeding it is an error rather than a truncation. Regular files keep the cheap stat-based pre-check.

`SOURCE` / `\.` gets the same `AllowNonRegular` policy for consistency — it previously rejected FIFOs outright, so `SOURCE <(...)` now works too.

Fixes #596

## Test plan

- [x] `make check`
- [x] New FIFO tests (skipped on Windows): within-limit read returns content; exceeding `MaxSize` errors with "too large" instead of truncating or hanging
