### PR TITLE
Migrate SHOW LOCAL/REMOTE PROTO to the spanenc virtual result set bridge

### DIFF
--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -522,7 +522,6 @@ type statementTestCase struct {
 	cmpOpts     []cmp.Option
 }
 
-// runStatementTests is a helper function to run statement execution tests
 // typedStringHeader builds the typesTableHeader produced by spanenc-backed
 // virtual result sets whose columns are all STRING (see executeStructRows).
 func typedStringHeader(names ...string) TableHeader {
@@ -533,6 +532,7 @@ func typedStringHeader(names ...string) TableHeader {
 	return toTableHeader(fields...)
 }
 
+// runStatementTests is a helper function to run statement execution tests
 func runStatementTests(t *testing.T, tests []statementTestCase) {
 	t.Helper()
 	t.Parallel()

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -523,6 +523,16 @@ type statementTestCase struct {
 }
 
 // runStatementTests is a helper function to run statement execution tests
+// typedStringHeader builds the typesTableHeader produced by spanenc-backed
+// virtual result sets whose columns are all STRING (see executeStructRows).
+func typedStringHeader(names ...string) TableHeader {
+	fields := make([]*sppb.StructType_Field, 0, len(names))
+	for _, name := range names {
+		fields = append(fields, &sppb.StructType_Field{Name: name, Type: &sppb.Type{Code: sppb.TypeCode_STRING}})
+	}
+	return toTableHeader(fields...)
+}
+
 func runStatementTests(t *testing.T, tests []statementTestCase) {
 	t.Helper()
 	t.Parallel()
@@ -860,10 +870,7 @@ func TestShowStatements(t *testing.T) {
 					"SHOW VARIABLES",
 					&Result{
 						// Virtual result sets carry row-type metadata like server results.
-						TableHeader: toTableHeader(
-							&sppb.StructType_Field{Name: "name", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
-							&sppb.StructType_Field{Name: "value", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
-						),
+						TableHeader:   typedStringHeader("name", "value"),
 						KeepVariables: true,
 						// Rows and AffectedRows are dynamic, so we don't check them here.
 					},
@@ -1141,7 +1148,7 @@ func TestProtoStatements(t *testing.T) {
 				{
 					stmt: `SHOW LOCAL PROTO`,
 					want: &Result{
-						TableHeader: toTableHeader("full_name", "kind", "package", "file"),
+						TableHeader: typedStringHeader("full_name", "kind", "package", "file"),
 						Rows: sliceOf(
 							toRow("examples.shipping.Order", "PROTO", "examples.shipping", "order_protos.proto"),
 							toRow("examples.shipping.Order.Address", "PROTO", "examples.shipping", "order_protos.proto"),
@@ -1161,7 +1168,7 @@ func TestProtoStatements(t *testing.T) {
 				{
 					stmt: `SHOW LOCAL PROTO`,
 					want: &Result{
-						TableHeader: toTableHeader("full_name", "kind", "package", "file"),
+						TableHeader: typedStringHeader("full_name", "kind", "package", "file"),
 						Rows: sliceOf(
 							toRow("examples.spanner.music.SingerInfo", "PROTO", "examples.spanner.music", "testdata/protos/singer.proto"),
 							toRow("examples.spanner.music.CustomSingerInfo", "PROTO", "examples.spanner.music", "testdata/protos/singer.proto"),
@@ -1178,7 +1185,7 @@ func TestProtoStatements(t *testing.T) {
 			desc: "PROTO BUNDLE statements",
 			// Note: Current cloud-spanner-emulator only accepts DDL, but it is nop.
 			stmtResults: []stmtResult{
-				sr("SHOW REMOTE PROTO", &Result{KeepVariables: true, TableHeader: toTableHeader("full_name", "kind", "package")}),
+				sr("SHOW REMOTE PROTO", &Result{KeepVariables: true, TableHeader: typedStringHeader("full_name", "kind", "package")}),
 				srKeep(`SET CLI_PROTO_DESCRIPTOR_FILE = "testdata/protos/order_descriptors.pb"`),
 				srEmpty("CREATE PROTO BUNDLE (`examples.shipping.Order`)"),
 				srEmpty("ALTER PROTO BUNDLE DELETE (`examples.shipping.Order`)"),

--- a/internal/mycli/statements_proto.go
+++ b/internal/mycli/statements_proto.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/apstndb/lox"
+	"github.com/apstndb/spanenc"
 	"github.com/bufbuild/protocompile/walk"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/samber/lo"
@@ -19,12 +20,19 @@ import (
 	"github.com/apstndb/spanner-mycli/internal/proto/zetasql"
 )
 
+// descriptorInfo is the row shape for SHOW LOCAL PROTO; SHOW REMOTE PROTO
+// uses the same shape with the file column masked out.
 type descriptorInfo struct {
-	FullName string
-	Kind     string
-	Package  string
-	FileName string
+	FullName string `spanner:"full_name"`
+	Kind     string `spanner:"kind"`
+	Package  string `spanner:"package"`
+	FileName string `spanner:"file"`
 }
+
+var (
+	localProtoRowEncoder  = spanenc.MustNewRowEncoder[*descriptorInfo]()
+	remoteProtoRowEncoder = spanenc.MustNewRowEncoder[*descriptorInfo](spanenc.WithoutColumns("file"))
+)
 
 type SyncProtoStatement struct {
 	UpsertPaths []string
@@ -80,21 +88,12 @@ type ShowLocalProtoStatement struct{}
 func (s *ShowLocalProtoStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	fds := session.systemVariables.Internal.ProtoDescriptor
 
-	rows := slices.Collect(
-		loi.Map(
-			loi.FlatMap(slices.Values(fds.GetFile()), fdpToInfo),
-			func(info *descriptorInfo) Row {
-				return toRow(info.FullName, info.Kind, info.Package, info.FileName)
-			},
-		),
-	)
-
-	return &Result{
-		TableHeader:   toTableHeader("full_name", "kind", "package", "file"),
-		Rows:          rows,
-		AffectedRows:  len(rows),
-		KeepVariables: true,
-	}, nil
+	result, err := executeStructRows(localProtoRowEncoder, slices.Collect(fdsToInfoSeq(fds)), session.systemVariables)
+	if err != nil {
+		return nil, err
+	}
+	result.KeepVariables = true
+	return result, nil
 }
 
 type ShowRemoteProtoStatement struct{}
@@ -110,21 +109,12 @@ func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session
 		return nil, err
 	}
 
-	rows := slices.Collect(
-		loi.Map(
-			loi.FlatMap(slices.Values(fds.GetFile()), fdpToInfo),
-			func(info *descriptorInfo) Row {
-				return toRow(info.FullName, info.Kind, info.Package)
-			},
-		),
-	)
-
-	return &Result{
-		TableHeader:   toTableHeader("full_name", "kind", "package"),
-		Rows:          rows,
-		AffectedRows:  len(rows),
-		KeepVariables: true,
-	}, nil
+	result, err := executeStructRows(remoteProtoRowEncoder, slices.Collect(fdsToInfoSeq(&fds)), session.systemVariables)
+	if err != nil {
+		return nil, err
+	}
+	result.KeepVariables = true
+	return result, nil
 }
 
 // Helper functions


### PR DESCRIPTION
## Summary

Implements #660's named candidates: `descriptorInfo` (already a stable struct) gains `spanner` tags, and both proto listing statements render through `executeStructRows`:

- `SHOW LOCAL PROTO` — full row shape (`full_name`, `kind`, `package`, `file`)
- `SHOW REMOTE PROTO` — same struct with the `file` column masked via `spanenc.WithoutColumns("file")`, exactly the column-mask variant the issue anticipated

One struct, two compiled package-level encoders (`MustNewRowEncoder`). The hand-built `toRow` assembly is deleted; both statements now get typed verbose headers and CSV/JSONL streaming (`streamStructRows` / `writer.WriteRowSeq`) like server results. `AffectedRows` / `KeepVariables` behavior is preserved; integration test header expectations move to a shared `typedStringHeader` helper (also adopted by the SHOW VARIABLES expectation from #661).

## Audit of remaining `toRow` call sites (why the migration stops here)

- **SHOW OPERATIONS family**: row-grouped display where continuation rows use empty cells in `DONE`/`PROGRESS`/`COMMIT_TIMESTAMP` columns. A typed shape would force NULL rendering (`NULL` vs today's empty string) — that output-design decision should be made deliberately, not as a side effect of this migration.
- **SHOW DATABASES / HELP / GEMINI / SHOW PARAMS / DDL text rows**: string-only with no concrete plan for typed columns, dynamic column names, or pre-rendered text — the spanenc adoption guide's poor-fit cases; deliberately kept on `toRow`.
- **DDL results' `Commit Timestamp` (execute_ddl.go)**: a genuine typed candidate, but it lives on the DDL execution path rather than a SHOW statement; better as its own follow-up if wanted.

Fixes #660

## Test plan

- [x] `make check` (test + lint + fmt-check), including the proto statement integration tests (pb-file and proto-file fixtures, REMOTE PROTO against the emulator)
