### PR TITLE
Bump spanemuboost to v0.4.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/apstndb/lox v0.0.0-20241212132733-62f24606dc82
 	github.com/apstndb/memebridge v0.6.0
 	github.com/apstndb/spancodec v0.1.1
-	github.com/apstndb/spanemuboost v0.4.5
+	github.com/apstndb/spanemuboost v0.4.6
 	github.com/apstndb/spaniter v0.1.0
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11

--- a/go.sum
+++ b/go.sum
@@ -2497,8 +2497,8 @@ github.com/apstndb/ptyhelp v0.2.1 h1:vGqYJiIBNS3opPA3JLCKsdKIZzomz2zFkO1PVuM+WLs
 github.com/apstndb/ptyhelp v0.2.1/go.mod h1:qQr/aibVk0BK/dweEW7mcaT0jAH9NeRHP2in6MIgEcA=
 github.com/apstndb/spancodec v0.1.1 h1:26jll4gTzB18yUilmSSE1IfCF9Rht2j/+cc492hjixE=
 github.com/apstndb/spancodec v0.1.1/go.mod h1:muPblFXUB5gkkvBBEM/2zzuVAOvin/dBtDsKagIcivY=
-github.com/apstndb/spanemuboost v0.4.5 h1:2TZpdJUcamBunmoFy8Qcr6pBXvw662sia8l1D78pOHk=
-github.com/apstndb/spanemuboost v0.4.5/go.mod h1:BRO3uMS4UETqSaEF36HoVxsTsSZhlV/Fgq8Eq4Lmi2g=
+github.com/apstndb/spanemuboost v0.4.6 h1:9f1qQDLNrPQJiswNLtiTaR0U//zToqxjcEGWGkyThm4=
+github.com/apstndb/spanemuboost v0.4.6/go.mod h1:urUe85EvqomWV4vCj2pALluNhIksbu9RAQZufgq1b8E=
 github.com/apstndb/spaniter v0.1.0 h1:OpTpePq0bN/EWS1mIXAk0lfQ98PAI4xRcBQ4pd9Ijk0=
 github.com/apstndb/spaniter v0.1.0/go.mod h1:vl6zVOnA2m35fAeF1WsGD7AuaWUK5aCVG6aS/35njFE=
 github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6 h1:JP8l0QJZRVSRwBXTxaMMAjrmF0kQDjXlCM0bwTCo5Gs=

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -18,6 +18,7 @@ package mycli
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -48,6 +49,9 @@ import (
 
 	"github.com/apstndb/spantype/typector"
 )
