### PR TITLE
Decompose systemVariables into ownership-layered state groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | CLI_VERBOSE                | READ_WRITE | `TRUE`                                         |
 | CLI_PROTO_DESCRIPTOR_FILE  | READ_WRITE | `"order_descriptors.pb"`                       |
 | CLI_PARSE_MODE             | READ_WRITE | `"FALLBACK"`                                   |
-| CLI_INSECURE               | READ_WRITE | `"FALSE"`                                      |
+| CLI_INSECURE               | READ_ONLY  | `"FALSE"`                                      |
 | CLI_QUERY_MODE             | READ_WRITE | `"PROFILE"`                                    |
 | CLI_LINT_PLAN              | READ_WRITE | `"TRUE"`                                       |
 | CLI_EXPLAIN_HANGING_INDENT | READ_WRITE | `"TRUE"`                                       |

--- a/internal/mycli/app.go
+++ b/internal/mycli/app.go
@@ -304,13 +304,13 @@ func run(ctx context.Context, opts *spannerOptions) error {
 		runtimePlatform, err := spanemuboost.RuntimePlatform(ctx, embeddedRuntime)
 		if err != nil {
 			slog.Warn("failed to detect embedded runtime platform", "error", err)
-			sysVars.Connection.EmulatorPlatform = "unknown"
+			sysVars.Config.EmulatorPlatform = "unknown"
 		} else {
-			sysVars.Connection.EmulatorPlatform = runtimePlatform
+			sysVars.Config.EmulatorPlatform = runtimePlatform
 		}
 		slog.Debug("Detected container platform",
 			"requested", opts.EmulatorPlatform,
-			"actual", sysVars.Connection.EmulatorPlatform)
+			"actual", sysVars.Config.EmulatorPlatform)
 
 		// Parse container URI into host and port
 		host, port, err := parseEndpoint(embeddedRuntime.URI())
@@ -318,14 +318,14 @@ func run(ctx context.Context, opts *spannerOptions) error {
 			// This should not happen with a valid URI from testcontainers, but handle defensively.
 			return fmt.Errorf("failed to parse embedded runtime endpoint URI %q: %w", embeddedRuntime.URI(), err)
 		}
-		sysVars.Connection.Host, sysVars.Connection.Port = host, port
+		sysVars.Config.Host, sysVars.Config.Port = host, port
 		switch backend {
 		case spanemuboost.BackendEmulator:
-			sysVars.Connection.WithoutAuthentication = true
+			sysVars.Config.WithoutAuthentication = true
 		case spanemuboost.BackendOmni:
-			sysVars.Internal.EmbeddedClientOptions = append([]option.ClientOption(nil), embeddedRuntime.ClientOptions()...)
+			sysVars.Config.EmbeddedClientOptions = append([]option.ClientOption(nil), embeddedRuntime.ClientOptions()...)
 			omniClientConfig := spanemuboost.RecommendedOmniClientConfig()
-			sysVars.Internal.EmbeddedClientConfig = &omniClientConfig
+			sysVars.Config.EmbeddedClientConfig = &omniClientConfig
 		}
 	}
 

