### PR TITLE
Support SET LOCAL for transaction-scoped system variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ There are differences between spanner-mycli and spanner-cli that include not onl
 * Generalized concepts to extend without a lot of original syntax
   * Generalized system variables concept inspired by Spanner JDBC properties
     * `SET <name> = <value>` statement
+    * `SET LOCAL <name> = <value>` statement (transaction-scoped; the value reverts when the transaction ends)
     * `SHOW VARIABLES` statement
     * `SHOW VARIABLE <name>` statement
     * `--set <name>=<value>` flag
@@ -609,6 +610,7 @@ and `{A|B|...}` for a mutually exclusive keyword.
 | Start DML batching                                              | `START BATCH DML;`                                                                                         |                                                                                                                                                                                           |
 | Run active batch                                                | `RUN BATCH;`                                                                                               |                                                                                                                                                                                           |
 | Abort active batch                                              | `ABORT BATCH [TRANSACTION];`                                                                               |                                                                                                                                                                                           |
+| Set variable for the current transaction                        | `SET LOCAL <name> = <value>;`                                                                              |                                                                                                                                                                                           |
 | Set variable                                                    | `SET <name> = <value>;`                                                                                    |                                                                                                                                                                                           |
 | Add value to variable                                           | `SET <name> += <value>;`                                                                                   |                                                                                                                                                                                           |
 | Show variables                                                  | `SHOW VARIABLES;`                                                                                          |                                                                                                                                                                                           |

