### PR TITLE
Use developerknowledge-go for documentation API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/alecthomas/kong v1.15.0
 	github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c
+	github.com/apstndb/developerknowledge-go v0.1.2
 	github.com/apstndb/genaischema v0.2.0
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe
 	github.com/apstndb/go-tabwrap v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -2471,6 +2471,8 @@ github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2
 github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4fPBx7Q=
 github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c h1:YDz0azy3d3QpwAf65m7y7EHn0G8dGG07ukYrIJK3pPQ=
 github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c/go.mod h1:6rE+3Wp06EaBJAUacxlXON90ZbvaFhNkg/4QCyxAepY=
+github.com/apstndb/developerknowledge-go v0.1.2 h1:ejpPuozEUEl6W7kCAeK3N9OzwfZEqSuTABckOSsNA9A=
+github.com/apstndb/developerknowledge-go v0.1.2/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/apstndb/genaischema v0.2.0 h1:Xy19ye4xUjU46ZGC7iHLQ6hCKNCin1+IqMCpjel+gfo=
 github.com/apstndb/genaischema v0.2.0/go.mod h1:qUY4LNMs5MeXLcbY3Ic4cW5I1iMnj9USzTTDf1BeezU=
 github.com/apstndb/gh-dev-tools v0.0.0-20250726094924-b386827f58e6 h1:Say3K7FyeOgvYi8/lsn2iDuFmKXA35XlPBNMHIptdo8=

--- a/internal/mycli/statements_llm_tooluse.go
+++ b/internal/mycli/statements_llm_tooluse.go
@@ -230,7 +230,7 @@ func executeToolCall(ctx context.Context, fc *genai.FunctionCall, cache *docCach
 
 // --- Developer Knowledge REST API client ---
 
-const defaultDevKnowledgeBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
+const defaultDevKnowledgeBaseURL = dkapi.DefaultV1BaseURL
 
 // devKnowledgeAPIError represents a non-OK HTTP response from the API.
 type devKnowledgeAPIError = dkapi.APIError

--- a/internal/mycli/statements_llm_tooluse.go
+++ b/internal/mycli/statements_llm_tooluse.go
@@ -5,15 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"github.com/samber/lo"
 	"golang.org/x/time/rate"
 	"google.golang.org/genai"
@@ -234,102 +233,40 @@ func executeToolCall(ctx context.Context, fc *genai.FunctionCall, cache *docCach
 const defaultDevKnowledgeBaseURL = "https://developerknowledge.googleapis.com/v1alpha"
 
 // devKnowledgeAPIError represents a non-OK HTTP response from the API.
-type devKnowledgeAPIError struct {
-	Code    int
-	Status  string
-	Message string
-}
-
-func (e *devKnowledgeAPIError) Error() string {
-	if e.Status != "" {
-		return fmt.Sprintf("API error %d (%s): %s", e.Code, e.Status, e.Message)
-	}
-	return fmt.Sprintf("HTTP %d: %s", e.Code, e.Message)
-}
+type devKnowledgeAPIError = dkapi.APIError
 
 // devKnowledgeClient is a REST client for the Developer Knowledge API.
 type devKnowledgeClient struct {
 	baseURL string
-	apiKey  string
-	client  *http.Client
-	limiter *rate.Limiter
+	client  *dkapi.Client
 }
 
 func newDevKnowledgeClient(apiKey string) *devKnowledgeClient {
 	return &devKnowledgeClient{
 		baseURL: defaultDevKnowledgeBaseURL,
-		apiKey:  apiKey,
-		client:  http.DefaultClient,
-		// 100 RPM = ~1.67 RPS, burst of 5 for short request bursts
-		limiter: rate.NewLimiter(rate.Every(600*time.Millisecond), 5),
+		client: &dkapi.Client{
+			BaseURL:    defaultDevKnowledgeBaseURL,
+			APIKey:     apiKey,
+			HTTPClient: http.DefaultClient,
+			// 100 RPM = ~1.67 RPS, burst of 5 for short request bursts.
+			Limiter: rate.NewLimiter(rate.Every(600*time.Millisecond), 5),
+			// Keep the previous behavior of three total attempts.
+			MaxRetries: 2,
+		},
 	}
 }
 
 func (c *devKnowledgeClient) doGet(ctx context.Context, reqURL string) ([]byte, error) {
-	const maxRetries = 3
-	backoff := 1 * time.Second
+	client := *c.client
+	client.Context = ctx
+	return client.DoGet(reqURL)
+}
 
-	for attempt := range maxRetries {
-		if err := c.limiter.Wait(ctx); err != nil {
-			return nil, fmt.Errorf("rate limiter: %w", err)
-		}
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("x-goog-api-key", c.apiKey)
-
-		// Network errors are not retried: doc fetching is best-effort
-		// (stale cache + embedded docs as fallback).
-		resp, err := c.client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		// Check for retriable 429 before reading body to avoid unnecessary I/O.
-		if resp.StatusCode == http.StatusTooManyRequests && attempt < maxRetries-1 {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
-			wait := backoff
-			if v := resp.Header.Get("Retry-After"); v != "" {
-				if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-					wait = time.Duration(secs) * time.Second
-				}
-			}
-			slog.Debug("Rate limited, retrying", "attempt", attempt, "wait", wait)
-			select {
-			case <-time.After(wait):
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-			backoff *= 2
-			continue
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			var apiErr struct {
-				Error struct {
-					Code    int    `json:"code"`
-					Message string `json:"message"`
-					Status  string `json:"status"`
-				} `json:"error"`
-			}
-			if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
-				return nil, &devKnowledgeAPIError{Code: apiErr.Error.Code, Status: apiErr.Error.Status, Message: apiErr.Error.Message}
-			}
-			return nil, &devKnowledgeAPIError{Code: resp.StatusCode, Message: string(body)}
-		}
-
-		return body, nil
-	}
-	return nil, fmt.Errorf("unreachable: exceeded max retries") // required by compiler
+func (c *devKnowledgeClient) batchGetDocuments(ctx context.Context, names []string) ([]dkapi.Document, error) {
+	client := *c.client
+	client.BaseURL = c.baseURL
+	client.Context = ctx
+	return client.BatchGetDocuments(names)
 }
 
 // devKnowledgeDocSearcher implements document operations using the Developer Knowledge REST API.
@@ -375,9 +312,7 @@ func (d *devKnowledgeDocSearcher) GetDocument(ctx context.Context, name string) 
 		return "", fmt.Errorf("get_document failed: %w", err)
 	}
 
