### PR TITLE
Remove go-json-experiment dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/cloudspannerecosystem/memefish v0.6.2
 	github.com/creack/pty v1.1.24
 	github.com/fatih/color v1.19.0
-	github.com/go-json-experiment/json v0.0.0-20250813233538-9b1f9ea2e11b
 	github.com/go-sprout/sprout v1.0.3
 	github.com/goccy/go-yaml v1.19.2
 	github.com/gocql/gocql v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -2662,8 +2662,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
-github.com/go-json-experiment/json v0.0.0-20250813233538-9b1f9ea2e11b h1:6Q4zRHXS/YLOl9Ng1b1OOOBWMidAQZR3Gel0UKPC/KU=
-github.com/go-json-experiment/json v0.0.0-20250813233538-9b1f9ea2e11b/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/mycli/format/format_test.go
+++ b/internal/mycli/format/format_test.go
@@ -453,6 +453,12 @@ func TestFormatJSONL(t *testing.T) {
 			want:    `{"data":"line1\nline2"}` + "\n",
 		},
 		{
+			name:    "html-sensitive characters",
+			columns: []string{"data"},
+			rows:    []Row{StringsToRow("<tag>&value")},
+			want:    `{"data":"<tag>&value"}` + "\n",
+		},
+		{
 			name:    "RawJSONCell with typed values",
 			columns: []string{"id", "name", "active", "tags"},
 			rows: []Row{
@@ -641,6 +647,22 @@ func TestJSONLFormatterLifecycle(t *testing.T) {
 		want := `{"id":"1"}` + "\n"
 		if diff := cmp.Diff(want, buf.String()); diff != "" {
 			t.Errorf("output mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("invalid raw JSON", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		f := NewJSONLFormatter(&buf)
+		if err := f.InitFormat([]string{"bad"}, FormatConfig{}, nil); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+		err := f.WriteRow(Row{RawJSONCell{Cell: PlainCell{Text: "not-json"}}})
+		if err == nil {
+			t.Fatal("expected error for invalid raw JSON")
+		}
+		if !strings.Contains(err.Error(), "invalid raw JSON value") {
+			t.Fatalf("error = %v, want invalid raw JSON value", err)
 		}
 	})
 }

--- a/internal/mycli/format/streaming_jsonl.go
+++ b/internal/mycli/format/streaming_jsonl.go
@@ -31,15 +31,20 @@ import (
 // Otherwise, values are output as JSON strings (fallback for client-side statements).
 type JSONLFormatter struct {
 	out         io.Writer
+	stringBuf   bytes.Buffer
+	stringEnc   *json.Encoder
 	columns     []string
 	initialized bool
 }
 
 // NewJSONLFormatter creates a new JSONL formatter.
 func NewJSONLFormatter(out io.Writer) *JSONLFormatter {
-	return &JSONLFormatter{
+	f := &JSONLFormatter{
 		out: out,
 	}
+	f.stringEnc = json.NewEncoder(&f.stringBuf)
+	f.stringEnc.SetEscapeHTML(false)
+	return f
 }
 
 // InitFormat stores column names for use as JSON keys.
@@ -77,7 +82,9 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 			columnName = fmt.Sprintf("Column_%d", i+1)
 		}
 
-		if err := writeJSONString(f.out, columnName); err != nil {
+		// Write object members directly instead of marshaling a map so JSONL
+		// output preserves the original column order.
+		if err := f.writeJSONString(columnName); err != nil {
 			return fmt.Errorf("failed to write JSONL key: %w", err)
 		}
 		if _, err := io.WriteString(f.out, ":"); err != nil {
@@ -108,7 +115,7 @@ func (f *JSONLFormatter) writeValue(cell Cell) error {
 		_, err := f.out.Write(raw)
 		return err
 	}
-	return writeJSONString(f.out, cell.RawText())
+	return f.writeJSONString(cell.RawText())
 }
 
 // FinishFormat completes JSONL output.
@@ -116,18 +123,16 @@ func (f *JSONLFormatter) FinishFormat() error {
 	return nil
 }
 
-func writeJSONString(w io.Writer, s string) error {
-	var b bytes.Buffer
-	enc := json.NewEncoder(&b)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(s); err != nil {
+func (f *JSONLFormatter) writeJSONString(s string) error {
+	f.stringBuf.Reset()
+	if err := f.stringEnc.Encode(s); err != nil {
 		return err
 	}
 
-	encoded := b.Bytes()
+	encoded := f.stringBuf.Bytes()
 	if len(encoded) > 0 && encoded[len(encoded)-1] == '\n' {
 		encoded = encoded[:len(encoded)-1]
 	}
-	_, err := w.Write(encoded)
+	_, err := f.out.Write(encoded)
 	return err
 }

--- a/internal/mycli/format/streaming_jsonl.go
+++ b/internal/mycli/format/streaming_jsonl.go
@@ -15,22 +15,22 @@
 package format
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
-
-	"github.com/go-json-experiment/json/jsontext"
 )
 
 // JSONLFormatter provides JSONL (JSON Lines) formatting logic.
 // Each row is output as a single JSON object with column names as keys.
-// The jsontext.Encoder writes a newline after each top-level JSON value,
-// producing valid JSONL output. Column order is preserved.
+// WriteRow writes one top-level JSON object plus a newline, producing valid
+// JSONL output. Column order is preserved.
 //
 // When cells are RawJSONCell, their text is written as raw JSON values
 // (e.g., ARRAY as JSON array, INT64 as JSON number).
 // Otherwise, values are output as JSON strings (fallback for client-side statements).
 type JSONLFormatter struct {
-	enc         *jsontext.Encoder
+	out         io.Writer
 	columns     []string
 	initialized bool
 }
@@ -38,7 +38,7 @@ type JSONLFormatter struct {
 // NewJSONLFormatter creates a new JSONL formatter.
 func NewJSONLFormatter(out io.Writer) *JSONLFormatter {
 	return &JSONLFormatter{
-		enc: jsontext.NewEncoder(out),
+		out: out,
 	}
 }
 
@@ -59,11 +59,17 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 		return fmt.Errorf("JSONL formatter not initialized")
 	}
 
-	if err := f.enc.WriteToken(jsontext.BeginObject); err != nil {
+	if _, err := io.WriteString(f.out, "{"); err != nil {
 		return fmt.Errorf("failed to write JSONL row: %w", err)
 	}
 
 	for i, cell := range row {
+		if i > 0 {
+			if _, err := io.WriteString(f.out, ","); err != nil {
+				return fmt.Errorf("failed to write JSONL separator: %w", err)
+			}
+		}
+
 		var columnName string
 		if i < len(f.columns) {
 			columnName = f.columns[i]
@@ -71,8 +77,11 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 			columnName = fmt.Sprintf("Column_%d", i+1)
 		}
 
-		if err := f.enc.WriteToken(jsontext.String(columnName)); err != nil {
+		if err := writeJSONString(f.out, columnName); err != nil {
 			return fmt.Errorf("failed to write JSONL key: %w", err)
+		}
+		if _, err := io.WriteString(f.out, ":"); err != nil {
+			return fmt.Errorf("failed to write JSONL separator: %w", err)
 		}
 
 		if err := f.writeValue(cell); err != nil {
@@ -80,7 +89,7 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 		}
 	}
 
-	if err := f.enc.WriteToken(jsontext.EndObject); err != nil {
+	if _, err := io.WriteString(f.out, "}\n"); err != nil {
 		return fmt.Errorf("failed to write JSONL row: %w", err)
 	}
 
@@ -92,12 +101,33 @@ func (f *JSONLFormatter) WriteRow(row Row) error {
 // Other cells are written as quoted JSON strings.
 func (f *JSONLFormatter) writeValue(cell Cell) error {
 	if IsRawJSON(cell) {
-		return f.enc.WriteValue(jsontext.Value(cell.RawText()))
+		raw := []byte(cell.RawText())
+		if !json.Valid(raw) {
+			return fmt.Errorf("invalid raw JSON value: %q", cell.RawText())
+		}
+		_, err := f.out.Write(raw)
+		return err
 	}
-	return f.enc.WriteToken(jsontext.String(cell.RawText()))
+	return writeJSONString(f.out, cell.RawText())
 }
 
 // FinishFormat completes JSONL output.
 func (f *JSONLFormatter) FinishFormat() error {
 	return nil
+}
+
+func writeJSONString(w io.Writer, s string) error {
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		return err
+	}
+
+	encoded := b.Bytes()
+	if len(encoded) > 0 && encoded[len(encoded)-1] == '\n' {
+		encoded = encoded[:len(encoded)-1]
+	}
+	_, err := w.Write(encoded)
+	return err
 }

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -2,6 +2,7 @@ package mycli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,8 +15,6 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/go-tabwrap"
 	"github.com/apstndb/spanner-mycli/enums"
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
 	"github.com/k0kubun/pp/v3"
 	"github.com/samber/lo"
 	loi "github.com/samber/lo/it"
@@ -23,16 +22,16 @@ import (
 )
 
 type queryProfiles struct {
-	RawQueryPlan jsontext.Value  `json:"queryPlan"`
+	RawQueryPlan json.RawMessage `json:"queryPlan"`
 	QueryPlan    *sppb.QueryPlan `json:"-"`
 	QueryStats   QueryStats      `json:"queryStats"`
 	Fprint       string          `json:"fprint"`
 }
 
 type rawQueryProfiles struct {
-	RawQueryPlan  jsontext.Value `json:"queryPlan"`
-	RawQueryStats map[string]any `json:"queryStats"`
-	Fprint        string         `json:"fprint"`
+	RawQueryPlan  json.RawMessage `json:"queryPlan"`
+	RawQueryStats map[string]any  `json:"queryStats"`
+	Fprint        string          `json:"fprint"`
 }
 
 type queryProfilesRow struct {


### PR DESCRIPTION
Summary:
- Replace go-json-experiment/json usage in query profile parsing with encoding/json.RawMessage and encoding/json.Unmarshal.
- Rewrite JSONL streaming to preserve column order using standard encoding/json string encoding and raw JSON validation.
- Remove github.com/go-json-experiment/json from go.mod/go.sum.

Future encoding/json/v2 plan:
- Keep this PR on stable encoding/json because the local Go toolchain currently exposes encoding/json but not encoding/json/v2.
- When encoding/json/v2 is available in the supported Go baseline, evaluate it only for the small JSONL string/raw-value helper boundary and QueryProfile RawMessage decoding path.
- Before migrating, compare JSONL byte output for column order, RawJSONCell values, invalid raw JSON errors, HTML-sensitive characters, and newline escaping against the tests in this PR.
- Avoid reintroducing an experimental external module in library-facing packages; any v2 adoption should come from the standard library once the project Go baseline supports it.

Validation:
- go test ./internal/mycli/format -run 'TestFormatJSONL|TestJSONLFormatterLifecycle' -count=1
- go test ./internal/mycli -run 'TestParseQueryStats|TestParseQueryProfile' -count=1
- go mod why -m github.com/go-json-experiment/json
- make check