### PR TITLE
Adopt spaniter v0.1.0 row iterator adapters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spancodec v0.1.1
 	github.com/apstndb/spanemuboost v0.4.5
-	github.com/apstndb/spaniter v0.1.0-alpha.1
+	github.com/apstndb/spaniter v0.1.0
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spanstats v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spancodec v0.1.1
 	github.com/apstndb/spanemuboost v0.4.5
+	github.com/apstndb/spaniter v0.1.0-alpha.1
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spanstats v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -2499,8 +2499,8 @@ github.com/apstndb/spancodec v0.1.1 h1:26jll4gTzB18yUilmSSE1IfCF9Rht2j/+cc492hji
 github.com/apstndb/spancodec v0.1.1/go.mod h1:muPblFXUB5gkkvBBEM/2zzuVAOvin/dBtDsKagIcivY=
 github.com/apstndb/spanemuboost v0.4.5 h1:2TZpdJUcamBunmoFy8Qcr6pBXvw662sia8l1D78pOHk=
 github.com/apstndb/spanemuboost v0.4.5/go.mod h1:BRO3uMS4UETqSaEF36HoVxsTsSZhlV/Fgq8Eq4Lmi2g=
-github.com/apstndb/spaniter v0.1.0-alpha.1 h1:XVBI96PLL85lBVgqAFSnTRrNhW6PM2HBE50Km3rMDNk=
-github.com/apstndb/spaniter v0.1.0-alpha.1/go.mod h1:vl6zVOnA2m35fAeF1WsGD7AuaWUK5aCVG6aS/35njFE=
+github.com/apstndb/spaniter v0.1.0 h1:OpTpePq0bN/EWS1mIXAk0lfQ98PAI4xRcBQ4pd9Ijk0=
+github.com/apstndb/spaniter v0.1.0/go.mod h1:vl6zVOnA2m35fAeF1WsGD7AuaWUK5aCVG6aS/35njFE=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l0QJZRVSRwBXTxaMMAjrmF0kQDjXlCM0bwTCo5Gs=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6/go.mod h1:Enpmw/D11tME865ROYDQzoHSIo9V8uCgWdu+fxA7n2M=
 github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+zhg2c=

--- a/go.sum
+++ b/go.sum
@@ -2499,6 +2499,8 @@ github.com/apstndb/spancodec v0.1.1 h1:26jll4gTzB18yUilmSSE1IfCF9Rht2j/+cc492hji
 github.com/apstndb/spancodec v0.1.1/go.mod h1:muPblFXUB5gkkvBBEM/2zzuVAOvin/dBtDsKagIcivY=
 github.com/apstndb/spanemuboost v0.4.5 h1:2TZpdJUcamBunmoFy8Qcr6pBXvw662sia8l1D78pOHk=
 github.com/apstndb/spanemuboost v0.4.5/go.mod h1:BRO3uMS4UETqSaEF36HoVxsTsSZhlV/Fgq8Eq4Lmi2g=
+github.com/apstndb/spaniter v0.1.0-alpha.1 h1:XVBI96PLL85lBVgqAFSnTRrNhW6PM2HBE50Km3rMDNk=
+github.com/apstndb/spaniter v0.1.0-alpha.1/go.mod h1:vl6zVOnA2m35fAeF1WsGD7AuaWUK5aCVG6aS/35njFE=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l0QJZRVSRwBXTxaMMAjrmF0kQDjXlCM0bwTCo5Gs=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6/go.mod h1:Enpmw/D11tME865ROYDQzoHSIo9V8uCgWdu+fxA7n2M=
 github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+zhg2c=

