### PR TITLE
Use spanstats for query stats parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1569,7 +1569,7 @@ spanner> SHOW SPLIT POINTS;
 ### Configurable query stats
 
 The detail lines are customizable using Go text/template.
-Note: You need to know `OutputContext` and `QueryStats` struct in source code of spanner-mycli.
+Note: You need to know `OutputContext` in spanner-mycli and `spanstats.QueryStats`.
 
 ```
 $ curl -sL https://github.com/apstndb/spanner-mycli/raw/main/output_full.tmpl -o output_full.tmpl

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/apstndb/spanemuboost v0.4.1
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
+	github.com/apstndb/spanstats v0.1.0
 	github.com/apstndb/spantype v0.3.11
 	github.com/apstndb/spanvalue v0.8.0
 	github.com/bufbuild/protocompile v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -2501,6 +2501,8 @@ github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6/go.mod h1:Enpmw/D11tME865ROYDQzoHSIo9V8uCgWdu+fxA7n2M=
 github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+zhg2c=
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
+github.com/apstndb/spanstats v0.1.0 h1:wAPqtFn1AfQaIudB4HwTLiIPinwWJw/gQhgE7NQWVKo=
+github.com/apstndb/spanstats v0.1.0/go.mod h1:DFGYC9e7WE0BFQL0st6EQwrl1Pn2FuvDWSefwI9FTWc=
 github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
 github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
 github.com/apstndb/spanvalue v0.8.0 h1:wLHl/0m5C6PvRwJOJoz1nRL4qSpS17eS1tW3Pjzcvo8=

--- a/internal/mycli/query_stats_test.go
+++ b/internal/mycli/query_stats_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseQueryStatsPreservesUnknown(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseQueryStats(map[string]any{
+		"elapsed_time":  "1.23 msecs",
+		"rows_returned": 42,
+		"future_key":    "future value",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := QueryStats{
+		ElapsedTime: "1.23 msecs",
+		Unknown: map[string]any{
+			"rows_returned": 42,
+			"future_key":    "future value",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("parseQueryStats mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseQueryProfilePreservesQueryStatsUnknown(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseQueryProfile(`{
+		"queryPlan": {"planNodes": []},
+		"queryStats": {
+			"elapsed_time": "1.23 msecs",
+			"rows_returned": 42,
+			"future_key": "future value"
+		},
+		"fprint": "123"
+	}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := QueryStats{
+		ElapsedTime: "1.23 msecs",
+		Unknown: map[string]any{
+			"rows_returned": float64(42),
+			"future_key":    "future value",
+		},
+	}
+	if diff := cmp.Diff(want, got.QueryStats); diff != "" {
+		t.Errorf("parseQueryProfile QueryStats mismatch (-want +got):\n%s", diff)
+	}
+	if got.Fprint != "123" {
+		t.Errorf("Fprint = %q, want %q", got.Fprint, "123")
+	}
+}

--- a/internal/mycli/row_iter.go
+++ b/internal/mycli/row_iter.go
@@ -8,8 +8,8 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
+	"github.com/apstndb/spanstats"
 	"github.com/apstndb/spanvalue"
