### PR TITLE
deps: bump github.com/apstndb/spanvalue from v0.7.5 to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spantype v0.3.11
-	github.com/apstndb/spanvalue v0.7.5
+	github.com/apstndb/spanvalue v0.8.0
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -2503,8 +2503,8 @@ github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.7.5 h1:qxx/dJ2BnNwS8rT347mKrwDbC2I9pckv9rC91+5fXuU=
-github.com/apstndb/spanvalue v0.7.5/go.mod h1:bqVJYydQf+D0Tux1LtyRlREPVwrVYNG+1usZJ489GTA=
+github.com/apstndb/spanvalue v0.8.0 h1:wLHl/0m5C6PvRwJOJoz1nRL4qSpS17eS1tW3Pjzcvo8=
+github.com/apstndb/spanvalue v0.8.0/go.mod h1:bqVJYydQf+D0Tux1LtyRlREPVwrVYNG+1usZJ489GTA=
 github.com/apstndb/structfields v0.1.0 h1:TQbi8EpzLyDr1GOsLWJfMQrtw+cq7BQhNCHhqZTCtEg=
 github.com/apstndb/structfields v0.1.0/go.mod h1:iZuSnr5cvgVvMaEhm0ceB+auA+MeNmA1mtnBA05m9Qw=
 github.com/apstndb/structfields/spannertag v0.1.0 h1:faXv5yYgKHV4DA3V0UpL4D9cTgMM87yacNbno0p3ulM=


### PR DESCRIPTION
## Summary

Bumps `github.com/apstndb/spanvalue` from v0.7.5 to v0.8.0 ([release notes](https://github.com/apstndb/spanvalue/releases/tag/v0.8.0)).

v0.8.0 is a **breaking release upstream** (`FormatConfig` collapses to `NullString` + the `FormatComplexPlugins` chain; deprecated fields/identifiers removed), but spanner-mycli requires **no code changes** — verified both in a pre-release downstream check (the v0.8.0 release notes list spanner-mycli as building and passing unmodified) and again here after the bump. Its only root-spanvalue surface is:

- preset constructors (`LiteralFormatConfig`, `SpannerCLICompatibleFormatConfig().Clone()`, `JSONFormatConfig`)
- `FormatRow*` / `FormatColumn*` convenience wrappers and `QuoteIdentifier` / `QuoteQualifiedIdentifier`
- writer options
- a `[]spanvalue.FormatComplexFunc` composite literal of protofmt plugin values — the `FormatComplexFunc` alias→defined-type change is transparent to plain function values

All of these are unchanged in v0.8.0. Preset outputs are byte-identical to v0.7.6 per the upstream golden tests.

## Test plan

- [x] `go build ./...`
- [x] `make check` (test + lint + fmt-check) — all pass; `golangci-lint` reports 0 issues
- [x] Emulator integration tests included: Docker was available, so `go test ./...` ran the spanemuboost/testcontainers-backed integration tests against `gcr.io/cloud-spanner-emulator/emulator` (verified a representative test executes against a real emulator container rather than skipping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