--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -84,6 +84,9 @@ func streamPartitionedQuery(
 	if err != nil {
 		return nil, true, normalizeSpanvalueWriterError(err)
 	}
+	if runResult == nil || runResult.Metadata == nil {
+		return nil, true, errors.New("partitioned query writer returned nil metadata")
+	}
 
 	return &Result{
 		TableHeader:           toTableHeader(runResult.Metadata.GetRowType().GetFields()),
@@ -186,11 +189,14 @@ func runPartitionedRowSeq(
 
 	p := pool.New().WithContext(childCtx).WithMaxGoroutines(parallelism)
 	for _, partition := range partitions {
-		p.Go(func(ctx context.Context) error {
-			rowIter := batchROTx.Execute(ctx, partition)
+		p.Go(func(workerCtx context.Context) error {
+			rowIter := batchROTx.Execute(workerCtx, partition)
 			var result spaniter.RowIteratorResult
 			rows := spaniter.RowIteratorSeq(rowIter, spaniter.WithResult(&result))
 			captureMetadata := func() {
+				if rowIter.Metadata != nil {
+					capturedMD.CompareAndSwap(nil, rowIter.Metadata)
+				}
 				if result.Metadata != nil {
 					capturedMD.CompareAndSwap(nil, result.Metadata)
 				}
@@ -200,16 +206,17 @@ func runPartitionedRowSeq(
 				if err != nil {
 					select {
 					case ch <- partitionedRow{err: err}:
-					case <-ctx.Done():
+					case <-workerCtx.Done():
 					}
 					return err
 				}
 				select {
 				case ch <- partitionedRow{row: row}:
-				case <-ctx.Done():
-					return ctx.Err()
+				case <-workerCtx.Done():
+					return workerCtx.Err()
 				}
 			}
+			captureMetadata()
 			return nil
 		})
 	}

--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -10,11 +10,11 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spaniter"
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 	"github.com/apstndb/spanvalue"
 	"github.com/apstndb/spanvalue/writer"
 	"github.com/sourcegraph/conc/pool"
-	"google.golang.org/api/iterator"
 )
 
 func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Result, error) {
@@ -188,18 +188,15 @@ func runPartitionedRowSeq(
 	for _, partition := range partitions {
 		p.Go(func(ctx context.Context) error {
 			rowIter := batchROTx.Execute(ctx, partition)
-			defer rowIter.Stop()
-			for {
-				row, err := rowIter.Next()
-				// Metadata is populated after the first Next, including when it
-				// returns iterator.Done; store it before sending the row so the
-				// consumer always sees metadata no later than the first row.
-				if md := rowIter.Metadata; md != nil {
-					capturedMD.CompareAndSwap(nil, md)
+			var result spaniter.RowIteratorResult
+			rows := spaniter.RowIteratorSeq(rowIter, spaniter.WithResult(&result))
+			captureMetadata := func() {
+				if result.Metadata != nil {
+					capturedMD.CompareAndSwap(nil, result.Metadata)
 				}
-				if err == iterator.Done {
-					return nil
-				}
+			}
+			for row, err := range rows {
+				captureMetadata()
 				if err != nil {
 					select {
 					case ch <- partitionedRow{err: err}:
@@ -213,6 +210,7 @@ func runPartitionedRowSeq(
 					return ctx.Err()
 				}
 			}
+			return nil
 		})
 	}
 

--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -194,6 +194,9 @@ func runPartitionedRowSeq(
 			var result spaniter.RowIteratorResult
 			rows := spaniter.RowIteratorSeq(rowIter, spaniter.WithResult(&result))
 			captureMetadata := func() {
+				if capturedMD.Load() != nil {
+					return
+				}
 				if rowIter.Metadata != nil {
 					capturedMD.CompareAndSwap(nil, rowIter.Metadata)
 				}

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -1136,6 +1136,21 @@ func TestPartitionedStatements(t *testing.T) {
 				}},
 			},
 		},
+		{
+			desc: "streaming zero-row partitioned query keeps metadata",
+			ddls: sliceOf(testTableSimpleDDL),
+			stmtResults: []stmtResult{
+				srKeep("SET CLI_FORMAT = CSV"),
+				{"RUN PARTITIONED QUERY SELECT id, active FROM TestTable WHERE FALSE", &Result{
+					TableHeader:  toTableHeader(testTableRowType),
+					Streamed:     true,
+					AffectedRows: 0,
+				}},
+			},
+			cmpOpts: []cmp.Option{
+				cmpopts.IgnoreFields(Result{}, "PartitionCount"),
+			},
+		},
 	}
 
 	runStatementTests(t, tests)

--- a/internal/mycli/row_iter.go
+++ b/internal/mycli/row_iter.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spaniter"
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
 	"github.com/apstndb/spanstats"
@@ -30,18 +31,26 @@ func parseQueryStats(stats map[string]any) (QueryStats, error) {
 
 // consumeRowIterDiscard calls iter.Stop().
 func consumeRowIterDiscard(iter *spanner.RowIterator) (queryStats map[string]interface{}, rowCount int64, metadata *sppb.ResultSetMetadata, queryPlan *sppb.QueryPlan, err error) {
-	return consumeRowIter(iter, func(*spanner.Row) error { return nil })
+	result, err := spaniter.DrainRowIterator(iter)
+	if err != nil {
+		return nil, 0, nil, nil, err
+	}
+	return result.Stats.QueryStats, result.Stats.RowCount, result.Metadata, result.Stats.QueryPlan, nil
 }
 
 // consumeRowIter calls iter.Stop().
 func consumeRowIter(iter *spanner.RowIterator, f func(*spanner.Row) error) (queryStats map[string]interface{}, rowCount int64, metadata *sppb.ResultSetMetadata, queryPlan *sppb.QueryPlan, err error) {
-	defer iter.Stop()
-	err = iter.Do(f)
-	if err != nil {
-		return nil, 0, nil, nil, err
+	var result spaniter.RowIteratorResult
+	for row, rowErr := range spaniter.RowIteratorSeq(iter, spaniter.WithResult(&result)) {
+		if rowErr != nil {
+			return nil, 0, nil, nil, rowErr
+		}
+		if err := f(row); err != nil {
+			return nil, 0, nil, nil, err
+		}
 	}
 
-	return iter.QueryStats, iter.RowCount, iter.Metadata, iter.QueryPlan, nil
+	return result.Stats.QueryStats, result.Stats.RowCount, result.Metadata, result.Stats.QueryPlan, nil
 }
 
 func consumeRowIterCollect[T any](iter *spanner.RowIterator, f func(*spanner.Row) (T, error)) (rows []T, queryStats map[string]interface{}, rowCount int64, metadata *sppb.ResultSetMetadata, queryPlan *sppb.QueryPlan, err error) {


### PR DESCRIPTION
## Summary

- update `github.com/apstndb/spaniter` from `v0.1.0-alpha.1` to `v0.1.0`
- use spaniter row-iterator adapters in the shared Spanner row consumption path
- keep partitioned-query metadata capture correct when every partition returns zero rows
- add a streaming zero-row partitioned query regression test for CSV output

## Validation

- `make check`
- `git diff --check`