### PR TITLE
Use spanvalue flush option for CSV streaming

### DIFF
--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -72,10 +72,7 @@ func streamPartitionedQuery(
 		return nil, handled, err
 	}
 
-	hooks := writer.AfterEachSuccessfulWriteRow(
-		writer.RowIteratorHooksFromWriter(w),
-		func() error { return flushSpanvalueStreamingRow(w) },
-	)
+	hooks := writer.RowIteratorHooksFromWriter(w)
 
 	var runResult *writer.RowIteratorResult
 	err = runPartitionedRowSeq(ctx, batchROTx, partitions, parallelism,

--- a/internal/mycli/row_iterator_transform.go
+++ b/internal/mycli/row_iterator_transform.go
@@ -35,7 +35,6 @@ type rowIteratorRunConfig struct {
 	transformErrorLabel string
 	writeErrorLabel     string
 	finishErrorLabel    string
-	afterWriteRow       func() error
 }
 
 type rowIteratorRunOption func(*rowIteratorRunConfig)
@@ -51,12 +50,6 @@ func withRowIteratorErrorLabels(transformLabel, writeLabel, finishLabel string) 
 		c.transformErrorLabel = transformLabel
 		c.writeErrorLabel = writeLabel
 		c.finishErrorLabel = finishLabel
-	}
-}
-
-func withRowIteratorAfterWriteRow(f func() error) rowIteratorRunOption {
-	return func(c *rowIteratorRunConfig) {
-		c.afterWriteRow = f
 	}
 }
 
@@ -99,11 +92,6 @@ func runRowIteratorTransform[T any](
 				cfg.metrics.RowCount = rowCount
 			}
 
-			if cfg.afterWriteRow != nil {
-				if err := cfg.afterWriteRow(); err != nil {
-					return err
-				}
-			}
 			return nil
 		},
 		Finish: func(result *writer.RowIteratorResult) error {

--- a/internal/mycli/spanvalue_streaming.go
+++ b/internal/mycli/spanvalue_streaming.go
@@ -122,6 +122,7 @@ func newSpanvalueRowIteratorWriterFor(sysVars *systemVariables, fc *spanvalue.Fo
 			writer.WithFormatter(fc),
 			writer.WithHeader(!sysVars.Display.SkipColumnNames),
 			writer.WithUnnamedFieldNamer(nil),
+			writer.WithFlushEachRow(),
 		)
 		if err != nil {
 			return nil, true, err
@@ -211,7 +212,6 @@ func runSpanvalueRowIterator(qe *queryExecution, w writer.RowIteratorWriter) (*w
 			},
 		},
 		withRowIteratorMetrics(qe.Metrics),
-		withRowIteratorAfterWriteRow(func() error { return flushSpanvalueStreamingRow(w) }),
 	)
 }
 
@@ -269,16 +269,6 @@ func rowIteratorResultParts(result *writer.RowIteratorResult) ([]*sppb.StructTyp
 		fields = result.Metadata.GetRowType().GetFields()
 	}
 	return fields, result.Stats.QueryStats, result.Stats.QueryPlan
-}
-
-func flushSpanvalueStreamingRow(w writer.RowIteratorWriter) error {
-	// RowIteratorWriter always has Flush, but per-row flushing is only safe for
-	// DelimitedWriter. SQLInsertWriter.Flush finalizes partial INSERT batches and
-	// would defeat CLI_SQL_BATCH_SIZE if called after every row.
-	if _, ok := w.(*writer.DelimitedWriter); !ok {
-		return nil
-	}
-	return w.Flush()
 }
 
 func normalizeSpanvalueWriterError(err error) error {


### PR DESCRIPTION
## Summary

- use spanvalue's `writer.WithFlushEachRow()` for CSV streaming output
- remove the spanner-mycli-specific per-row flush hook and `DelimitedWriter` type assertion
- keep SQL INSERT batching untouched by leaving final batch flushing to spanvalue writer hooks

## Spanvalue-side check

No spanvalue change is needed for this downstream cleanup. `WithFlushEachRow()` already exists in the selected `github.com/apstndb/spanvalue v0.8.0`, and spanvalue's writer docs already recommend it for delimited streaming instead of custom per-row hooks.

## Verification

- `env MISE_CACHE_DIR=/private/tmp/mise-cache make check` *(passed outside the Codex sandbox; sandbox blocks `httptest` loopback listeners)*
- `mise x --no-deps -- go test ./internal/mycli -run '^TestSQLExportStreamingMode$'` *(passed outside the sandbox after Colima restart)*
- `mise x --no-deps -- go test ./internal/mycli -run '^TestPartitionedStatements$'` *(passed outside the sandbox after Colima restart)*