+
+//go:embed testdata/protos/order_descriptors.pb
+var orderDescriptorsPB []byte
 
 type testTableSchema struct {
 	Id     int64 `spanner:"id"`
@@ -186,7 +190,7 @@ func initializeWithRandomDB(t *testing.T, ddls, dmls []string) (clients *spanemu
 // If database is empty, a random database name is generated.
 // Each test gets its own instance within the shared emulator for isolation.
 // The database is automatically configured with the provided DDLs and DMLs.
-func initializeWithDB(t *testing.T, database string, ddls, dmls []string) (clients *spanemuboost.Clients, session *Session) {
+func initializeWithDB(t *testing.T, database string, ddls, dmls []string, extraOpts ...spanemuboost.Option) (clients *spanemuboost.Clients, session *Session) {
 	t.Helper()
 	ctx := t.Context()
 
@@ -208,6 +212,7 @@ func initializeWithDB(t *testing.T, database string, ddls, dmls []string) (clien
 		spanemuboost.WithSetupDDLs(ddls),
 		spanemuboost.WithSetupRawDMLs(dmls),
 	)
+	options = append(options, extraOpts...)
 
 	clients = spanemuboost.SetupClients(t, lazyRuntime, options...)
 
@@ -514,12 +519,13 @@ func srBatchDDL(stmt string, size int) stmtResult {
 
 // statementTestCase represents a test case for statement execution
 type statementTestCase struct {
-	desc        string
-	ddls, dmls  []string
-	admin       bool   // admin mode (no database)
-	database    string // specific database name (empty = use random name)
-	stmtResults []stmtResult
-	cmpOpts     []cmp.Option
+	desc          string
+	ddls, dmls    []string
+	bootstrapOpts []spanemuboost.Option
+	admin         bool   // admin mode (no database)
+	database      string // specific database name (empty = use random name)
+	stmtResults   []stmtResult
+	cmpOpts       []cmp.Option
 }
 
 // typedStringHeader builds the typesTableHeader produced by spancodec-backed
@@ -558,7 +564,7 @@ func runStatementTests(t *testing.T, tests []statementTestCase) {
 				_, session = initializeAdminSession(t)
 			} else {
 				// Regular database mode (specific or random database name)
-				_, session = initializeWithDB(t, tt.database, tt.ddls, tt.dmls)
+				_, session = initializeWithDB(t, tt.database, tt.ddls, tt.dmls, tt.bootstrapOpts...)
 			}
 
 			// Create SessionHandler to properly test USE/DETACH statements
@@ -1136,21 +1142,6 @@ func TestPartitionedStatements(t *testing.T) {
 				}},
 			},
 		},
-		{
-			desc: "streaming zero-row partitioned query keeps metadata",
-			ddls: sliceOf(testTableSimpleDDL),
-			stmtResults: []stmtResult{
-				srKeep("SET CLI_FORMAT = CSV"),
-				{"RUN PARTITIONED QUERY SELECT id, active FROM TestTable WHERE FALSE", &Result{
-					TableHeader:  toTableHeader(testTableRowType),
-					Streamed:     true,
-					AffectedRows: 0,
-				}},
-			},
-			cmpOpts: []cmp.Option{
-				cmpopts.IgnoreFields(Result{}, "PartitionCount"),
-			},
-		},
 	}
 
 	runStatementTests(t, tests)
@@ -1199,8 +1190,31 @@ func TestProtoStatements(t *testing.T) {
 			},
 		},
 		{
+			desc: "SHOW REMOTE PROTO with spanemuboost proto bundle bootstrap",
+			bootstrapOpts: []spanemuboost.Option{
+				spanemuboost.WithSetupDDLs([]string{"CREATE PROTO BUNDLE (`examples.shipping.Order`)"}),
+				spanemuboost.WithSetupRawFileDescriptorSet(orderDescriptorsPB),
+			},
+			stmtResults: []stmtResult{
+				{
+					stmt: `SHOW REMOTE PROTO`,
+					want: &Result{
+						TableHeader: typedStringHeader("full_name", "kind", "package"),
+						Rows: sliceOf(
+							toRow("examples.shipping.Order", "PROTO", "examples.shipping"),
+							toRow("examples.shipping.Order.Address", "PROTO", "examples.shipping"),
+							toRow("examples.shipping.Order.Item", "PROTO", "examples.shipping"),
+							toRow("examples.shipping.OrderHistory", "PROTO", "examples.shipping"),
+						),
+						AffectedRows:  4,
+						KeepVariables: true,
+					},
+				},
+			},
+		},
+		{
 			desc: "PROTO BUNDLE statements",
-			// Note: Current cloud-spanner-emulator only accepts DDL, but it is nop.
+			// Note: CREATE/ALTER/SYNC PROTO BUNDLE still exercise the CLI session path.
 			stmtResults: []stmtResult{
 				sr("SHOW REMOTE PROTO", &Result{KeepVariables: true, TableHeader: typedStringHeader("full_name", "kind", "package")}),
 				srKeep(`SET CLI_PROTO_DESCRIPTOR_FILE = "testdata/protos/order_descriptors.pb"`),

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -1142,6 +1142,21 @@ func TestPartitionedStatements(t *testing.T) {
 				}},
 			},
 		},
+		{
+			desc: "streaming zero-row partitioned query keeps metadata",
+			ddls: sliceOf(testTableSimpleDDL),
+			stmtResults: []stmtResult{
+				srKeep("SET CLI_FORMAT = CSV"),
+				{"RUN PARTITIONED QUERY SELECT id, active FROM TestTable WHERE FALSE", &Result{
+					TableHeader:  toTableHeader(testTableRowType),
+					Streamed:     true,
+					AffectedRows: 0,
+				}},
+			},
+			cmpOpts: []cmp.Option{
+				cmpopts.IgnoreFields(Result{}, "PartitionCount"),
+			},
+		},
 	}
 
 	runStatementTests(t, tests)


### PR DESCRIPTION
## Summary
- Upgrade `github.com/apstndb/spanemuboost` to v0.4.6.
- Add `bootstrapOpts` to integration test harness so databases can be created with proto bundle descriptors via spanemuboost.
- Add a `SHOW REMOTE PROTO` case that pre-bootstraps a bundle with `WithSetupRawFileDescriptorSet`.

## Test plan
- [x] `go test -run TestProtoStatements ./internal/mycli/...`

Made with [Cursor](https://cursor.com)