--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -895,6 +895,33 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 	},
 	// System Variable
 	{
+		// Must precede the generic `SET <name> = <value>` definition so that
+		// LOCAL is consumed as a keyword rather than as a variable name.
+		Descriptions: []clientSideStatementDescription{
+			{
+				Usage:  `Set variable for the current transaction`,
+				Syntax: `SET LOCAL <name> = <value>`,
+			},
+		},
+		Pattern: regexp.MustCompile(`(?is)^SET\s+LOCAL\s+(?P<name>[^\s=]+)\s*=\s*(?P<value>\S.*)$`),
+		HandleGroups: func(groups map[string]string) (Statement, error) {
+			return &SetLocalStatement{VarName: groups["name"], Value: groups["value"]}, nil
+		},
+		Completion: []fuzzyArgCompletion{
+			{
+				// Value completion: SET LOCAL <name> = <partial_value>
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+LOCAL\s+(\S+)\s*=\s*(\S*)$`),
+				CompletionType: fuzzyCompleteVariableValue,
+			},
+			{
+				// Name completion: SET LOCAL <partial_name>
+				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+LOCAL\s+([^\s=]*)$`),
+				CompletionType: fuzzyCompleteVariable,
+				Suffix:         " = ",
+			},
+		},
+	},
+	{
 		Descriptions: []clientSideStatementDescription{
 			{
 				Usage:  `Set variable`,

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -837,6 +837,69 @@ func TestTransactionStatements(t *testing.T) {
 	runStatementTests(t, tests)
 }
 
+// TestSetLocalStatements tests transaction-scoped system variables (SET LOCAL).
+// The value set by SET LOCAL must be visible inside the transaction and revert
+// when the transaction ends by COMMIT, ROLLBACK, or automatic rollback.
+func TestSetLocalStatements(t *testing.T) {
+	showVerbose := func(want string) stmtResult {
+		return sr("SHOW VARIABLE CLI_VERBOSE", &Result{
+			KeepVariables: true,
+			TableHeader:   toTableHeader("CLI_VERBOSE"),
+			Rows:          sliceOf(toRow(want)),
+		})
+	}
+
+	tests := []statementTestCase{
+		{
+			desc: "SET LOCAL reverts on COMMIT of a read-write transaction",
+			stmtResults: []stmtResult{
+				srEmpty(testTableSimpleDDL),
+				srEmpty("BEGIN RW"),
+				srKeep("SET LOCAL CLI_VERBOSE = TRUE"),
+				showVerbose("TRUE"),
+				srDML("INSERT INTO TestTable (id, active) VALUES (1, true)", 1),
+				showVerbose("TRUE"),
+				srEmpty("COMMIT"),
+				showVerbose("FALSE"),
+			},
+		},
+		{
+			desc: "SET LOCAL reverts on ROLLBACK of a read-write transaction",
+			stmtResults: []stmtResult{
+				srEmpty("BEGIN RW"),
+				srKeep("SET LOCAL CLI_VERBOSE = TRUE"),
+				showVerbose("TRUE"),
+				srEmpty("ROLLBACK"),
+				showVerbose("FALSE"),
+			},
+		},
+		{
+			desc: "SET LOCAL reverts when a read-only transaction is closed",
+			stmtResults: []stmtResult{
+				srEmpty("BEGIN RO"),
+				srKeep("SET LOCAL CLI_VERBOSE = TRUE"),
+				showVerbose("TRUE"),
+				srEmpty("COMMIT"), // closes the read-only transaction
+				showVerbose("FALSE"),
+			},
+		},
+		{
+			desc: "SET LOCAL survives the pending to active transition",
+			stmtResults: []stmtResult{
+				srEmpty(testTableSimpleDDL),
+				srEmpty("BEGIN"), // pending until the first statement
+				srKeep("SET LOCAL CLI_VERBOSE = TRUE"),
+				srDML("INSERT INTO TestTable (id, active) VALUES (1, true)", 1), // determines RW
+				showVerbose("TRUE"),
+				srEmpty("ROLLBACK"),
+				showVerbose("FALSE"),
+			},
+		},
+	}
+
+	runStatementTests(t, tests)
+}
+
 // TestShowStatements tests SHOW, DESCRIBE, and HELP statement functionality
 func TestShowStatements(t *testing.T) {
 	tests := []statementTestCase{

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -185,28 +185,57 @@ func (h *SessionHandler) createSessionWithOpts(ctx context.Context, sysVars *sys
 	return NewSession(ctx, sysVars, h.clientOpts...)
 }
 
-func (h *SessionHandler) handleUse(ctx context.Context, s *UseStatement) (*Result, error) {
-	newSystemVariables := *h.systemVariables
-	newSystemVariables.Connection.Database = s.Database
-	newSystemVariables.Connection.Role = s.Role
-	// Clear the registry so it gets recreated with the new systemVariables instance
-	newSystemVariables.Registry = nil
+// validateSessionSwitch rejects USE/DETACH while a transaction or batch is
+// active. Switching sessions would silently abandon the transaction (its locks
+// would persist until client teardown) and drop any buffered batch statements.
+func (h *SessionHandler) validateSessionSwitch() error {
+	if h.Session == nil {
+		return nil
+	}
+	if h.InTransaction() {
+		return errors.New("cannot switch session while a transaction is active; COMMIT, ROLLBACK, or CLOSE it first")
+	}
+	if h.batch.IsActive() {
+		return errors.New("cannot switch session while a batch is active; RUN BATCH or ABORT BATCH first")
+	}
+	return nil
+}
 
-	newSession, err := h.createSessionWithOpts(ctx, &newSystemVariables)
-	if err != nil {
+// switchSession mutates the single live systemVariables instance in place and
+// builds a replacement session around it. The registry holds pointers into this
+// struct and other components (Cli, StreamManager consumers) hold the same
+// pointer, so copying the struct would fork the state they read (split-brain).
+// On any failure the connection fields and the inTransaction hook (which
+// newSessionWithFactories points at the new session) are restored.
+func (h *SessionHandler) switchSession(ctx context.Context, database, role string, validate func(*Session) error) (*Result, error) {
+	if err := h.validateSessionSwitch(); err != nil {
 		return nil, err
 	}
 
-	// Check if the target database exists
-	exists, err := newSession.DatabaseExists(ctx)
+	sysVars := h.systemVariables
+	oldDatabase, oldRole := sysVars.Connection.Database, sysVars.Connection.Role
+	oldInTransaction := sysVars.inTransaction
+	sysVars.Connection.Database = database
+	sysVars.Connection.Role = role
+
+	restore := func() {
+		sysVars.Connection.Database = oldDatabase
+		sysVars.Connection.Role = oldRole
+		sysVars.inTransaction = oldInTransaction
+	}
+
+	newSession, err := h.createSessionWithOpts(ctx, sysVars)
 	if err != nil {
-		newSession.Close()
+		restore()
 		return nil, err
 	}
 
-	if !exists {
-		newSession.Close()
-		return nil, fmt.Errorf("unknown database %q", s.Database)
+	if validate != nil {
+		if err := validate(newSession); err != nil {
+			newSession.Close()
+			restore()
+			return nil, err
+		}
 	}
 
 	// Replace the old session with the new one
@@ -216,25 +245,22 @@ func (h *SessionHandler) handleUse(ctx context.Context, s *UseStatement) (*Resul
 	return &Result{}, nil
 }
 
+func (h *SessionHandler) handleUse(ctx context.Context, s *UseStatement) (*Result, error) {
+	return h.switchSession(ctx, s.Database, s.Role, func(newSession *Session) error {
+		exists, err := newSession.DatabaseExists(ctx)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("unknown database %q", s.Database)
+		}
+		return nil
+	})
+}
+
 func (h *SessionHandler) handleDetach(ctx context.Context, s *DetachStatement) (*Result, error) {
-	newSystemVariables := *h.systemVariables
-
 	// Clear database and role to switch to detached mode
-	newSystemVariables.Connection.Database = ""
-	newSystemVariables.Connection.Role = ""
-	// Clear the registry so it gets recreated with the new systemVariables instance
-	newSystemVariables.Registry = nil
-
-	newSession, err := h.createSessionWithOpts(ctx, &newSystemVariables)
-	if err != nil {
-		return nil, err
-	}
-
-	// Replace the old session with the new one
-	h.Session.Close()
-	h.Session = newSession
-
-	return &Result{}, nil
+	return h.switchSession(ctx, "", "", nil)
 }
 
 type SessionMode int
@@ -937,6 +963,14 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 	defer func() {
 		if result != nil {
 			result.BatchInfo = s.batch.Info()
+		}
+	}()
+	// SET LOCAL values revert when the transaction ends for any reason:
+	// COMMIT/ROLLBACK/CLOSE statements, or automatic rollback on statement error.
+	// All those paths funnel through here, so one post-statement check suffices.
+	defer func() {
+		if s.txn != nil {
+			s.txn.restoreLocalVarsIfIdle()
 		}
 	}()
 	if _, ok := stmt.(MutationStatement); ok {

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -935,6 +935,16 @@ TABLE Singers (42)
 			want:  &SetAddStatement{VarName: "CLI_PROTO_DESCRIPTOR_FILE", Value: `"./message_descriptors.pb"`},
 		},
 		{
+			desc:  "SET LOCAL statement",
+			input: `SET LOCAL OPTIMIZER_VERSION = "3"`,
+			want:  &SetLocalStatement{VarName: "OPTIMIZER_VERSION", Value: `"3"`},
+		},
+		{
+			desc:  "SET statement with variable named LOCAL is not SET LOCAL",
+			input: `SET LOCAL = "3"`,
+			want:  &SetStatement{VarName: "LOCAL", Value: `"3"`},
+		},
+		{
 			desc:  "SHOW VARIABLE statement",
 			input: `SHOW VARIABLE OPTIMIZER_VERSION`,
 			want:  &ShowVariableStatement{VarName: "OPTIMIZER_VERSION"},

--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the MIT License.
+
+package mycli
+
+import (
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+)
+
+// newSessionForLocalVarTest builds a Session wired for the pending-transaction
+// lifecycle (BEGIN -> ... -> COMMIT/ROLLBACK on a pending transaction performs
+// no RPCs), so SET LOCAL semantics can be tested without an emulator.
+func newSessionForLocalVarTest(t *testing.T) *Session {
+	t.Helper()
+	sysVars := newSystemVariablesWithDefaultsForTest()
+	sysVars.ensureRegistry()
+	session := &Session{
+		mode:            DatabaseConnected,
+		systemVariables: sysVars,
+		txn:             NewTransactionManager(nil, sysVars, spanner.ClientConfig{}),
+	}
+	sysVars.inTransaction = session.InTransaction
+	return session
+}
+
+func mustGetVar(t *testing.T, session *Session, name string) string {
+	t.Helper()
+	value, err := session.systemVariables.Registry.Get(name)
+	if err != nil {
+		t.Fatalf("Registry.Get(%q) error: %v", name, err)
+	}
+	return value
+}
+
+func TestSetLocalRequiresTransaction(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+
+	_, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"})
+	if err == nil || !strings.Contains(err.Error(), "requires an active transaction") {
+		t.Errorf("SET LOCAL outside transaction: got error %v, want 'requires an active transaction'", err)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Errorf("CLI_VERBOSE changed by failed SET LOCAL: got %q, want FALSE", got)
+	}
+}
+
+func TestSetLocalRevertsOnTransactionEnd(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		desc    string
+		endStmt Statement
+	}{
+		{desc: "COMMIT", endStmt: &CommitStatement{}},
+		{desc: "ROLLBACK", endStmt: &RollbackStatement{}},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			session := newSessionForLocalVarTest(t)
+			ctx := t.Context()
+
+			if _, err := session.ExecuteStatement(ctx, &BeginStatement{Priority: sppb.RequestOptions_PRIORITY_UNSPECIFIED}); err != nil {
+				t.Fatalf("BEGIN error: %v", err)
+			}
+
+			if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+				t.Fatalf("SET LOCAL error: %v", err)
+			}
+			if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+				t.Errorf("CLI_VERBOSE during transaction: got %q, want TRUE", got)
+			}
+
+			if _, err := session.ExecuteStatement(ctx, tt.endStmt); err != nil {
+				t.Fatalf("%s error: %v", tt.desc, err)
+			}
+			if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+				t.Errorf("CLI_VERBOSE after %s: got %q, want FALSE (reverted)", tt.desc, got)
+			}
+		})
+	}
+}
+
+func TestSetLocalTwiceRestoresOriginalValue(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+
+	if err := session.systemVariables.SetFromSimple("CLI_PROMPT", "original> "); err != nil {
+		t.Fatalf("SET CLI_PROMPT error: %v", err)
+	}
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatalf("BEGIN error: %v", err)
+	}
+	for _, value := range []string{`'first> '`, `'second> '`} {
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_PROMPT", Value: value}); err != nil {
+			t.Fatalf("SET LOCAL CLI_PROMPT = %s error: %v", value, err)
+		}
+	}
+	if got := mustGetVar(t, session, "CLI_PROMPT"); got != "second> " {
+		t.Errorf("CLI_PROMPT during transaction: got %q, want %q", got, "second> ")
+	}
+
+	if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+		t.Fatalf("ROLLBACK error: %v", err)
+	}
+	if got := mustGetVar(t, session, "CLI_PROMPT"); got != "original> " {
+		t.Errorf("CLI_PROMPT after ROLLBACK: got %q, want %q (first saved value wins)", got, "original> ")
+	}
+}
+
+func TestSetLocalRejectsUnsupportedVariables(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		desc    string
+		varName string
+		value   string
+		wantErr string
+	}{
+		{desc: "read-only variable", varName: "CLI_VERSION", value: "'v1'", wantErr: "does not support SET LOCAL"},
+		{desc: "unknown variable", varName: "NO_SUCH_VARIABLE", value: "1", wantErr: "unknown variable name"},
+		{desc: "virtual variable", varName: "COMMIT_RESPONSE", value: "1", wantErr: "unimplemented setter"},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			session := newSessionForLocalVarTest(t)
+			ctx := t.Context()
+
+			if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+				t.Fatalf("BEGIN error: %v", err)
+			}
+			_, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: tt.varName, Value: tt.value})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("SET LOCAL %s: got error %v, want containing %q", tt.varName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSessionSwitchGuards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("USE rejected while in transaction", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		handler := NewSessionHandler(session)
+		ctx := t.Context()
+
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatalf("BEGIN error: %v", err)
+		}
+		_, err := handler.ExecuteStatement(ctx, &UseStatement{Database: "other"})
+		if err == nil || !strings.Contains(err.Error(), "transaction is active") {
+			t.Errorf("USE in transaction: got error %v, want 'transaction is active'", err)
+		}
+	})
+
+	t.Run("DETACH rejected while batch is active", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		handler := NewSessionHandler(session)
+		ctx := t.Context()
+
+		if err := session.batch.Start(batchModeDDL); err != nil {
+			t.Fatalf("batch.Start error: %v", err)
+		}
+		_, err := handler.ExecuteStatement(ctx, &DetachStatement{})
+		if err == nil || !strings.Contains(err.Error(), "batch is active") {
+			t.Errorf("DETACH with active batch: got error %v, want 'batch is active'", err)
+		}
+	})
+}

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -3,6 +3,7 @@ package mycli
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -90,6 +91,62 @@ func (s *SetStatement) Execute(ctx context.Context, session *Session) (*Result, 
 	if err := session.systemVariables.SetFromGoogleSQL(s.VarName, s.Value); err != nil {
 		return nil, err
 	}
+	return &Result{KeepVariables: true}, nil
+}
+
+// SetLocalStatement implements `SET LOCAL <name> = <value>`: the change is
+// scoped to the current transaction. The previous value is recorded in the
+// transaction's undo log (TransactionManager.localVarUndo) and restored when
+// the transaction ends, whether by COMMIT, ROLLBACK, or CLOSE.
+// Following java-spanner, SET LOCAL outside a transaction is an error.
+type SetLocalStatement struct {
+	VarName string
+	Value   string
+}
+
+func (s *SetLocalStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	if session.txn == nil || !session.InTransaction() {
+		return nil, errors.New("SET LOCAL requires an active transaction; start one with BEGIN")
+	}
+
+	sysVars := session.systemVariables
+	upperName := strings.ToUpper(s.VarName)
+
+	// Mirror the SET special cases for variables living outside the registry.
+	if upperName == "COMMIT_RESPONSE" || upperName == "CLI_DIRECT_READ" {
+		return nil, errSetterUnimplemented{s.VarName}
+	}
+
+	oldValue, err := sysVars.Registry.Get(upperName)
+	if err != nil {
+		var unknownErr *ErrUnknownVariable
+		if errors.As(err, &unknownErr) {
+			return nil, fmt.Errorf("unknown variable name: %v", s.VarName)
+		}
+		return nil, err
+	}
+
+	// Pre-flight: verify the saved value can be set back, so the restore at
+	// transaction end cannot fail. This also rejects read-only variables and
+	// variables whose setter refuses writes mid-transaction, before any state
+	// changes. Setting the current value again is semantically a no-op.
+	if err := sysVars.Registry.Set(upperName, oldValue, false); err != nil {
+		return nil, fmt.Errorf("%s does not support SET LOCAL: %w", upperName, err)
+	}
+
+	if err := sysVars.SetFromGoogleSQL(s.VarName, s.Value); err != nil {
+		return nil, err
+	}
+
+	if err := session.txn.pushLocalVarUndo(upperName, oldValue); err != nil {
+		// The transaction ended between the check above and the push;
+		// undo the set so the value does not silently outlive the transaction.
+		if restoreErr := sysVars.Registry.Set(upperName, oldValue, false); restoreErr != nil {
+			err = errors.Join(err, restoreErr)
+		}
+		return nil, err
+	}
+
 	return &Result{KeepVariables: true}, nil
 }
 

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -120,6 +121,18 @@ type TransactionManager struct {
 	client       *spanner.Client      // same pointer as Session.client
 	sysVars      *systemVariables     // same pointer as Session.systemVariables
 	clientConfig spanner.ClientConfig // for directed read in tryQueryInTransaction
+
+	// localVarUndo records (name, previous value) pairs for system variables
+	// changed by SET LOCAL in the current transaction. Guarded by mu.
+	// It lives on the TransactionManager rather than on transactionContext so it
+	// survives the pending -> active context replacement in Begin*TransactionLocked.
+	localVarUndo []savedLocalVar
+}
+
+// savedLocalVar is one SET LOCAL undo-log entry.
+type savedLocalVar struct {
+	name     string // uppercase variable name
+	oldValue string // display-string value before SET LOCAL, restored via Registry.Set
 }
 
 // NewTransactionManager creates a new TransactionManager.