-	var doc struct {
-		Content string `json:"content"`
-	}
+	var doc dkapi.Document
 	if err := json.Unmarshal(body, &doc); err != nil {
 		return "", err
 	}
@@ -406,28 +341,13 @@ func (d *devKnowledgeDocSearcher) BatchGetDocuments(ctx context.Context, names [
 }
 
 func (d *devKnowledgeDocSearcher) fetchBatchGet(ctx context.Context, names []string) ([]DocResult, error) {
-	params := url.Values{}
-	for _, name := range names {
-		params.Add("names", name)
-	}
-
-	body, err := d.client.doGet(ctx, d.client.baseURL+"/documents:batchGet?"+params.Encode())
+	docs, err := d.client.batchGetDocuments(ctx, names)
 	if err != nil {
 		return nil, err
 	}
 
-	var resp struct {
-		Documents []struct {
-			Name    string `json:"name"`
-			Content string `json:"content"`
-		} `json:"documents"`
-	}
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, err
-	}
-
-	results := make([]DocResult, len(resp.Documents))
-	for i, doc := range resp.Documents {
+	results := make([]DocResult, len(docs))
+	for i, doc := range docs {
 		results[i] = DocResult{Name: doc.Name, Content: doc.Content}
 	}
 	return results, nil

--- a/internal/mycli/statements_llm_tooluse_test.go
+++ b/internal/mycli/statements_llm_tooluse_test.go
@@ -175,6 +175,17 @@ func newTestDocSearcher(t *testing.T, handler http.HandlerFunc) *devKnowledgeDoc
 	return &devKnowledgeDocSearcher{client: client}
 }
 
+func TestNewDevKnowledgeClientUsesV1BaseURL(t *testing.T) {
+	t.Parallel()
+	client := newDevKnowledgeClient("test-api-key")
+	if client.baseURL != dkapi.DefaultV1BaseURL {
+		t.Fatalf("baseURL = %q, want %q", client.baseURL, dkapi.DefaultV1BaseURL)
+	}
+	if client.client.BaseURL != dkapi.DefaultV1BaseURL {
+		t.Fatalf("dkapi BaseURL = %q, want %q", client.client.BaseURL, dkapi.DefaultV1BaseURL)
+	}
+}
+
 func TestDevKnowledgeClient_DoGet_APIKeyHeader(t *testing.T) {
 	t.Parallel()
 	var gotHeader string

--- a/internal/mycli/statements_llm_tooluse_test.go
+++ b/internal/mycli/statements_llm_tooluse_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	dkapi "github.com/apstndb/developerknowledge-go"
 	"golang.org/x/time/rate"
 	"google.golang.org/genai"
 )
@@ -158,9 +159,13 @@ func newTestDevKnowledgeClient(t *testing.T, handler http.HandlerFunc) (*devKnow
 	t.Cleanup(server.Close)
 	return &devKnowledgeClient{
 		baseURL: server.URL,
-		apiKey:  "test-api-key",
-		client:  server.Client(),
-		limiter: rate.NewLimiter(rate.Inf, 1),
+		client: &dkapi.Client{
+			BaseURL:    server.URL,
+			APIKey:     "test-api-key",
+			HTTPClient: server.Client(),
+			Limiter:    rate.NewLimiter(rate.Inf, 1),
+			MaxRetries: 2,
+		},
 	}, server.URL
 }
 
@@ -238,12 +243,9 @@ func TestDevKnowledgeClient_DoGet_MaxRetriesExceeded(t *testing.T) {
 	if attempts != 3 {
 		t.Errorf("attempts = %d, want 3", attempts)
 	}
-	var apiErr *devKnowledgeAPIError
-	if !errors.As(err, &apiErr) {
-		t.Fatalf("expected devKnowledgeAPIError, got %T: %v", err, err)
-	}
-	if apiErr.Code != 429 {
-		t.Errorf("error code = %d, want 429", apiErr.Code)
+	var rateLimitErr *dkapi.RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		t.Fatalf("expected RateLimitError, got %T: %v", err, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the local Developer Knowledge API HTTP/error/retry client with github.com/apstndb/developerknowledge-go v0.1.2
- use the GA v1 Developer Knowledge document endpoints while keeping spanner-mycli-specific document name normalization, search result formatting, and batch-to-individual fallback behavior
- update tests for the shared rate-limit error type while preserving the existing three total attempts

## Tests
- make check
