### PR TITLE
Migrate SHOW DATABASES, SHOW PARAMS, and HELP to the spanenc bridge

### DIFF
--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -661,8 +661,9 @@ func TestParameterStatements(t *testing.T) {
 					"SHOW PARAMS",
 					&Result{
 						KeepVariables: true,
-						TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),
+						TableHeader:   typedStringHeader("Param_Name", "Param_Kind", "Param_Value"),
 						Rows:          sliceOf(toRow("i", "TYPE", "INT64")),
+						AffectedRows:  1,
 					},
 				},
 				{
@@ -685,8 +686,9 @@ func TestParameterStatements(t *testing.T) {
 					"SHOW PARAMS",
 					&Result{
 						KeepVariables: true,
-						TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),
+						TableHeader:   typedStringHeader("Param_Name", "Param_Kind", "Param_Value"),
 						Rows:          sliceOf(toRow("b", "VALUE", "2")),
+						AffectedRows:  1,
 					},
 				},
 			},
@@ -980,7 +982,7 @@ func TestShowStatements(t *testing.T) {
 				{
 					"SHOW DATABASES",
 					&Result{
-						TableHeader: toTableHeader("Database"),
+						TableHeader: typedStringHeader("Database"),
 						// Don't check specific rows since databases vary
 					},
 				},
@@ -1214,7 +1216,7 @@ func TestAdminStatements(t *testing.T) {
 				{
 					stmt: "SHOW DATABASES",
 					want: &Result{
-						TableHeader: toTableHeader("Database"),
+						TableHeader: typedStringHeader("Database"),
 						// Don't check specific content
 					},
 				},
@@ -1222,7 +1224,7 @@ func TestAdminStatements(t *testing.T) {
 				{
 					stmt: "SHOW DATABASES",
 					want: &Result{
-						TableHeader: toTableHeader("Database"),
+						TableHeader: typedStringHeader("Database"),
 						// Don't check specific content
 					},
 				},
@@ -1263,7 +1265,7 @@ func TestAdminStatements(t *testing.T) {
 				{
 					stmt: "SHOW DATABASES", // Should show both databases
 					want: &Result{
-						TableHeader:  toTableHeader("Database"),
+						TableHeader:  typedStringHeader("Database"),
 						Rows:         sliceOf(toRow("test-database"), toRow("test_detach_db")), // Both databases
 						AffectedRows: 2,
 					},
@@ -1297,19 +1299,19 @@ func TestAdminStatements(t *testing.T) {
 			stmtResults: []stmtResult{
 				{
 					stmt: "SHOW DATABASES",
-					want: &Result{TableHeader: toTableHeader("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
+					want: &Result{TableHeader: typedStringHeader("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
 				},
 				srEmpty("CREATE DATABASE `new-database`"), // CREATE DATABASE returns empty result
 				{
 					stmt: "SHOW DATABASES",
-					want: &Result{TableHeader: toTableHeader("Database"), Rows: sliceOf(toRow("new-database"), toRow("test-database")), AffectedRows: 2},
+					want: &Result{TableHeader: typedStringHeader("Database"), Rows: sliceOf(toRow("new-database"), toRow("test-database")), AffectedRows: 2},
 				},
 				srEmpty("USE `new-database` ROLE spanner_info_reader"), // nop
 				srEmpty("USE `test-database`"),                         // nop
 				srEmpty("DROP DATABASE `new-database`"),                // DROP DATABASE
 				{
 					stmt: "SHOW DATABASES",
-					want: &Result{TableHeader: toTableHeader("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
+					want: &Result{TableHeader: typedStringHeader("Database"), Rows: sliceOf(toRow("test-database")), AffectedRows: 1},
 				},
 			},
 			// Ignore duration field in CREATE DATABASE result

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apstndb/gsqlutils"
 	"github.com/apstndb/lox"
 	"github.com/apstndb/memebridge"
+	"github.com/apstndb/spanenc"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/gcvctor"
@@ -196,26 +197,29 @@ func (s *ShowDatabasesStatement) isDetachedCompatible() {}
 
 var extractDatabaseRe = regexp.MustCompile(`projects/[^/]+/instances/[^/]+/databases/(.+)`)
 
+// databaseNameRow is the row shape for SHOW DATABASES.
+type databaseNameRow struct {
+	Database string `spanner:"Database"`
+}
+
+var showDatabasesRowEncoder = spanenc.MustNewRowEncoder[databaseNameRow]()
+
 func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	dbIter := session.adminClient.ListDatabases(ctx, &databasepb.ListDatabasesRequest{
 		Parent: session.InstancePath(),
 	})
 
-	var rows []Row
+	var items []databaseNameRow
 	for database, err := range dbIter.All() {
 		if err != nil {
 			return nil, err
 		}
 
 		matched := extractDatabaseRe.FindStringSubmatch(database.GetName())
-		rows = append(rows, toRow(matched[1]))
+		items = append(items, databaseNameRow{Database: matched[1]})
 	}
 
-	return &Result{
-		TableHeader:  toTableHeader("Database"),
-		Rows:         rows,
-		AffectedRows: len(rows),
-	}, nil
+	return executeStructRows(showDatabasesRowEncoder, items, session.systemVariables)
 }
 
 // Split Points
@@ -729,19 +733,33 @@ type HelpStatement struct{}
 
 func (s *HelpStatement) isDetachedCompatible() {}
 
+// helpRow is the row shape for HELP.
+type helpRow struct {
+	Usage  string `spanner:"Usage"`
+	Syntax string `spanner:"Syntax"`
+}
+
+var helpRowEncoder = spanenc.MustNewRowEncoder[helpRow]()
+
 func (s *HelpStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	var rows []Row
+	var items []helpRow
 	for _, stmt := range clientSideStatementDefs {
 		for _, desc := range stmt.Descriptions {
-			rows = append(rows, toRow(desc.Usage, desc.Syntax+";"))
+			items = append(items, helpRow{Usage: desc.Usage, Syntax: desc.Syntax + ";"})
 		}
 	}
-	return &Result{
-		TableHeader:   toTableHeader("Usage", "Syntax"),
-		Rows:          rows,
-		AffectedRows:  len(rows),
-		KeepVariables: true,
-	}, nil
+
+	// session is nil when HELP is rendered without a connection.
+	var sysVars *systemVariables
+	if session != nil {
+		sysVars = session.systemVariables
+	}
+	result, err := executeStructRows(helpRowEncoder, items, sysVars)
+	if err != nil {
+		return nil, err
+	}
+	result.KeepVariables = true
+	return result, nil
 }
 
 type ExitStatement struct {

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -216,6 +216,9 @@ func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) 
 		}
 
 		matched := extractDatabaseRe.FindStringSubmatch(database.GetName())
+		if len(matched) < 2 {
+			return nil, fmt.Errorf("unexpected database resource name format: %q", database.GetName())
+		}
 		items = append(items, databaseNameRow{Database: matched[1]})
 	}
 

--- a/internal/mycli/statements_params.go
+++ b/internal/mycli/statements_params.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/apstndb/lox"
+	"github.com/apstndb/spanenc"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/samber/lo"
@@ -16,17 +17,32 @@ type ShowParamsStatement struct{}
 
 func (s *ShowParamsStatement) isDetachedCompatible() {}
 
-func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	rows := lo.MapToSlice(session.systemVariables.Params, func(k string, v ast.Node) Row {
-		return toRow(k, lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"), v.SQL())
-	})
-	slices.SortFunc(rows, func(lhs, rhs Row) int { return cmp.Compare(lhs[0].RawText(), rhs[0].RawText()) /* parameter name */ })
+// paramRow is the row shape for SHOW PARAMS. Param_Value is the memefish
+// SQL rendering of the parameter, so it stays a string by design.
+type paramRow struct {
+	Name  string `spanner:"Param_Name"`
+	Kind  string `spanner:"Param_Kind"`
+	Value string `spanner:"Param_Value"`
+}
 
-	return &Result{
-		TableHeader:   toTableHeader("Param_Name", "Param_Kind", "Param_Value"),
-		Rows:          rows,
-		KeepVariables: true,
-	}, nil
+var showParamsRowEncoder = spanenc.MustNewRowEncoder[paramRow]()
+
+func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	items := lo.MapToSlice(session.systemVariables.Params, func(k string, v ast.Node) paramRow {
+		return paramRow{
+			Name:  k,
+			Kind:  lo.Ternary(lox.InstanceOf[ast.Type](v), "TYPE", "VALUE"),
+			Value: v.SQL(),
+		}
+	})
+	slices.SortFunc(items, func(lhs, rhs paramRow) int { return cmp.Compare(lhs.Name, rhs.Name) })
+
+	result, err := executeStructRows(showParamsRowEncoder, items, session.systemVariables)
+	if err != nil {
+		return nil, err
+	}
+	result.KeepVariables = true
+	return result, nil
 }
 
 type UnsetParamStatement struct {


### PR DESCRIPTION
## Summary

Follow-up to #673, applying the maintainer direction that practical benefit, not adoption-guide deference, should drive migration: the guide's string-only caution was written for the pre-#661 cost structure (every migration added a bespoke GCV bridge); with `executeStructRows` the cost is a struct plus one call, and each fixed-shape statement gains typed verbose headers and CSV/JSONL streaming via `writer.WriteRowSeq`.

- **SHOW DATABASES** → `databaseNameRow`. Streaming benefits scripting (`--format=JSONL -e 'SHOW DATABASES'`), and typed columns (state, create time) are plausible future additions per gcloud parity (#5).
- **SHOW PARAMS** → `paramRow` (`Param_Value` stays a string by design — it is the memefish SQL rendering). Also fixes a footer bug: `AffectedRows` was unset, so the interactive result line said `Empty set` under rendered rows — the same bug SHOW VARIABLES had before #661.
- **HELP** → `helpRow`, tolerating the nil-session invocation used by tests/docs rendering.

## Still deliberately on `toRow`

- **SHOW OPERATIONS family**: continuation rows use empty cells in typed-looking columns; migrating forces a NULL-vs-empty output decision that should be made explicitly (open question on #660's audit, happy to follow up either way).
- **GEMINI**: each row is a different field of one record (transposed layout) — structurally not row structs.
- **SHOW VARIABLE (singular)**: dynamic column names.
- **Pre-rendered DDL/SQL text rows**: already display strings with no shape to type.

## Behavior changes

- Verbose headers for the three statements show column types (consistent with all other migrated virtual result sets).
- SHOW PARAMS result line reports `N rows in set` instead of `Empty set`.

## Test plan

- [x] `make check` (test + lint + fmt-check); integration expectations updated to `typedStringHeader` and the corrected SHOW PARAMS `AffectedRows`