@@ -247,6 +260,48 @@ func (tm *TransactionManager) withReadOnlyTransactionOrStart(ctx context.Context
 
 	// Now execute within the transaction we created
 	return tm.withReadOnlyTransaction(fn)
+}
+
+// pushLocalVarUndo appends a SET LOCAL undo entry for the current transaction.
+// It fails if no transaction is active, because the entry would never be replayed.
+func (tm *TransactionManager) pushLocalVarUndo(name, oldValue string) error {
+	return tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
+		if *tcPtr == nil {
+			return ErrNoTransaction
+		}
+		tm.localVarUndo = append(tm.localVarUndo, savedLocalVar{name: name, oldValue: oldValue})
+		return nil
+	})
+}
+
+// restoreLocalVarsIfIdle replays the SET LOCAL undo log once the transaction has
+// ended. SET LOCAL values revert on commit, rollback, and close alike, so instead
+// of hooking every transaction-ending site (including automatic rollback on
+// statement error), this runs after each statement execution and acts only when
+// no transaction context remains. Replay happens outside the lock because
+// variable setters may themselves inspect transaction state.
+func (tm *TransactionManager) restoreLocalVarsIfIdle() {
+	var entries []savedLocalVar
+	_ = tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
+		if *tcPtr != nil || len(tm.localVarUndo) == 0 {
+			return nil
+		}
+		entries = tm.localVarUndo
+		tm.localVarUndo = nil
+		return nil
+	})
+
+	// Replay in reverse so that for a variable set twice, the value saved by the
+	// first SET LOCAL wins.
+	for _, e := range slices.Backward(entries) {
+		if err := tm.sysVars.Registry.Set(e.name, e.oldValue, false); err != nil {
+			// SET LOCAL verified at set time that the saved value round-trips
+			// through the setter, so a failure here means session state changed
+			// underneath us; the variable keeps its transaction-local value.
+			slog.Warn("failed to restore SET LOCAL variable after transaction end",
+				"name", e.name, "value", e.oldValue, "err", err)
+		}
+	}
 }
 
 // clearTransactionContext atomically clears the transaction context.