--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -248,17 +248,17 @@ func (c *Cli) executeStatementInteractive(ctx context.Context, stmt Statement, i
 
 func (c *Cli) updateSystemVariables(result *Result) {
 	// Update timestamps - both ReadTimestamp and CommitTimestamp are now separate fields
-	c.SystemVariables.Query.ReadTimestamp = result.ReadTimestamp
-	c.SystemVariables.Transaction.CommitTimestamp = result.CommitTimestamp
+	c.SystemVariables.LastResult.ReadTimestamp = result.ReadTimestamp
+	c.SystemVariables.LastResult.CommitTimestamp = result.CommitTimestamp
 
 	if result.CommitStats != nil {
 		var ts *timestamppb.Timestamp
 		if !result.CommitTimestamp.IsZero() {
 			ts = timestamppb.New(result.CommitTimestamp)
 		}
-		c.SystemVariables.Transaction.CommitResponse = &sppb.CommitResponse{CommitStats: result.CommitStats, CommitTimestamp: ts}
+		c.SystemVariables.LastResult.CommitResponse = &sppb.CommitResponse{CommitStats: result.CommitStats, CommitTimestamp: ts}
 	} else {
-		c.SystemVariables.Transaction.CommitResponse = nil
+		c.SystemVariables.LastResult.CommitResponse = nil
 	}
 }
 

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -359,7 +359,7 @@ func createSystemVariablesFromOptions(opts *spannerOptions) (*systemVariables, e
 	sysVars.Connection.Instance = opts.InstanceId
 	sysVars.Connection.Database = determineInitialDatabase(opts)
 	sysVars.Display.Verbose = opts.Verbose || opts.MCP // Set Verbose to true when MCP is true
-	sysVars.Feature.MCP = opts.MCP                     // Set MCP field for CLI_MCP system variable
+	sysVars.Config.MCP = opts.MCP                      // Set MCP field for CLI_MCP system variable
 
 	// Override defaults only if explicitly provided
 	if opts.Prompt != nil {
@@ -392,11 +392,11 @@ func createSystemVariablesFromOptions(opts *spannerOptions) (*systemVariables, e
 
 	// Implement precedence: non-hidden flag (--insecure) takes precedence when both are set
 	if opts.Insecure != nil {
-		sysVars.Connection.Insecure = *opts.Insecure
+		sysVars.Config.Insecure = *opts.Insecure
 	} else if opts.SkipTlsVerify != nil {
-		sysVars.Connection.Insecure = *opts.SkipTlsVerify
+		sysVars.Config.Insecure = *opts.SkipTlsVerify
 	} else {
-		sysVars.Connection.Insecure = false // default value
+		sysVars.Config.Insecure = false // default value
 	}
 
 	// Handle --endpoint/--deployment-endpoint aliases with proper precedence
@@ -412,37 +412,37 @@ func createSystemVariablesFromOptions(opts *spannerOptions) (*systemVariables, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse endpoint %q: %w", endpoint, err)
 		}
-		sysVars.Connection.Host, sysVars.Connection.Port = host, port
+		sysVars.Config.Host, sysVars.Config.Port = host, port
 	} else if opts.Host != "" || opts.Port != 0 {
 		// Handle --host and --port flags
 		if opts.Port != 0 && opts.Host == "" {
 			// Only port specified: use localhost for emulator
-			sysVars.Connection.Host = "localhost"
-			sysVars.Connection.Port = opts.Port
+			sysVars.Config.Host = "localhost"
+			sysVars.Config.Port = opts.Port
 		} else if opts.Host != "" && opts.Port == 0 {
 			// Only host specified: use standard Spanner port
-			sysVars.Connection.Host = opts.Host
-			sysVars.Connection.Port = 443
+			sysVars.Config.Host = opts.Host
+			sysVars.Config.Port = 443
 		} else {
 			// Both specified
-			sysVars.Connection.Host = opts.Host
-			sysVars.Connection.Port = opts.Port
+			sysVars.Config.Host = opts.Host
+			sysVars.Config.Port = opts.Port
 		}
 	}
 	sysVars.Params = params
-	sysVars.Feature.LogGrpc = opts.LogGrpc
+	sysVars.Config.LogGrpc = opts.LogGrpc
 	sysVars.Feature.LogLevel = l
-	sysVars.Connection.ImpersonateServiceAccount = opts.ImpersonateServiceAccount
+	sysVars.Config.ImpersonateServiceAccount = opts.ImpersonateServiceAccount
 	sysVars.Feature.VertexAIProject = opts.VertexAIProject
 	sysVars.Feature.AsyncDDL = opts.Async
 
 	// Handle system command options
 	// Priority: --skip-system-command takes precedence over --system-command
 	if opts.SkipSystemCommand {
-		sysVars.Feature.SkipSystemCommand = true
+		sysVars.Config.SkipSystemCommand = true
 	} else if opts.SystemCommand != nil {
 		// --system-command=OFF disables system commands
-		sysVars.Feature.SkipSystemCommand = *opts.SystemCommand == "OFF"
+		sysVars.Config.SkipSystemCommand = *opts.SystemCommand == "OFF"
 	}
 	// If neither flag is set, system commands are enabled by default (SkipSystemCommand = false)
 
@@ -546,8 +546,8 @@ func applyFormatAndSetOptions(sysVars *systemVariables, opts *spannerOptions) er
 func applyEmbeddedRuntimeDefaults(sysVars *systemVariables, opts *spannerOptions) error {
 	if opts.usesEmbeddedRuntime() {
 		// When using an embedded runtime, insecure connection is required.
-		sysVars.Connection.Insecure = true
-		// sysVars.Connection.Host/Port and authentication-related settings are set in run() after the runtime starts.
+		sysVars.Config.Insecure = true
+		// sysVars.Config.Host/Port and authentication-related settings are set in run() after the runtime starts.
 
 		// Set default values for embedded runtime if not specified by user.
 		if sysVars.Connection.Project == "" {

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -119,7 +119,7 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 		return nil, err
 	}
 
-	session.systemVariables.Internal.LastQueryCache = &LastQueryCache{
+	session.systemVariables.LastResult.QueryCache = &LastQueryCache{
 		QueryPlan:       result.Plan,
 		QueryStats:      queryStats,
 		CommitTimestamp: result.CommitResponse.CommitTs,

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -316,7 +316,7 @@ func finalizeQueryResult(result *Result, stats map[string]any, roTxn *spanner.Re
 		}
 	}
 
-	sysVars.Internal.LastQueryCache = &LastQueryCache{
+	sysVars.LastResult.QueryCache = &LastQueryCache{
 		QueryPlan:     plan,
 		QueryStats:    stats,
 		ReadTimestamp: result.ReadTimestamp,

--- a/internal/mycli/integration_mcp_test.go
+++ b/internal/mycli/integration_mcp_test.go
@@ -223,9 +223,11 @@ func testRunMCPWithNonExistentDatabase(t *testing.T) {
 	}
 	sysVarsNonExistent := systemVariables{
 		Connection: ConnectionVars{
-			Project:               clients.ProjectID,  // Use real project
-			Instance:              clients.InstanceID, // Use real instance
-			Database:              "non-existent-database",
+			Project:  clients.ProjectID,  // Use real project
+			Instance: clients.InstanceID, // Use real instance
+			Database: "non-existent-database",
+		},
+		Config: StartupConfig{
 			Host:                  host,
 			Port:                  port,
 			WithoutAuthentication: true,
@@ -431,12 +433,14 @@ func TestRunMCP(t *testing.T) {
 		// Create a new system variables with modified values
 		modifiedSysVars := &systemVariables{
 			Connection: ConnectionVars{
-				Project:               session.systemVariables.Connection.Project,
-				Instance:              session.systemVariables.Connection.Instance,
-				Database:              session.systemVariables.Connection.Database,
-				Host:                  session.systemVariables.Connection.Host,
-				Port:                  session.systemVariables.Connection.Port,
-				WithoutAuthentication: session.systemVariables.Connection.WithoutAuthentication,
+				Project:  session.systemVariables.Connection.Project,
+				Instance: session.systemVariables.Connection.Instance,
+				Database: session.systemVariables.Connection.Database,
+			},
+			Config: StartupConfig{
+				Host:                  session.systemVariables.Config.Host,
+				Port:                  session.systemVariables.Config.Port,
+				WithoutAuthentication: session.systemVariables.Config.WithoutAuthentication,
 			},
 			Display: DisplayVars{
 				AutoWrap:        true, // Set a different value

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -879,13 +879,13 @@ priority = "HIGH"
 			assertEqual(t, "RPCPriority", sysVars.Query.RPCPriority, &tt.wantPriority)
 			// Check endpoint by constructing from host and port
 			var gotEndpoint string
-			if sysVars.Connection.Host != "" && sysVars.Connection.Port != 0 {
-				gotEndpoint = fmt.Sprintf("%s:%d", sysVars.Connection.Host, sysVars.Connection.Port)
+			if sysVars.Config.Host != "" && sysVars.Config.Port != 0 {
+				gotEndpoint = fmt.Sprintf("%s:%d", sysVars.Config.Host, sysVars.Config.Port)
 			}
 			assertEqual(t, "Endpoint (constructed from Host:Port)", gotEndpoint, &tt.wantEndpoint)
 			assertEqual(t, "Role", sysVars.Connection.Role, &tt.wantRole)
-			assertEqual(t, "LogGrpc", sysVars.Feature.LogGrpc, &tt.wantLogGrpc)
-			assertEqual(t, "Insecure", sysVars.Connection.Insecure, &tt.wantInsecure)
+			assertEqual(t, "LogGrpc", sysVars.Config.LogGrpc, &tt.wantLogGrpc)
+			assertEqual(t, "Insecure", sysVars.Config.Insecure, &tt.wantInsecure)
 		})
 	}
 }
@@ -1043,9 +1043,9 @@ func TestFlagSpecialModes(t *testing.T) {
 
 			// Check results
 			verifyConnectionParams(t, sysVars, tt.wantProject, tt.wantInstance, tt.wantDatabase)
-			assertEqual(t, "Insecure", sysVars.Connection.Insecure, &tt.wantInsecure)
+			assertEqual(t, "Insecure", sysVars.Config.Insecure, &tt.wantInsecure)
 			assertEqual(t, "Verbose", sysVars.Display.Verbose, &tt.wantVerbose)
-			assertEqual(t, "MCP", sysVars.Feature.MCP, &tt.wantMCP)
+			assertEqual(t, "MCP", sysVars.Config.MCP, &tt.wantMCP)
 
 			// For CLI_FORMAT, we need to simulate what run() does
 			// Check if this test case has specified a desired CLI_FORMAT value
@@ -2278,7 +2278,7 @@ func TestComplexFlagInteractions(t *testing.T) {
 						if sysVars.Connection.Role != tt.wantRole {
 							t.Errorf("Role = %q, want %q", sysVars.Connection.Role, tt.wantRole)
 						}
-						assertEqual(t, "Insecure", sysVars.Connection.Insecure, &tt.wantInsecure)
+						assertEqual(t, "Insecure", sysVars.Config.Insecure, &tt.wantInsecure)
 						assertEqual(t, "Verbose", sysVars.Display.Verbose, &tt.wantVerbose)
 						assertEqual(t, "ReadOnly", sysVars.Transaction.ReadOnly, &tt.wantReadOnly)
 						assertEqual(t, "RPCPriority", sysVars.Query.RPCPriority, &tt.wantPriority)
@@ -2360,11 +2360,11 @@ func TestAliasFlagPrecedence(t *testing.T) {
 			if sysVars.Connection.Role != tt.wantRole {
 				t.Errorf("Role = %q, want %q", sysVars.Connection.Role, tt.wantRole)
 			}
-			assertEqual(t, "Insecure", sysVars.Connection.Insecure, &tt.wantInsecure)
+			assertEqual(t, "Insecure", sysVars.Config.Insecure, &tt.wantInsecure)
 			// Check endpoint by constructing from host and port
 			var gotEndpoint string
-			if sysVars.Connection.Host != "" && sysVars.Connection.Port != 0 {
-				gotEndpoint = fmt.Sprintf("%s:%d", sysVars.Connection.Host, sysVars.Connection.Port)
+			if sysVars.Config.Host != "" && sysVars.Config.Port != 0 {
+				gotEndpoint = fmt.Sprintf("%s:%d", sysVars.Config.Host, sysVars.Config.Port)
 			}
 			if gotEndpoint != tt.wantEndpoint {
 				t.Errorf("Endpoint (constructed from Host:Port) = %q, want %q", gotEndpoint, tt.wantEndpoint)
@@ -2436,10 +2436,10 @@ func TestHostPortFlags(t *testing.T) {
 				return
 			}
 
-			if sysVars.Connection.Host != tt.wantHost {
-				t.Errorf("Host = %q, want %q", sysVars.Connection.Host, tt.wantHost)
+			if sysVars.Config.Host != tt.wantHost {
+				t.Errorf("Host = %q, want %q", sysVars.Config.Host, tt.wantHost)
 			}
-			assertEqual(t, "Port", sysVars.Connection.Port, &tt.wantPort)
+			assertEqual(t, "Port", sysVars.Config.Port, &tt.wantPort)
 		})
 	}
 }

--- a/internal/mycli/main_test.go
+++ b/internal/mycli/main_test.go
@@ -97,15 +97,18 @@ func Test_initializeSystemVariables(t *testing.T) {
 			},
 			want: systemVariables{
 				Connection: ConnectionVars{
-					Project:                   "test-project",
-					Instance:                  "test-instance",
-					Database:                  "test-database",
-					Role:                      "test-role",
+					Project:  "test-project",
+					Instance: "test-instance",
+					Database: "test-database",
+					Role:     "test-role",
+				},
+				Config: StartupConfig{
 					Host:                      "test-endpoint",
 					Port:                      443,
 					Insecure:                  true,
 					ImpersonateServiceAccount: "test-sa@example.com",
 					EnableADCPlus:             true,
+					LogGrpc:                   true,
 				},
 				Display: DisplayVars{
 					Verbose:              true,
@@ -145,7 +148,6 @@ func Test_initializeSystemVariables(t *testing.T) {
 					ReadOnly:          true,
 				},
 				Feature: FeatureVars{
-					LogGrpc:          true,
 					LogLevel:         slog.LevelInfo,
 					VertexAIProject:  "vertex-project",
 					VertexAIModel:    "gemini-1.0-pro",
@@ -178,7 +180,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				ReadTimestamp: "2023-01-01T00:00:00Z",
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -233,7 +235,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				Timeout: "30s",
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -273,7 +275,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				SkipTlsVerify: lo.ToPtr(true),
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					Insecure:      true, // --insecure takes precedence
 					EnableADCPlus: true,
 				},
@@ -312,7 +314,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				SkipTlsVerify: lo.ToPtr(true),
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					Insecure:      false, // --insecure takes precedence even when false
 					EnableADCPlus: true,
 				},
@@ -350,7 +352,8 @@ func Test_initializeSystemVariables(t *testing.T) {
 				SkipTlsVerify: lo.ToPtr(true),
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Connection: ConnectionVars{},
+				Config: StartupConfig{
 					Insecure:      true, // Uses skip-tls-verify value
 					EnableADCPlus: true,
 				},
@@ -396,7 +399,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				DirectedRead: "invalid-option",
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -470,9 +473,11 @@ func Test_initializeSystemVariables(t *testing.T) {
 			},
 			want: systemVariables{
 				Connection: ConnectionVars{
-					Project:       "user-project",
-					Instance:      "user-instance",
-					Database:      "user-database",
+					Project:  "user-project",
+					Instance: "user-instance",
+					Database: "user-database",
+				},
+				Config: StartupConfig{
 					Insecure:      true, // embedded emulator always sets this
 					EnableADCPlus: true,
 				},
@@ -511,9 +516,11 @@ func Test_initializeSystemVariables(t *testing.T) {
 			},
 			want: systemVariables{
 				Connection: ConnectionVars{
-					Project:       "emulator-project",  // Default value set in initializeSystemVariables
-					Instance:      "emulator-instance", // Default value set in initializeSystemVariables
-					Database:      "emulator-database", // Default value set in initializeSystemVariables
+					Project:  "emulator-project",  // Default value set in initializeSystemVariables
+					Instance: "emulator-instance", // Default value set in initializeSystemVariables
+					Database: "emulator-database", // Default value set in initializeSystemVariables
+				},
+				Config: StartupConfig{
 					Insecure:      true,
 					EnableADCPlus: true,
 				},
@@ -553,9 +560,11 @@ func Test_initializeSystemVariables(t *testing.T) {
 			},
 			want: systemVariables{
 				Connection: ConnectionVars{
-					Project:       "emulator-project",  // Default set for emulator
-					Instance:      "emulator-instance", // Default set for emulator
-					Database:      "",                  // Empty - respects detached mode
+					Project:  "emulator-project",  // Default set for emulator
+					Instance: "emulator-instance", // Default set for emulator
+					Database: "",                  // Empty - respects detached mode
+				},
+				Config: StartupConfig{
 					Insecure:      true,
 					EnableADCPlus: true,
 				},
@@ -594,9 +603,11 @@ func Test_initializeSystemVariables(t *testing.T) {
 			},
 			want: systemVariables{
 				Connection: ConnectionVars{
-					Project:       "default",
-					Instance:      "default",
-					Database:      "emulator-database",
+					Project:  "default",
+					Instance: "default",
+					Database: "emulator-database",
+				},
+				Config: StartupConfig{
 					Insecure:      true,
 					EnableADCPlus: true,
 				},
@@ -636,9 +647,11 @@ func Test_initializeSystemVariables(t *testing.T) {
 			},
 			want: systemVariables{
 				Connection: ConnectionVars{
-					Project:       "default",
-					Instance:      "default",
-					Database:      "",
+					Project:  "default",
+					Instance: "default",
+					Database: "",
+				},
+				Config: StartupConfig{
 					Insecure:      true,
 					EnableADCPlus: true,
 				},
@@ -678,7 +691,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				},
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -715,7 +728,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				OutputTemplate: "output_full.tmpl",
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -754,7 +767,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				},
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -793,7 +806,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 				},
 			},
 			want: systemVariables{
-				Connection: ConnectionVars{
+				Config: StartupConfig{
 					EnableADCPlus: true,
 				},
 				Display: DisplayVars{
@@ -852,7 +865,7 @@ func Test_initializeSystemVariables(t *testing.T) {
 			// and those that are set later in run() (e.g., EnableProgressBar, WithoutAuthentication)
 			if diff := cmp.Diff(tt.want, *got,
 				cmpopts.IgnoreUnexported(systemVariables{}),
-				cmpopts.IgnoreFields(systemVariables{}, "Display.OutputTemplate", "Internal.ProtoDescriptor", "Display.EnableProgressBar", "Connection.WithoutAuthentication", "Registry"), // Removed Params from here
+				cmpopts.IgnoreFields(systemVariables{}, "Display.OutputTemplate", "Internal.ProtoDescriptor", "Display.EnableProgressBar", "Config.WithoutAuthentication", "Registry"), // Removed Params from here
 				cmpopts.IgnoreFields(systemVariables{}, "Display.ParsedAnalyzeColumns", "Display.ExplainPrintSections", "Display.ParsedExplainPrintSections"),
 				cmpopts.EquateApproxTime(time.Microsecond),
 				protocmp.Transform(),
@@ -909,7 +922,8 @@ func Test_newSystemVariablesWithDefaults(t *testing.T) {
 	got := newSystemVariablesWithDefaults()
 
 	want := systemVariables{
-		Connection: ConnectionVars{
+		Connection: ConnectionVars{},
+		Config: StartupConfig{
 			EnableADCPlus: true,
 		},
 		Display: DisplayVars{
@@ -1079,7 +1093,7 @@ func Test_createSystemVariablesFromOptions(t *testing.T) {
 			want: func() systemVariables {
 				sv := newSystemVariablesWithDefaults()
 				sv.Feature.LogLevel = slog.LevelWarn
-				sv.Feature.SkipSystemCommand = true
+				sv.Config.SkipSystemCommand = true
 				sv.Params = make(map[string]ast.Node)
 				return sv
 			}(),
@@ -1092,7 +1106,7 @@ func Test_createSystemVariablesFromOptions(t *testing.T) {
 			want: func() systemVariables {
 				sv := newSystemVariablesWithDefaults()
 				sv.Feature.LogLevel = slog.LevelWarn
-				sv.Feature.SkipSystemCommand = true
+				sv.Config.SkipSystemCommand = true
 				sv.Params = make(map[string]ast.Node)
 				return sv
 			}(),
@@ -1105,7 +1119,7 @@ func Test_createSystemVariablesFromOptions(t *testing.T) {
 			want: func() systemVariables {
 				sv := newSystemVariablesWithDefaults()
 				sv.Feature.LogLevel = slog.LevelWarn
-				sv.Feature.SkipSystemCommand = false
+				sv.Config.SkipSystemCommand = false
 				sv.Params = make(map[string]ast.Node)
 				return sv
 			}(),
@@ -1119,7 +1133,7 @@ func Test_createSystemVariablesFromOptions(t *testing.T) {
 			want: func() systemVariables {
 				sv := newSystemVariablesWithDefaults()
 				sv.Feature.LogLevel = slog.LevelWarn
-				sv.Feature.SkipSystemCommand = true
+				sv.Config.SkipSystemCommand = true
 				sv.Params = make(map[string]ast.Node)
 				return sv
 			}(),

--- a/internal/mycli/meta_commands.go
+++ b/internal/mycli/meta_commands.go
@@ -34,7 +34,7 @@ func (s *ShellMetaCommand) isMetaCommand() {}
 // Execute runs the shell command
 func (s *ShellMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
 	// Check if system commands are disabled
-	if session.systemVariables.Feature.SkipSystemCommand {
+	if session.systemVariables.Config.SkipSystemCommand {
 		return nil, errors.New("system commands are disabled")
 	}
 

--- a/internal/mycli/meta_commands_test.go
+++ b/internal/mycli/meta_commands_test.go
@@ -346,7 +346,7 @@ func TestShellMetaCommand_Execute(t *testing.T) {
 
 	t.Run("system commands disabled", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Feature.SkipSystemCommand = true
+		sysVars.Config.SkipSystemCommand = true
 		sysVars.StreamManager = streamio.NewStreamManager(os.Stdin, io.Discard, io.Discard)
 		session := &Session{
 			systemVariables: &sysVars,
@@ -366,7 +366,7 @@ func TestShellMetaCommand_Execute(t *testing.T) {
 		var output bytes.Buffer
 		var errOutput bytes.Buffer
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Feature.SkipSystemCommand = false
+		sysVars.Config.SkipSystemCommand = false
 		sysVars.StreamManager = streamio.NewStreamManager(os.Stdin, &output, &errOutput)
 		session := &Session{
 			systemVariables: &sysVars,
@@ -390,7 +390,7 @@ func TestShellMetaCommand_Execute(t *testing.T) {
 		var output bytes.Buffer
 		var errOutput bytes.Buffer
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Feature.SkipSystemCommand = false
+		sysVars.Config.SkipSystemCommand = false
 		sysVars.StreamManager = streamio.NewStreamManager(os.Stdin, &output, &errOutput)
 		session := &Session{
 			systemVariables: &sysVars,

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -67,7 +67,7 @@ var defaultClientOpts = []option.ClientOption{
 }
 
 func clientConfigForSystemVariables(sysVars *systemVariables) spanner.ClientConfig {
-	if override := sysVars.Internal.EmbeddedClientConfig; override != nil {
+	if override := sysVars.Config.EmbeddedClientConfig; override != nil {
 		return *override
 	}
 	return defaultClientConfig
@@ -321,11 +321,11 @@ func newSessionWithFactories(
 	clientConfig.DatabaseRole = sysVars.Connection.Role
 	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
 
-	if sysVars.Connection.Insecure && len(sysVars.Internal.EmbeddedClientOptions) == 0 {
+	if sysVars.Config.Insecure && len(sysVars.Config.EmbeddedClientOptions) == 0 {
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	}
 
-	if sysVars.Feature.LogGrpc {
+	if sysVars.Config.LogGrpc {
 		opts = append(opts, logGrpcClientOptions()...)
 	}
 
@@ -360,11 +360,11 @@ func NewAdminSession(ctx context.Context, sysVars *systemVariables, opts ...opti
 	clientConfig.DatabaseRole = sysVars.Connection.Role
 	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
 
-	if sysVars.Connection.Insecure && len(sysVars.Internal.EmbeddedClientOptions) == 0 {
+	if sysVars.Config.Insecure && len(sysVars.Config.EmbeddedClientOptions) == 0 {
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	}
 
-	if sysVars.Feature.LogGrpc {
+	if sysVars.Config.LogGrpc {
 		opts = append(opts, logGrpcClientOptions()...)
 	}
 
@@ -992,22 +992,22 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 
 // createClientOptions creates client options based on credential and system variables
 func createClientOptions(ctx context.Context, credential []byte, sysVars *systemVariables) ([]option.ClientOption, error) {
-	if len(sysVars.Internal.EmbeddedClientOptions) > 0 {
-		return append([]option.ClientOption(nil), sysVars.Internal.EmbeddedClientOptions...), nil
+	if len(sysVars.Config.EmbeddedClientOptions) > 0 {
+		return append([]option.ClientOption(nil), sysVars.Config.EmbeddedClientOptions...), nil
 	}
 
 	var opts []option.ClientOption
-	if sysVars.Connection.Host != "" && sysVars.Connection.Port != 0 {
+	if sysVars.Config.Host != "" && sysVars.Config.Port != 0 {
 		// Reconstruct the endpoint, adding brackets back for IPv6 addresses
-		endpoint := net.JoinHostPort(sysVars.Connection.Host, strconv.Itoa(sysVars.Connection.Port))
+		endpoint := net.JoinHostPort(sysVars.Config.Host, strconv.Itoa(sysVars.Config.Port))
 		opts = append(opts, option.WithEndpoint(endpoint))
 	}
 
 	switch {
-	case sysVars.Connection.WithoutAuthentication:
+	case sysVars.Config.WithoutAuthentication:
 		opts = append(opts, option.WithoutAuthentication())
-	case sysVars.Connection.EnableADCPlus:
-		source, err := tokensource.SmartAccessTokenSource(ctx, adcplus.WithCredentialsJSON(credential), adcplus.WithTargetPrincipal(sysVars.Connection.ImpersonateServiceAccount))
+	case sysVars.Config.EnableADCPlus:
+		source, err := tokensource.SmartAccessTokenSource(ctx, adcplus.WithCredentialsJSON(credential), adcplus.WithTargetPrincipal(sysVars.Config.ImpersonateServiceAccount))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -172,12 +172,10 @@ func TestCreateClientOptionsUsesEmbeddedClientOptions(t *testing.T) {
 	t.Parallel()
 
 	sysVars := &systemVariables{
-		Connection: ConnectionVars{
+		Config: StartupConfig{
 			Host:                  "localhost",
 			Port:                  9010,
 			WithoutAuthentication: true,
-		},
-		Internal: InternalVars{
 			EmbeddedClientOptions: []option.ClientOption{
 				option.WithoutAuthentication(),
 			},
@@ -273,7 +271,7 @@ func TestNewSessionWithFactoriesUsesEmbeddedClientConfig(t *testing.T) {
 		Query: QueryVars{
 			DirectedRead: directedRead,
 		},
-		Internal: InternalVars{
+		Config: StartupConfig{
 			EmbeddedClientConfig: &spanner.ClientConfig{
 				DisableNativeMetrics: true,
 				IsExperimentalHost:   true,
@@ -330,9 +328,9 @@ func TestNewSessionWithFactoriesDoesNotAppendInsecureForEmbeddedOptions(t *testi
 			Project:  "test-project",
 			Instance: "test-instance",
 			Database: "test-database",
-			Insecure: true,
 		},
-		Internal: InternalVars{
+		Config: StartupConfig{
+			Insecure: true,
 			EmbeddedClientOptions: []option.ClientOption{
 				option.WithoutAuthentication(),
 			},
@@ -351,7 +349,7 @@ func TestNewSessionWithFactoriesDoesNotAppendInsecureForEmbeddedOptions(t *testi
 			return &adminapi.DatabaseAdminClient{}, nil
 		},
 		func(*spanner.Client) {},
-		sysVars.Internal.EmbeddedClientOptions...,
+		sysVars.Config.EmbeddedClientOptions...,
 	)
 	if err != nil {
 		t.Fatalf("newSessionWithFactories() error = %v", err)
@@ -359,7 +357,7 @@ func TestNewSessionWithFactoriesDoesNotAppendInsecureForEmbeddedOptions(t *testi
 	if session == nil {
 		t.Fatal("newSessionWithFactories() returned nil session")
 	}
-	if len(gotOpts) != len(sysVars.Internal.EmbeddedClientOptions)+len(defaultClientOpts) {
-		t.Fatalf("len(opts) = %d, want %d", len(gotOpts), len(sysVars.Internal.EmbeddedClientOptions)+len(defaultClientOpts))
+	if len(gotOpts) != len(sysVars.Config.EmbeddedClientOptions)+len(defaultClientOpts) {
+		t.Fatalf("len(opts) = %d, want %d", len(gotOpts), len(sysVars.Config.EmbeddedClientOptions)+len(defaultClientOpts))
 	}
 }

--- a/internal/mycli/startup_config_test.go
+++ b/internal/mycli/startup_config_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the MIT License.
+
+package mycli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseEndpoint covers endpoint string parsing for the --endpoint flag.
+// (CLI_ENDPOINT itself is read-only; see TestStartupConfigVariablesAreReadOnly.)
+func TestParseEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc        string
+		value       string
+		wantHost    string
+		wantPort    int
+		errContains string
+	}{
+		{desc: "valid endpoint", value: "example.com:443", wantHost: "example.com", wantPort: 443},
+		{desc: "endpoint with IPv6", value: "[2001:db8::1]:443", wantHost: "2001:db8::1", wantPort: 443},
+		{desc: "invalid endpoint - no port", value: "example.com", errContains: "invalid endpoint format"},
+		{desc: "invalid endpoint - bare IPv6 without port", value: "2001:db8::1", errContains: "invalid endpoint format"},
+		{desc: "invalid endpoint - non-numeric port", value: "example.com:abc", errContains: "invalid port in endpoint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			host, port, err := parseEndpoint(tt.value)
+			if tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("parseEndpoint(%q) error = %v, want containing %q", tt.value, err, tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseEndpoint(%q) unexpected error: %v", tt.value, err)
+			}
+			if host != tt.wantHost || port != tt.wantPort {
+				t.Errorf("parseEndpoint(%q) = (%q, %d), want (%q, %d)", tt.value, host, port, tt.wantHost, tt.wantPort)
+			}
+		})
+	}
+}
+
+// TestStartupConfigVariablesAreReadOnly asserts that every system variable
+// backed by StartupConfig rejects SET. This is load-bearing for
+// CLI_SKIP_SYSTEM_COMMAND: it is a security feature, and if it were settable a
+// user in a restricted environment could re-enable shell access with SET.
+// CLI_ENABLE_ADC_PLUS is excluded: it is session-init-only by design.
+func TestStartupConfigVariablesAreReadOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		varName string
+		value   string
+	}{
+		{varName: "CLI_HOST", value: "example.com"},
+		{varName: "CLI_PORT", value: "443"},
+		{varName: "CLI_ENDPOINT", value: "example.com:443"},
+		{varName: "CLI_INSECURE", value: "TRUE"},
+		{varName: "CLI_IMPERSONATE_SERVICE_ACCOUNT", value: "sa@example.com"},
+		{varName: "CLI_EMULATOR_PLATFORM", value: "linux/amd64"},
+		{varName: "CLI_LOG_GRPC", value: "TRUE"},
+		{varName: "CLI_MCP", value: "TRUE"},
+		{varName: "CLI_SKIP_SYSTEM_COMMAND", value: "FALSE"},
+	} {
+		t.Run(tt.varName, func(t *testing.T) {
+			t.Parallel()
+			sysVars := newSystemVariablesWithDefaultsForTest()
+			err := sysVars.SetFromSimple(tt.varName, tt.value)
+			if err == nil || !strings.Contains(err.Error(), "read-only") {
+				t.Errorf("SET %s: got error %v, want read-only error", tt.varName, err)
+			}
+		})
+	}
+}

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -92,11 +92,11 @@ type ExplainLastQueryStatement struct {
 }
 
 func (s *ExplainLastQueryStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	if session.systemVariables.Internal.LastQueryCache == nil {
+	if session.systemVariables.LastResult.QueryCache == nil {
 		return nil, fmt.Errorf("last query cache missing because query not executed")
 	}
 
-	if session.systemVariables.Internal.LastQueryCache.QueryPlan == nil || len(session.systemVariables.Internal.LastQueryCache.QueryPlan.GetPlanNodes()) == 0 {
+	if session.systemVariables.LastResult.QueryCache.QueryPlan == nil || len(session.systemVariables.LastResult.QueryCache.QueryPlan.GetPlanNodes()) == 0 {
 		return nil, fmt.Errorf("missing last query plan. This may happen if the Cloud Spanner Emulator is used, as it may not fully support EXPLAIN and EXPLAIN ANALYZE features")
 	}
 
@@ -104,12 +104,12 @@ func (s *ExplainLastQueryStatement) Execute(ctx context.Context, session *Sessio
 	var result *Result
 	if s.Analyze {
 		result, err = generateExplainAnalyzeResult(session.systemVariables,
-			session.systemVariables.Internal.LastQueryCache.QueryPlan,
-			session.systemVariables.Internal.LastQueryCache.QueryStats,
+			session.systemVariables.LastResult.QueryCache.QueryPlan,
+			session.systemVariables.LastResult.QueryCache.QueryStats,
 			s.Format, s.Width, s.PrintSections)
 	} else {
 		result, err = generateExplainResult(session.systemVariables,
-			session.systemVariables.Internal.LastQueryCache.QueryPlan, s.Format, s.Width, s.PrintSections)
+			session.systemVariables.LastResult.QueryCache.QueryPlan, s.Format, s.Width, s.PrintSections)
 	}
 
 	if err != nil {
@@ -117,8 +117,8 @@ func (s *ExplainLastQueryStatement) Execute(ctx context.Context, session *Sessio
 	}
 
 	// Restore the appropriate timestamp from cache
-	result.ReadTimestamp = session.systemVariables.Internal.LastQueryCache.ReadTimestamp
-	result.CommitTimestamp = session.systemVariables.Internal.LastQueryCache.CommitTimestamp
+	result.ReadTimestamp = session.systemVariables.LastResult.QueryCache.ReadTimestamp
+	result.CommitTimestamp = session.systemVariables.LastResult.QueryCache.CommitTimestamp
 	return result, nil
 }
 
@@ -127,11 +127,11 @@ type ShowPlanNodeStatement struct {
 }
 
 func (s *ShowPlanNodeStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	if session.systemVariables.Internal.LastQueryCache == nil || session.systemVariables.Internal.LastQueryCache.QueryPlan == nil {
+	if session.systemVariables.LastResult.QueryCache == nil || session.systemVariables.LastResult.QueryCache.QueryPlan == nil {
 		return nil, errors.New("no query plan cached. Run query or EXPLAIN ANALYZE first")
 	}
 
-	planNodes := session.systemVariables.Internal.LastQueryCache.QueryPlan.GetPlanNodes()
+	planNodes := session.systemVariables.LastResult.QueryCache.QueryPlan.GetPlanNodes()
 	if s.NodeID >= len(planNodes) {
 		return nil, fmt.Errorf("node with ID %d not found in the cached query plan", s.NodeID)
 	}
@@ -325,7 +325,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		}
 	}
 
-	session.systemVariables.Internal.LastQueryCache = &LastQueryCache{
+	session.systemVariables.LastResult.QueryCache = &LastQueryCache{
 		QueryPlan:     plan,
 		QueryStats:    stats,
 		ReadTimestamp: result.ReadTimestamp,
@@ -426,7 +426,7 @@ func executeExplainAnalyzeDML(ctx context.Context, session *Session, sql string,
 	result.CommitTimestamp = dmlResult.CommitResponse.CommitTs
 
 	// Update LastQueryCache to maintain consistency with other DML execution functions
-	session.systemVariables.Internal.LastQueryCache = &LastQueryCache{
+	session.systemVariables.LastResult.QueryCache = &LastQueryCache{
 		QueryPlan:       dmlResult.Plan,
 		QueryStats:      queryStats,
 		CommitTimestamp: dmlResult.CommitResponse.CommitTs,

--- a/internal/mycli/statements_explain_describe_test.go
+++ b/internal/mycli/statements_explain_describe_test.go
@@ -857,8 +857,8 @@ func TestExplainLastQueryStatement_Execute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.statement.Execute(context.Background(), &Session{systemVariables: &systemVariables{
-				Display:  DisplayVars{ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns},
-				Internal: InternalVars{LastQueryCache: tt.lastQueryCache},
+				Display:    DisplayVars{ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns},
+				LastResult: LastResult{QueryCache: tt.lastQueryCache},
 			}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
@@ -910,8 +910,8 @@ execution_stats:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.statement.Execute(context.Background(), &Session{systemVariables: &systemVariables{
-				Display:  DisplayVars{ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns},
-				Internal: InternalVars{LastQueryCache: tt.lastQueryCache},
+				Display:    DisplayVars{ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns},
+				LastResult: LastResult{QueryCache: tt.lastQueryCache},
 			}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -49,9 +49,9 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 	merged := session.systemVariables.ListVariables()
 
 	// Special handling for COMMIT_RESPONSE
-	if session.systemVariables.Transaction.CommitResponse != nil {
-		merged["COMMIT_TIMESTAMP"] = formatTimestamp(session.systemVariables.Transaction.CommitTimestamp, "NULL")
-		merged["MUTATION_COUNT"] = strconv.FormatInt(session.systemVariables.Transaction.CommitResponse.GetCommitStats().GetMutationCount(), 10)
+	if session.systemVariables.LastResult.CommitResponse != nil {
+		merged["COMMIT_TIMESTAMP"] = formatTimestamp(session.systemVariables.LastResult.CommitTimestamp, "NULL")
+		merged["MUTATION_COUNT"] = strconv.FormatInt(session.systemVariables.LastResult.CommitResponse.GetCommitStats().GetMutationCount(), 10)
 	}
 
 	// Special handling for CLI_DIRECT_READ

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -47,12 +47,14 @@ type LastQueryCache struct {
 	CommitTimestamp time.Time
 }
 
-// ConnectionVars holds connection-related configuration.
-type ConnectionVars struct {
-	Project                   string // CLI_PROJECT
-	Instance                  string // CLI_INSTANCE
-	Database                  string // CLI_DATABASE
-	Role                      string // CLI_ROLE
+// StartupConfig holds configuration that is immutable after startup.
+// It is populated by parseFlags/createSystemVariablesFromOptions (and, for the
+// embedded runtime, by setup code in app.go before any session is created) and
+// must never be written afterwards: every corresponding system variable is
+// registered read-only, and USE/DETACH do not touch it.
+// Exception: EnableADCPlus is session-init-only; its custom setter rejects
+// writes once a session exists (see var_registry.go).
+type StartupConfig struct {
 	Host                      string // CLI_HOST
 	Port                      int    // CLI_PORT
 	Insecure                  bool   // CLI_INSECURE
@@ -60,6 +62,35 @@ type ConnectionVars struct {
 	ImpersonateServiceAccount string // CLI_IMPERSONATE_SERVICE_ACCOUNT
 	EnableADCPlus             bool   // CLI_ENABLE_ADC_PLUS
 	EmulatorPlatform          string // CLI_EMULATOR_PLATFORM
+	LogGrpc                   bool   // CLI_LOG_GRPC
+	MCP                       bool   // CLI_MCP
+	SkipSystemCommand         bool   // CLI_SKIP_SYSTEM_COMMAND
+
+	// Embedded runtime overrides used by tests and the embedded emulator.
+	EmbeddedClientOptions []option.ClientOption
+	EmbeddedClientConfig  *spanner.ClientConfig
+}
+
+// ConnectionVars holds the connection identity. Project and Instance are fixed
+// at startup; Database and Role are mutated in place only by USE/DETACH
+// (SessionHandler.switchSession).
+type ConnectionVars struct {
+	Project  string // CLI_PROJECT
+	Instance string // CLI_INSTANCE
+	Database string // CLI_DATABASE
+	Role     string // CLI_ROLE
+}
+
+// LastResult holds outputs of the most recently executed statement or
+// transaction. It is written by statement execution and read back through
+// read-only system variables (READ_TIMESTAMP, COMMIT_TIMESTAMP,
+// COMMIT_RESPONSE) and last-query features such as CLI_INLINE_STATS.
+// Unlike the *Vars groups, nothing here is user-settable.
+type LastResult struct {
+	ReadTimestamp   time.Time            // READ_TIMESTAMP
+	CommitTimestamp time.Time            // COMMIT_TIMESTAMP
+	CommitResponse  *sppb.CommitResponse // COMMIT_RESPONSE
+	QueryCache      *LastQueryCache
 }
 
 // DisplayVars holds display and output formatting configuration.
@@ -103,7 +134,6 @@ type QueryVars struct {
 	StatementTimeout           *time.Duration                    // STATEMENT_TIMEOUT
 	RPCPriority                sppb.RequestOptions_Priority      // RPC_PRIORITY
 	ReadOnlyStaleness          *spanner.TimestampBound           // READ_ONLY_STALENESS
-	ReadTimestamp              time.Time                         // READ_TIMESTAMP
 	OptimizerVersion           string                            // OPTIMIZER_VERSION
 	OptimizerStatisticsPackage string                            // OPTIMIZER_STATISTICS_PACKAGE
 	AutoPartitionMode          bool                              // AUTO_PARTITION_MODE
@@ -129,8 +159,6 @@ type TransactionVars struct {
 	AutoBatchDML                bool                                           // AUTO_BATCH_DML
 	AutocommitDMLMode           enums.AutocommitDMLMode                        // AUTOCOMMIT_DML_MODE
 	ReturnCommitStats           bool                                           // RETURN_COMMIT_STATS
-	CommitResponse              *sppb.CommitResponse                           // COMMIT_RESPONSE
-	CommitTimestamp             time.Time                                      // COMMIT_TIMESTAMP
 	DefaultIsolationLevel       sppb.TransactionOptions_IsolationLevel         // DEFAULT_ISOLATION_LEVEL
 	ReadLockMode                sppb.TransactionOptions_ReadWrite_ReadLockMode // READ_LOCK_MODE
 
@@ -150,28 +178,33 @@ type FeatureVars struct {
 	EchoExecutedDDL        bool                       // CLI_ECHO_EXECUTED_DDL
 	EchoInput              bool                       // CLI_ECHO_INPUT
 	AsyncDDL               bool                       // CLI_ASYNC_DDL
-	SkipSystemCommand      bool                       // CLI_SKIP_SYSTEM_COMMAND
 	AutoConnectAfterCreate bool                       // CLI_AUTO_CONNECT_AFTER_CREATE
-	LogGrpc                bool                       // CLI_LOG_GRPC
 	LogLevel               slog.Level                 // CLI_LOG_LEVEL
 	DatabaseDialect        databasepb.DatabaseDialect // CLI_DATABASE_DIALECT
 }
 
 // InternalVars holds internal state not directly exposed as system variables.
 type InternalVars struct {
-	ProtoDescriptorFile   []string // CLI_PROTO_DESCRIPTOR_FILE
-	ProtoDescriptor       *descriptorpb.FileDescriptorSet
-	LastQueryCache        *LastQueryCache
-	EmbeddedClientOptions []option.ClientOption
-	EmbeddedClientConfig  *spanner.ClientConfig
+	ProtoDescriptorFile []string // CLI_PROTO_DESCRIPTOR_FILE
+	ProtoDescriptor     *descriptorpb.FileDescriptorSet
 }
 
-// systemVariables holds configuration state for spanner-mycli sessions.
-// IMPORTANT: This struct is designed to be read-only after creation for session safety.
-// SessionHandler depends on this read-only property when creating new sessions with
-// modified copies of systemVariables (e.g., for USE/DETACH operations).
+// systemVariables holds the session state of spanner-mycli, layered by
+// ownership and mutability:
+//
+//   - Config: immutable after startup (see StartupConfig)
+//   - Connection: connection identity; Database/Role mutated only by USE/DETACH
+//   - LastResult: per-statement outputs, written by statement execution
+//   - Display/Query/Transaction/Feature/Internal: the SET-able surface,
+//     mutated through the Registry (and transaction-scoped via SET LOCAL)
+//
+// There is exactly one live instance per process: the Registry captures
+// pointers into this struct, so it must never be copied (USE/DETACH mutate it
+// in place; see SessionHandler.switchSession).
 type systemVariables struct {
+	Config      StartupConfig
 	Connection  ConnectionVars
+	LastResult  LastResult
 	Display     DisplayVars
 	Query       QueryVars
 	Transaction TransactionVars
@@ -288,7 +321,7 @@ func (sv *systemVariables) ProjectPath() string {
 // This function ensures consistency between initialization and test expectations.
 func newSystemVariablesWithDefaults() systemVariables {
 	sv := systemVariables{
-		Connection: ConnectionVars{
+		Config: StartupConfig{
 			EnableADCPlus: true,
 		},
 		Display: DisplayVars{

--- a/internal/mycli/system_variables_registry.go
+++ b/internal/mycli/system_variables_registry.go
@@ -140,12 +140,12 @@ func (sv *systemVariables) get(name string) (map[string]string, error) {
 	// This behavior is maintained for java-spanner compatibility where SHOW VARIABLE
 	// COMMIT_RESPONSE returns both values as a result set.
 	if upperName == "COMMIT_RESPONSE" {
-		if sv.Transaction.CommitResponse == nil {
+		if sv.LastResult.CommitResponse == nil {
 			return nil, errIgnored
 		}
 		return map[string]string{
-			"COMMIT_TIMESTAMP": formatTimestamp(sv.Transaction.CommitTimestamp, "NULL"),
-			"MUTATION_COUNT":   strconv.FormatInt(sv.Transaction.CommitResponse.GetCommitStats().GetMutationCount(), 10),
+			"COMMIT_TIMESTAMP": formatTimestamp(sv.LastResult.CommitTimestamp, "NULL"),
+			"MUTATION_COUNT":   strconv.FormatInt(sv.LastResult.CommitResponse.GetCommitStats().GetMutationCount(), 10),
 		}, nil
 	}
 

--- a/internal/mycli/system_variables_test.go
+++ b/internal/mycli/system_variables_test.go
@@ -159,17 +159,17 @@ func newTestSysVars() *sysVarsBuilder {
 }
 
 func (b *sysVarsBuilder) withReadTimestamp(t time.Time) *sysVarsBuilder {
-	b.sv.Query.ReadTimestamp = t
+	b.sv.LastResult.ReadTimestamp = t
 	return b
 }
 
 func (b *sysVarsBuilder) withCommitTimestamp(t time.Time) *sysVarsBuilder {
-	b.sv.Transaction.CommitTimestamp = t
+	b.sv.LastResult.CommitTimestamp = t
 	return b
 }
 
 func (b *sysVarsBuilder) withCommitResponse(r *sppb.CommitResponse) *sysVarsBuilder {
-	b.sv.Transaction.CommitResponse = r
+	b.sv.LastResult.CommitResponse = r
 	return b
 }
 
@@ -190,15 +190,15 @@ func (b *sysVarsBuilder) withHistoryFile(f string) *sysVarsBuilder {
 	return b
 }
 
-func (b *sysVarsBuilder) withHost(h string) *sysVarsBuilder   { b.sv.Connection.Host = h; return b }
-func (b *sysVarsBuilder) withPort(p int) *sysVarsBuilder      { b.sv.Connection.Port = p; return b }
+func (b *sysVarsBuilder) withHost(h string) *sysVarsBuilder   { b.sv.Config.Host = h; return b }
+func (b *sysVarsBuilder) withPort(p int) *sysVarsBuilder      { b.sv.Config.Port = p; return b }
 func (b *sysVarsBuilder) withRole(r string) *sysVarsBuilder   { b.sv.Connection.Role = r; return b }
-func (b *sysVarsBuilder) withInsecure(i bool) *sysVarsBuilder { b.sv.Connection.Insecure = i; return b }
-func (b *sysVarsBuilder) withLogGrpc(l bool) *sysVarsBuilder  { b.sv.Feature.LogGrpc = l; return b }
-func (b *sysVarsBuilder) withMCP(m bool) *sysVarsBuilder      { b.sv.Feature.MCP = m; return b }
+func (b *sysVarsBuilder) withInsecure(i bool) *sysVarsBuilder { b.sv.Config.Insecure = i; return b }
+func (b *sysVarsBuilder) withLogGrpc(l bool) *sysVarsBuilder  { b.sv.Config.LogGrpc = l; return b }
+func (b *sysVarsBuilder) withMCP(m bool) *sysVarsBuilder      { b.sv.Config.MCP = m; return b }
 
 func (b *sysVarsBuilder) withImpersonateServiceAccount(a string) *sysVarsBuilder {
-	b.sv.Connection.ImpersonateServiceAccount = a
+	b.sv.Config.ImpersonateServiceAccount = a
 	return b
 }
 
@@ -476,40 +476,13 @@ func TestSystemVariables_ProtoDescriptorFiles(t *testing.T) {
 func TestSystemVariables_StringTypes(t *testing.T) {
 	t.Parallel()
 
-	t.Run("CLI_ENDPOINT_Setter", func(t *testing.T) {
+	// CLI_ENDPOINT is read-only (part of the immutable startup config);
+	// endpoint string parsing for the --endpoint flag is covered by TestParseEndpoint.
+	t.Run("CLI_ENDPOINT_ReadOnly", func(t *testing.T) {
 		t.Parallel()
-		tests := []struct {
-			desc        string
-			value       string
-			wantHost    string
-			wantPort    int
-			errContains string
-		}{
-			{desc: "valid endpoint", value: "example.com:443", wantHost: "example.com", wantPort: 443},
-			{desc: "endpoint with IPv6", value: "[2001:db8::1]:443", wantHost: "2001:db8::1", wantPort: 443},
-			{desc: "invalid endpoint - no port", value: "example.com", errContains: "invalid endpoint format"},
-			{desc: "empty endpoint clears host and port", value: "", wantHost: "", wantPort: 0},
-			{desc: "invalid endpoint - bare IPv6 without port", value: "2001:db8::1", errContains: "invalid endpoint format"},
-			{desc: "invalid endpoint - non-numeric port", value: "example.com:abc", errContains: "invalid port in endpoint"},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.desc, func(t *testing.T) {
-				t.Parallel()
-				sysVars := newSystemVariablesWithDefaultsForTest()
-				err := sysVars.SetFromSimple("CLI_ENDPOINT", tt.value)
-				assertError(t, err, tt.errContains)
-				if err != nil {
-					return
-				}
-				if sysVars.Connection.Host != tt.wantHost {
-					t.Errorf("Host = %q, want %q", sysVars.Connection.Host, tt.wantHost)
-				}
-				if sysVars.Connection.Port != tt.wantPort {
-					t.Errorf("Port = %d, want %d", sysVars.Connection.Port, tt.wantPort)
-				}
-			})
-		}
+		sysVars := newSystemVariablesWithDefaultsForTest()
+		err := sysVars.SetFromSimple("CLI_ENDPOINT", "example.com:443")
+		assertError(t, err, "read-only")
 	})
 
 	t.Run("StatementTimeout", func(t *testing.T) {
@@ -1013,15 +986,7 @@ func TestSystemVariables_SetGetOperations(t *testing.T) {
 			})
 		}
 
-		// CLI_ENDPOINT special cases
-		t.Run("CLI_ENDPOINT_setter", func(t *testing.T) {
-			t.Parallel()
-			testStringVariable(t, setFunc, "CLI_ENDPOINT", "example.com:443")
-		})
-		t.Run("CLI_ENDPOINT_setter_IPv6", func(t *testing.T) {
-			t.Parallel()
-			testStringVariable(t, setFunc, "CLI_ENDPOINT", "[2001:db8::1]:443")
-		})
+		// CLI_ENDPOINT special cases (read-only; only the getter is exercised)
 		t.Run("CLI_ENDPOINT_getter", func(t *testing.T) {
 			t.Parallel()
 			sysVars := newTestSysVars().withHost("localhost").withPort(9010).build()

--- a/internal/mycli/var_custom_handlers.go
+++ b/internal/mycli/var_custom_handlers.go
@@ -151,7 +151,10 @@ func (p *ProtoDescriptorVar) IsReadOnly() bool {
 	return false
 }
 
-// EndpointVar handles CLI_ENDPOINT (host:port)
+// EndpointVar handles CLI_ENDPOINT (host:port).
+// Read-only, like CLI_HOST and CLI_PORT which it is derived from: the
+// endpoint is part of the immutable StartupConfig, and changing it after
+// startup would not reconnect the live session.
 type EndpointVar struct {
 	hostPtr     *string
 	portPtr     *int
@@ -166,19 +169,7 @@ func (e *EndpointVar) Get() (string, error) {
 }
 
 func (e *EndpointVar) Set(value string) error {
-	if value == "" {
-		*e.hostPtr = ""
-		*e.portPtr = 0
-		return nil
-	}
-
-	host, port, err := parseEndpoint(value)
-	if err != nil {
-		return err
-	}
-	*e.hostPtr = host
-	*e.portPtr = port
-	return nil
+	return errSetterReadOnly
 }
 
 func (e *EndpointVar) Description() string {
@@ -186,7 +177,7 @@ func (e *EndpointVar) Description() string {
 }
 
 func (e *EndpointVar) IsReadOnly() bool {
-	return false
+	return true
 }
 
 // parseOutputTemplate parses output template file

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -207,8 +207,11 @@ func (r *VarRegistry) registerAll() {
 		"A boolean indicating whether to display progress bars during operations. The default is false."))
 	r.Register("CLI_ASYNC_DDL", BoolVar(&sv.Feature.AsyncDDL,
 		"A boolean indicating whether DDL statements should be executed asynchronously. The default is false."))
-	r.Register("CLI_SKIP_SYSTEM_COMMAND", BoolVar(&sv.Feature.SkipSystemCommand,
-		"Controls whether system commands are disabled."))
+	// Read-only: this is a security feature (--skip-system-command /
+	// --system-command=OFF); if it were settable, a user in a restricted
+	// environment could re-enable shell access with a single SET.
+	r.Register("CLI_SKIP_SYSTEM_COMMAND", BoolVar(&sv.Config.SkipSystemCommand,
+		"A read-only boolean indicating whether system commands are disabled. Set by --skip-system-command or --system-command=OFF.").AsReadOnly())
 	r.Register("CLI_TAB_VISUALIZE", BoolVar(&sv.Display.TabVisualize, "Visualize tab characters with arrow symbol in table output."))
 	r.Register("CLI_SKIP_COLUMN_NAMES", BoolVar(&sv.Display.SkipColumnNames,
 		"A boolean indicating whether to suppress column headers in output. The default is false."))
@@ -253,9 +256,9 @@ func (r *VarRegistry) registerAll() {
 	r.Register("CLI_VERTEXAI_MODEL", StringVar(&sv.Feature.VertexAIModel, "Vertex AI model for natural language features."))
 	r.Register("CLI_VERTEXAI_LOCATION", StringVar(&sv.Feature.VertexAILocation, "Vertex AI location for natural language features."))
 	r.Register("CLI_ROLE", StringVar(&sv.Connection.Role, "Cloud Spanner database role.").AsReadOnly())
-	r.Register("CLI_HOST", StringVar(&sv.Connection.Host, "Host on which Spanner server is located").AsReadOnly())
-	r.Register("CLI_EMULATOR_PLATFORM", StringVar(&sv.Connection.EmulatorPlatform, "Container platform used by embedded emulator.").AsReadOnly())
-	r.Register("CLI_IMPERSONATE_SERVICE_ACCOUNT", StringVar(&sv.Connection.ImpersonateServiceAccount, "Service account to impersonate.").AsReadOnly())
+	r.Register("CLI_HOST", StringVar(&sv.Config.Host, "Host on which Spanner server is located").AsReadOnly())
+	r.Register("CLI_EMULATOR_PLATFORM", StringVar(&sv.Config.EmulatorPlatform, "Container platform used by embedded emulator.").AsReadOnly())
+	r.Register("CLI_IMPERSONATE_SERVICE_ACCOUNT", StringVar(&sv.Config.ImpersonateServiceAccount, "Service account to impersonate.").AsReadOnly())
 
 	// === Integer variables (10+) ===
 	r.Register("MAX_PARTITIONED_PARALLELISM", IntVar(&sv.Query.MaxPartitionedParallelism,
@@ -272,7 +275,7 @@ func (r *VarRegistry) registerAll() {
 	r.Register("CLI_SUPPRESS_RESULT_LINES", BoolVar(&sv.Display.SuppressResultLines,
 		"Suppress result lines like 'rows in set' for clean output. Useful for scripting and dump operations."))
 	r.Register("CLI_PORT", &IntGetterVar{
-		getter:      func() int64 { return int64(sv.Connection.Port) },
+		getter:      func() int64 { return int64(sv.Config.Port) },
 		description: "Port number for connections.",
 	})
 
@@ -373,11 +376,11 @@ func (r *VarRegistry) registerAll() {
 		return "NULL"
 	}, "Current terminal width. Returns NULL if not connected to a terminal."))
 	r.Register("READ_TIMESTAMP", &TimestampVar{
-		ptr:         &sv.Query.ReadTimestamp,
+		ptr:         &sv.LastResult.ReadTimestamp,
 		description: "The read timestamp of the most recent read-only transaction.",
 	})
 	r.Register("COMMIT_TIMESTAMP", &TimestampVar{
-		ptr:         &sv.Transaction.CommitTimestamp,
+		ptr:         &sv.LastResult.CommitTimestamp,
 		description: "The commit timestamp of the last read-write transaction that Spanner committed.",
 	})
 
@@ -420,8 +423,8 @@ func (r *VarRegistry) registerAll() {
 	})
 
 	r.Register("CLI_ENDPOINT", &EndpointVar{
-		hostPtr:     &sv.Connection.Host,
-		portPtr:     &sv.Connection.Port,
+		hostPtr:     &sv.Config.Host,
+		portPtr:     &sv.Config.Port,
 		description: "Host and port for connections (host:port format).",
 	})
 
@@ -481,7 +484,7 @@ func (r *VarRegistry) registerAll() {
 	// to detect whether a session has been created. Could use native support
 	// for session-init-only behavior if added to VarHandler (see TODO in var_handler.go).
 	r.Register("CLI_ENABLE_ADC_PLUS", &CustomVar{
-		base: BoolVar(&sv.Connection.EnableADCPlus, "A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true."),
+		base: BoolVar(&sv.Config.EnableADCPlus, "A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true."),
 		customSetter: func(value string) error {
 			if sv.inTransaction != nil {
 				return fmt.Errorf("CLI_ENABLE_ADC_PLUS cannot be changed after session creation")
@@ -490,14 +493,14 @@ func (r *VarRegistry) registerAll() {
 			if err != nil {
 				return err
 			}
-			sv.Connection.EnableADCPlus = b
+			sv.Config.EnableADCPlus = b
 			return nil
 		},
 	})
 
-	r.Register("CLI_MCP", BoolVar(&sv.Feature.MCP, "A read-only boolean indicating whether the connection is running as an MCP server.").AsReadOnly())
-	r.Register("CLI_INSECURE", BoolVar(&sv.Connection.Insecure, "Skip TLS certificate verification (insecure).").AsReadOnly())
-	r.Register("CLI_LOG_GRPC", BoolVar(&sv.Feature.LogGrpc, "Enable gRPC logging.").AsReadOnly())
+	r.Register("CLI_MCP", BoolVar(&sv.Config.MCP, "A read-only boolean indicating whether the connection is running as an MCP server.").AsReadOnly())
+	r.Register("CLI_INSECURE", BoolVar(&sv.Config.Insecure, "Skip TLS certificate verification (insecure).").AsReadOnly())
+	r.Register("CLI_LOG_GRPC", BoolVar(&sv.Config.LogGrpc, "Enable gRPC logging.").AsReadOnly())
 
 	// === Unimplemented variables ===
 	r.Register("AUTOCOMMIT", &UnimplementedVar{


### PR DESCRIPTION
## Summary

Decomposes `systemVariables` into ownership-layered state groups, completing the state-model restructuring started in #691 (single-owner instance). Each field group now has an explicit owner and mutability contract, enforced by the registry.

## New layout

```
systemVariables
├── Config      StartupConfig   -- immutable after startup; all vars read-only
├── Connection  ConnectionVars  -- identity: Project/Instance/Database/Role;
│                                  Database/Role mutated only by USE/DETACH
├── LastResult  LastResult      -- per-statement outputs; not user-settable
├── Display/Query/Transaction/Feature/Internal  -- the SET-able surface
├── Params, StreamManager, Registry, ...        -- unchanged
```

- **StartupConfig** (new): Host, Port, Insecure, WithoutAuthentication, ImpersonateServiceAccount, EnableADCPlus, EmulatorPlatform, LogGrpc, MCP, SkipSystemCommand, and the embedded-runtime client overrides. Populated only by flag parsing and embedded-runtime setup, before any session exists. (EnableADCPlus keeps its session-init-only custom setter semantics.)
- **LastResult** (new): READ_TIMESTAMP / COMMIT_TIMESTAMP / COMMIT_RESPONSE / last-query cache, previously scattered across QueryVars, TransactionVars, and InternalVars. Written by statement execution, read back via read-only variables and CLI_INLINE_STATS.
- **ConnectionVars** shrinks to the four identity fields; **InternalVars** shrinks to proto descriptor state (still SET-able via `CLI_PROTO_DESCRIPTOR_FILE`).
- The stale "read-only after creation" struct comment (written for the pre-#691 copy-on-USE design) is replaced with the actual single-instance contract.

## Behavior changes

The immutability contract surfaces two fixes:

- **`CLI_SKIP_SYSTEM_COMMAND` is now read-only**, as docs/system_variables.md has always documented. Previously, in a restricted environment launched with `--skip-system-command`, a user could re-enable shell command execution (`\!`) with `SET CLI_SKIP_SYSTEM_COMMAND = FALSE`, defeating the documented security property.
- **`CLI_ENDPOINT` is now read-only**, matching `CLI_HOST`/`CLI_PORT` (which it writes) and matching its own row in the README table. Previously `SET CLI_ENDPOINT` silently mutated connection state without reconnecting the live session.
- README table correction: `CLI_INSECURE` was listed READ_WRITE but has always been read-only in code.

`--endpoint`, `--host`, `--port`, `--insecure`, `--skip-system-command`, and `--system-command=OFF` flag handling is unchanged (these fields were already assigned directly in config.go, not through the registry).

## Testing

- New `TestStartupConfigVariablesAreReadOnly` asserts every StartupConfig-backed variable rejects SET - this is the regression test for the `CLI_SKIP_SYSTEM_COMMAND` security fix.
- New `TestParseEndpoint` preserves the endpoint-parsing coverage that previously lived in the CLI_ENDPOINT setter tests.
- Existing CLI_ENDPOINT setter tests rewritten to assert read-only behavior.
- `make check` passes (full suite incl. emulator, lint, fmt-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ft2Q1ULY16tKgfW8xDT9f