-	"github.com/go-json-experiment/json"
 	loi "github.com/samber/lo/it"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -21,18 +21,11 @@ func extractColumnNames(fields []*sppb.StructType_Field) []string {
 
 // parseQueryStats parses spanner.RowIterator.QueryStats.
 func parseQueryStats(stats map[string]any) (QueryStats, error) {
-	var queryStats QueryStats
-
-	b, err := json.Marshal(stats)
-	if err != nil {
-		return queryStats, err
+	parsed := spanstats.FromMap(stats)
+	if parsed == nil {
+		return QueryStats{}, nil
 	}
-
-	err = json.Unmarshal(b, &queryStats)
-	if err != nil {
-		return queryStats, err
-	}
-	return queryStats, nil
+	return *parsed, nil
 }
 
 // consumeRowIterDiscard calls iter.Stop().

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -30,9 +30,9 @@ import (
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
+	"github.com/apstndb/spanstats"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
-	"github.com/go-json-experiment/json/jsontext"
 	"github.com/olekukonko/tablewriter/tw"
 )
 
@@ -240,33 +240,7 @@ func sliceOf[V any](vs ...V) []V {
 // QueryStats contains query statistics.
 // Some fields may not have a valid value depending on the environment.
 // For example, only ElapsedTime and RowsReturned has valid value for Cloud Spanner Emulator.
-type QueryStats struct {
-	ElapsedTime                string `json:"elapsed_time"`
-	CPUTime                    string `json:"cpu_time"`
-	RowsReturned               string `json:"rows_returned"`
-	RowsScanned                string `json:"rows_scanned"`
-	DeletedRowsScanned         string `json:"deleted_rows_scanned"`
-	OptimizerVersion           string `json:"optimizer_version"`
-	OptimizerStatisticsPackage string `json:"optimizer_statistics_package"`
-	RemoteServerCalls          string `json:"remote_server_calls"`
-	MemoryPeakUsageBytes       string `json:"memory_peak_usage_bytes"`
-	TotalMemoryPeakUsageByte   string `json:"total_memory_peak_usage_byte"`
-	QueryText                  string `json:"query_text"`
-	BytesReturned              string `json:"bytes_returned"`
-	RuntimeCreationTime        string `json:"runtime_creation_time"`
-	StatisticsLoadTime         string `json:"statistics_load_time"`
-	MemoryUsagePercentage      string `json:"memory_usage_percentage"`
-	FilesystemDelaySeconds     string `json:"filesystem_delay_seconds"`
-	LockingDelay               string `json:"locking_delay"`
-	QueryPlanCreationTime      string `json:"query_plan_creation_time"`
-	ServerQueueDelay           string `json:"server_queue_delay"`
-	DataBytesRead              string `json:"data_bytes_read"`
-	IsGraphQuery               string `json:"is_graph_query"`
-	RuntimeCached              string `json:"runtime_cached"`
-	QueryPlanCached            string `json:"query_plan_cached"`
-
-	Unknown jsontext.Value `json:",unknown" pp:"-"`
-}
+type QueryStats = spanstats.QueryStats
 
 var (
 	operatorColumnName       = "Operator <execution_method> (metadata, ...)"

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -29,6 +29,12 @@ type queryProfiles struct {
 	Fprint       string          `json:"fprint"`
 }
 
+type rawQueryProfiles struct {
+	RawQueryPlan  jsontext.Value `json:"queryPlan"`
+	RawQueryStats map[string]any `json:"queryStats"`
+	Fprint        string         `json:"fprint"`
+}
+
 type queryProfilesRow struct {
 	IntervalEnd     time.Time        `spanner:"INTERVAL_END"`
 	TextFingerprint int64            `spanner:"TEXT_FINGERPRINT"`
@@ -192,12 +198,11 @@ func toQpr(row *spanner.Row) (*queryProfilesRow, error) {
 		return nil, err
 	}
 
-	var profile queryProfiles
-	err := json.Unmarshal([]byte(qpr.RawQueryProfile.String()), &profile)
+	profile, err := parseQueryProfile(qpr.RawQueryProfile.String())
 	if err != nil {
 		return nil, err
 	}
-	qpr.QueryProfile = &profile
+	qpr.QueryProfile = profile
 
 	var queryPlan sppb.QueryPlan
 	err = protojson.Unmarshal(profile.RawQueryPlan, &queryPlan)
@@ -207,4 +212,20 @@ func toQpr(row *spanner.Row) (*queryProfilesRow, error) {
 	profile.QueryPlan = &queryPlan
 
 	return &qpr, nil
+}
+
+func parseQueryProfile(raw string) (*queryProfiles, error) {
+	var profile rawQueryProfiles
+	if err := json.Unmarshal([]byte(raw), &profile); err != nil {
+		return nil, err
+	}
+	queryStats, err := parseQueryStats(profile.RawQueryStats)
+	if err != nil {
+		return nil, err
+	}
+	return &queryProfiles{
+		RawQueryPlan: profile.RawQueryPlan,
+		QueryStats:   queryStats,
+		Fprint:       profile.Fprint,
+	}, nil
 }


### PR DESCRIPTION
Summary:
- Replace the local QueryStats definition with the spanstats.QueryStats type alias.
- Parse row iterator and query profile stats through spanstats.FromMap while preserving unknown future fields.
- Update the README note and add focused parser coverage.

Validation:
- make check