### PR DESCRIPTION
## Summary

Implements `SET LOCAL <name> = <value>` for transaction-scoped system variables, together with the state-model prerequisite that makes it safe: `systemVariables` is now a single-owner instance that is never copied.

Fixes #400

## SET LOCAL semantics

- `SET LOCAL <name> = <value>` changes a system variable for the duration of the current transaction (including a pending transaction created by `BEGIN`). The previous value is restored when the transaction ends by `COMMIT`, `ROLLBACK`, `CLOSE`, or automatic rollback on statement error.
- `SET LOCAL` outside a transaction is an error, following java-spanner rather than the PostgreSQL warning+no-op behavior.
- Setting the same variable twice restores the value saved by the first `SET LOCAL`.
- Read-only variables, unknown variables, virtual variables (`COMMIT_RESPONSE`, `CLI_DIRECT_READ`), and variables whose setter rejects writes mid-transaction (e.g. `READONLY`) are rejected.

## Design

Follows the save/restore design recorded on #400 (an overlay map would require rewriting every field read site because the registry is pointer-backed):

- `SET LOCAL` reads the current display value via the registry, applies the new value through the normal setter, and pushes an `(name, oldValue)` undo entry.
- The undo log lives on `TransactionManager` (guarded by its mutex), not on `transactionContext`, so it survives the pending -> active context replacement in `Begin*TransactionLocked`.
- A pre-flight check sets the saved value back through the setter before applying the new one, guaranteeing the restore at transaction end cannot fail. This also re-runs setter side effects deterministically.
- Restore is triggered by one post-statement check in `Session.ExecuteStatement` (`restoreLocalVarsIfIdle`): every transaction-ending path funnels through there, including automatic rollback on error, so no per-site hooks are needed. Replay happens outside the lock because setters may inspect transaction state, and in reverse order so the oldest saved value wins.

## Prerequisite: single-owner systemVariables

`USE`/`DETACH` previously shallow-copied `systemVariables` and rebuilt the registry against the copy. That fork produced split-brain state: `Cli.SystemVariables` kept pointing at the old instance, so after `USE`, `SET CLI_FORMAT` (and other display variables) was silently ignored on buffered output paths, and the `DROP DATABASE` current-database guard compared a stale database name. It would also have made the SET LOCAL undo log restore onto a dead instance.

- `handleUse`/`handleDetach` now mutate the single live instance in place (database/role and the `inTransaction` hook are restored on failure) and rebuild only the session/clients around it. The `Registry = nil` reset dance is gone.
- `USE`/`DETACH` are rejected while a transaction or batch is active. Previously the transaction was silently abandoned (its locks persisted until client teardown) and buffered batch statements were dropped.

## Testing

- Unit tests (`statements_set_local_test.go`, run in `-short`): the pending-transaction lifecycle needs no RPCs, so revert-on-COMMIT/ROLLBACK, first-saved-value-wins, unsupported-variable rejection, and the USE/DETACH guards are covered without an emulator.
- Integration tests (`TestSetLocalStatements`, emulator): revert on COMMIT and ROLLBACK of a real read-write transaction, revert on read-only transaction close, and survival across the pending -> active transition.
- `make check` passes (full test suite incl. emulator, lint, fmt-check); `make docs-update` regenerated the README statement help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ft2Q1ULY16tKgfW8xDT9f
