### PR TITLE
docs: fix dev-flow drift found while shipping two feature PRs

### DIFF
--- a/.claude/commands/merge-issue-pr.md
+++ b/.claude/commands/merge-issue-pr.md
@@ -5,18 +5,20 @@ description: Complete PR workflow for an issue including squash merge and cleanu
 
 ## Context
 
-You are completing the PR workflow for issue #$ARGUMENTS in the spanner-mycli repository.
+You are completing the PR workflow for #$ARGUMENTS in the spanner-mycli repository.
+`#$ARGUMENTS` may be either an issue number or a PR number — check which one it is first.
 
 ## Your task
 
-1. Find the PR associated with issue #$ARGUMENTS
+1. Identify the PR: if #$ARGUMENTS is a PR, use it directly; if it is an issue, find the PR associated with it
 2. Wait for reviews and checks to complete using `go tool gh-helper reviews wait <PR>`
 3. Squash merge the PR with a descriptive commit message that includes:
    - Clear summary of changes
-   - Reference to the issue being fixed
+   - Reference to the issue being fixed (if any)
 4. Clean up the phantom worktree for this issue if it exists
 
 Important notes:
 - `/gemini summary` is posted automatically on PR creation. Do not request it manually during merge.
+- **Gemini sunset (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17**. If `reviews wait` times out with checks green because no review will arrive, proceed on green checks — they are the merge gate until the replacement flow in #693 is decided.
 - Use the squash merge method as enforced by the repository ruleset
 - Include a meaningful commit message that describes the changes made in the PR

--- a/.claude/commands/review-cycle.md
+++ b/.claude/commands/review-cycle.md
@@ -15,6 +15,8 @@ Please execute the following steps:
 - `/gemini review` triggers an **inline code review** — this is also automatic but may take several minutes for large PRs.
 - If the wait times out without a review, **wait longer or request `/gemini review`** (NOT `/gemini summary`).
 
+**Gemini sunset (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17**. On or after that date (or whenever reviews stop arriving), skip the retry advice above: do not re-request `/gemini review` or extend the wait. Verify CI checks pass and continue; checks are the merge gate until the replacement flow in #693 is decided.
+
 2. Check for unresolved threads:
 !go tool gh-helper reviews fetch --unresolved-only
 

--- a/.claude/commands/review-respond.md
+++ b/.claude/commands/review-respond.md
@@ -55,3 +55,5 @@ Note: Even threads marked as "outdated" should be replied to and resolved, as th
 
 3. After all threads are resolved, request a new review:
 !go tool gh-helper reviews wait --request-review
+
+**Gemini sunset (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17**. On or after that date (or whenever reviews stop arriving), skip step 3 — a re-requested review will never come. Verify CI checks pass instead; checks are the merge gate until the replacement flow in #693 is decided.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ credentials.json
 .agents/
 .claude/*
 !.claude/settings.json
+!.claude/commands
 .codex/
 
 # Cache and temporary files - safe to delete anywhere

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ spanner-mycli is a personal fork of spanner-cli, an interactive CLI for Google C
 2. **Resolve conflicts with origin/main** - ensure branch can merge cleanly
 3. **Never push/commit directly to main branch** - always use feature branches + PRs
 4. **Squash merge only** - enforced via Repository Ruleset
-5. **PR merge process**: Use `go tool gh-helper reviews wait` before merging. Gemini review and summary are auto-triggered on PR creation — do NOT use `--request-review` or `--request-summary` at that point. After additional commits: use `--request-review` to get a new Gemini review. Use `--request-summary` only right before merge to update the summary. Do not request Copilot reviews for this repository.
+5. **PR merge process**: Use `go tool gh-helper reviews wait` before merging. Gemini review and summary are auto-triggered on PR creation — do NOT use `--request-review` or `--request-summary` at that point. After additional commits: use `--request-review` to get a new Gemini review. Use `--request-summary` only right before merge, and only if the PR changed substantially after creation. Do not request Copilot reviews for this repository.
+   - **Gemini sunset (#693)**: consumer Gemini Code Assist code review ceases on 2026-07-17. If no Gemini review arrives (timeout, or after that date), do NOT keep re-requesting or waiting; CI checks (item 8) are the merge gate. Replacement flow is tracked in issue #693.
 6. **Squash merge commits**: MUST include descriptive summary of PR changes
 7. **GitHub comment editing**: NEVER use `gh pr comment --edit-last` - always specify exact comment ID
 8. **GitHub checks must pass**: All CI checks MUST pass before merging. Always investigate failures - never assume they are transient.
@@ -74,7 +75,7 @@ For full gh-helper command reference, see [dev-docs/issue-management.md](dev-doc
 
 ### System Variable Conventions
 - CLI-specific variables **MUST** use `CLI_` prefix
-- All registrations in `internal/mycli/system_variables_registry.go`
+- All registrations in `internal/mycli/var_registry.go` (`registerAll`)
 - Details: [dev-docs/patterns/system-variables.md](dev-docs/patterns/system-variables.md)
 
 ### Regex Pattern Guidelines

--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -1,270 +1,142 @@
 # System Variable Implementation Patterns
 
-This document provides detailed patterns and best practices for implementing system variables in spanner-mycli.
+This document describes how to add and modify system variables in spanner-mycli,
+matching the actual code as of the StartupConfig/LastResult decomposition
+(PR #692) and SET LOCAL support (PR #400 / PR #691).
 
-## Design Patterns (Issue #243 Insights)
+## State model
 
-**Discovery**: Consistent patterns for system variable implementation improve maintainability and user experience
+`systemVariables` (internal/mycli/system_variables.go) is layered by ownership
+and mutability:
 
-### Basic Implementation Pattern
+| Group | Type | Mutability | Examples |
+|-------|------|------------|----------|
+| `Config` | `StartupConfig` | Immutable after startup; every backing variable is registered read-only | `CLI_HOST`, `CLI_INSECURE`, `CLI_SKIP_SYSTEM_COMMAND` |
+| `Connection` | `ConnectionVars` | Identity; `Database`/`Role` mutated only by USE/DETACH | `CLI_DATABASE`, `CLI_ROLE` |
+| `LastResult` | `LastResult` | Written by statement execution; never user-settable | `READ_TIMESTAMP`, `COMMIT_RESPONSE` |
+| `Display`/`Query`/`Transaction`/`Feature`/`Internal` | `*Vars` | The SET-able surface (also scoped by SET LOCAL) | `CLI_FORMAT`, `STATEMENT_TIMEOUT` |
 
-1. **Naming Convention**: CLI-specific variables **MUST** use `CLI_` prefix to distinguish from java-spanner JDBC properties
+**Single-instance contract**: there is exactly one live `systemVariables` per
+process. The registry (`VarRegistry`) captures raw pointers into it, so the
+struct must never be copied. USE/DETACH mutate it in place
+(`SessionHandler.switchSession`).
 
-2. **Access Control Design**:
-   - **Presentation layer variables** (display, formatting): Use standard VarHandler with read/write access
-   - **Session behavior variables** (authentication, connection settings): Use read-only VarHandler to prevent runtime session state changes
+## Adding a variable
 
-3. **Implementation Template**:
-   ```go
-   // In internal/mycli/system_variables_registry.go
-   
-   // Read/write variable (boolean)
-   r.Register("CLI_VARIABLE_NAME", 
-       BoolVar(&sv.FieldName).
-           WithDescription("Clear description of purpose and default value"))
-   
-   // Read/write variable (string)
-   r.Register("CLI_STRING_VARIABLE",
-       StringVar(&sv.FieldName).
-           WithDescription("Description of the variable"))
-   
-   // Read-only variable
-   r.Register("CLI_READ_ONLY_VARIABLE",
-       NewReadOnlyVar(
-           func() (string, error) { return sv.FieldName, nil },
-           "Description explaining read-only nature"))
-   ```
+1. **Naming**: spanner-mycli-specific variables MUST use the `CLI_` prefix.
+   Names without the prefix are reserved for java-spanner JDBC-compatible
+   properties.
+2. **Pick the group by mutability**, not by topic:
+   - Fixed at startup -> `StartupConfig` field + read-only registration +
+     direct assignment in `createSystemVariablesFromOptions` (config.go).
+   - User-settable -> the matching `*Vars` group + writable registration.
+   - Produced by statement execution -> `LastResult` field + read-only
+     registration (or a getter-only handler).
+3. **Register** in `registerAll` in `internal/mycli/var_registry.go`
+   (NOT system_variables_registry.go, which holds the set/get plumbing).
+4. **Document**: the README system-variables table is hand-maintained; add a
+   row there. Add a section to docs/system_variables.md if the variable needs
+   more than one line of explanation.
+5. **Test**: see Testing below.
 
-4. **Testing Requirements**: Add comprehensive test cases to `internal/mycli/system_variables_test.go` covering both successful operations and proper error handling for unimplemented setters
+## Registration API (var_handler.go, var_enum_handlers.go, var_custom_handlers.go)
 
-5. **Documentation**: Include clear descriptions explaining purpose, default values, and any access restrictions
+Descriptions are constructor arguments; there is no `WithDescription`.
 
-### Architecture Guidelines
-
-- **Pattern**: Use generic VarHandler types (BoolVar, StringVar, IntVar, etc.) for type-safe variable handling
-- **Architecture**: Session behavior variables should be read-only to prevent runtime session state changes that could cause inconsistencies
-- **Error Handling**: The registry automatically handles type validation and returns appropriate errors
-- **Testing Strategy**: System variables test pattern in `internal/mycli/system_variables_test.go` covers both SET/GET operations and proper error handling
-- **Code Organization**: All variable registrations are centralized in `internal/mycli/system_variables_registry.go`
-
-### Session-Init-Only Variables
-
-Some variables can only be set before session creation because they control client initialization behavior that cannot be changed after the session is established.
-
-**Implementation Pattern**:
-1. Use a custom validator that checks if session exists
-2. Document in the Description that it must be set before session creation
-
-**Example**:
 ```go
-// In internal/mycli/system_variables_registry.go
-r.Register("CLI_ENABLE_ADC_PLUS",
-    BoolVar(&sv.EnableADCPlus).
-        WithValidator(func(v bool) error {
-            if sv.CurrentSession != nil {
-                return fmt.Errorf("CLI_ENABLE_ADC_PLUS cannot be changed after session creation")
-            }
-            return nil
-        }).
-        WithDescription("A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true."))
+// In registerAll (internal/mycli/var_registry.go):
+
+// Writable bool/string/int
+r.Register("CLI_VERBOSE", BoolVar(&sv.Display.Verbose, "Display verbose output."))
+
+// Read-only (StartupConfig-backed): same constructors + AsReadOnly()
+r.Register("CLI_INSECURE", BoolVar(&sv.Config.Insecure,
+	"Skip TLS certificate verification (insecure).").AsReadOnly())
+
+// Nullable types display and accept the literal NULL
+r.Register("MAX_COMMIT_DELAY", NullableDurationVar(&sv.Transaction.MaxCommitDelay, "..."))
+
+// Computed read-only value: getter is func() string (it cannot fail)
+r.Register("CLI_VERSION", NewReadOnlyVar(getVersion, "The version of spanner-mycli."))
+
+// Enums: enumer-generated types in enums/ with a small typed constructor
+r.Register("CLI_FORMAT", DisplayModeVar(&sv.Display.CLIFormat, "..."))
+
+// Validation hook
+r.Register("CLI_PROMPT2", StringVar(&sv.Display.Prompt2, "...").
+	WithValidator(func(s string) error { /* reject invalid values */ return nil }))
 ```
 
-**Behavior**:
-- Can be set via `--set` flag before session creation
-- After session creation, any attempt to set the value will return an error with a clear message
-- The registry handles case-insensitive variable names automatically
+### Session-init-only variables
 
-### Development Workflow
+Variables that control client initialization can be set via `--set` before the
+session exists but must reject later writes. The actual pattern is a
+`CustomVar` whose setter checks `sv.inTransaction` as a session-existence
+proxy (it is nil until the first session is created); see the
+`CLI_ENABLE_ADC_PLUS` registration in `registerAll` for the canonical example.
 
-- **Workflow**: phantom + tmux horizontal split works well for focused system variable implementation
-- **Manual Testing**: Use `--embedded-emulator` only when Go test suite is insufficient - prefer comprehensive test cases in existing test suite
+### Raw + parsed variables
 
-## Timeout Implementation Patterns (Issue #276 Insights)
+Variables like `CLI_TYPE_STYLES` and `CLI_ANALYZE_COLUMNS` store the raw
+string (shown by SHOW VARIABLE) plus a parsed artifact in a sibling field.
+Their custom setter must keep both in sync, and parse errors must reject the
+SET before any state changes.
 
-**Discovery**: Centralized timeout management and pointer type design for proper state handling
+## SET LOCAL compatibility
 
-### Pointer Type Design
+`SET LOCAL` (statements_system_variable.go) saves the current display value
+and restores it through the setter when the transaction ends. This imposes a
+contract on every writable variable:
 
-**Key Pattern**: Using `*time.Duration` for system variables enables distinction between unset (nil) vs zero timeout, critical for backward compatibility
+- **Get -> Set must round-trip**: the string returned by the getter must be
+  accepted by the setter (nullable handlers already accept `NULL`). SET LOCAL
+  verifies this with a pre-flight `Set(Get())` and rejects variables that
+  fail, so a non-round-tripping variable degrades gracefully - but fix the
+  round-trip if the variable should support SET LOCAL.
+- **Setter side effects re-run on restore**: parsing (templates, styles) is
+  re-executed when the saved value is set back. Setters must be idempotent
+  for the same value.
+- Read-only variables and setters that reject writes mid-transaction are
+  rejected by the pre-flight check automatically.
+
+## CLI flag mapping (config.go)
+
+- StartupConfig fields are assigned directly in
+  `createSystemVariablesFromOptions` (their variables are read-only, so the
+  registry path would reject them).
+- Settable variables map flags through `applyOptionMappings` /
+  `SetFromSimple`, which routes through the setter and its validation.
+  Prefer this over direct assignment so `--flag` and `SET` cannot diverge.
+
+## Testing
+
+Match the existing test style (std testing + go-cmp; no testify):
 
 ```go
-type systemVariables struct {
-    // Other fields...
-    StatementTimeout *time.Duration
+func TestMyVariable(t *testing.T) {
+	t.Parallel()
+	sysVars := newSystemVariablesWithDefaultsForTest() // registry-ready defaults
+	if err := sysVars.SetFromSimple("CLI_MY_VARIABLE", "value"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := sysVars.Registry.Get("CLI_MY_VARIABLE")
+	// assert on got/err
+	_ = got
+	_ = err
 }
 ```
 
-Benefits:
-- `nil` = unset (use default behavior)
-- `&time.Duration{0}` = explicitly set to zero (immediate timeout)
-- `&time.Duration{5*time.Minute}` = explicitly set timeout
-
-### Context Management Pattern
-
-**Centralized timeout application** in `Session.ExecuteStatement` prevents `defer cancel()` timing issues during resource cleanup:
-
-```go
-func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) error {
-    // Apply timeout at the session boundary, not in individual operations
-    if s.systemVariables.StatementTimeout != nil {
-        var cancel context.CancelFunc
-        ctx, cancel = context.WithTimeout(ctx, *s.systemVariables.StatementTimeout)
-        defer cancel()
-    }
-    
-    // Execute statement with timeout context
-    return s.executeStatementWithContext(ctx, stmt)
-}
-```
-
-### Early Validation Pattern
-
-**Pre-validate CLI flag values** before system variable assignment for better error reporting:
-
-```go
-if opts.Timeout != "" {
-    // Validate format first
-    _, err := time.ParseDuration(opts.Timeout)
-    if err != nil {
-        return systemVariables{}, fmt.Errorf("invalid value of --timeout: %v: %w", opts.Timeout, err)
-    }
-    
-    // Then set the system variable
-    if err := sysVars.SetFromSimple("STATEMENT_TIMEOUT", opts.Timeout); err != nil {
-        return systemVariables{}, fmt.Errorf("invalid value of --timeout: %v: %w", opts.Timeout, err)
-    }
-}
-```
-
-### Differentiated Defaults
-
-**Operation-specific defaults** when timeout is unspecified:
-
-```go
-func (s *Session) getEffectiveTimeout() time.Duration {
-    if s.systemVariables.StatementTimeout != nil {
-        return *s.systemVariables.StatementTimeout
-    }
-    
-    // Apply different defaults based on operation type
-    switch s.currentOperation {
-    case "partitioned_dml":
-        return 24 * time.Hour  // Existing PDML default
-    default:
-        return 10 * time.Minute  // New general default
-    }
-}
-```
-
-### Context Lifecycle Management
-
-**Context cancellation must align with resource lifecycle** - centralize timeout application at statement execution boundary, not at individual operation level:
-
-- ✅ Apply timeout at `Session.ExecuteStatement` level
-- ❌ Apply timeout at individual `client.Single().Query()` calls
-- ✅ Ensure `defer cancel()` happens after all resource cleanup
-- ❌ Cancel context before resource cleanup completes
-
-## Testing Patterns
-
-### System Variable Test Structure
-
-```go
-func TestSystemVariable_TIMEOUT(t *testing.T) {
-    tests := []struct {
-        name    string
-        value   string
-        wantErr bool
-        want    *time.Duration
-    }{
-        {"valid duration", "5m", false, durationPtr(5 * time.Minute)},
-        {"zero duration", "0", false, durationPtr(0)},
-        {"invalid format", "invalid", true, nil},
-        {"negative duration", "-5m", true, nil},
-    }
-    
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            vars := newSystemVariables()
-            err := vars.Set("STATEMENT_TIMEOUT", tt.value)
-            
-            if tt.wantErr {
-                assert.Error(t, err)
-                return
-            }
-            
-            assert.NoError(t, err)
-            assert.Equal(t, tt.want, vars.StatementTimeout)
-        })
-    }
-}
-```
-
-### Integration Test Considerations
-
-**Long-running integration tests** need explicit timeout configuration (1h) to prevent false failures during CI:
-
-```go
-func TestIntegration_LongRunningQuery(t *testing.T) {
-    if testing.Short() {
-        t.Skip("Skipping long-running integration test")
-    }
-    
-    // Set explicit timeout for integration tests
-    session.systemVariables.StatementTimeout = &time.Hour
-    
-    // Run test...
-}
-```
-
-## Async DDL System Variable Patterns (Issue #277)
-
-**Discovery**: System variable integration with operation control patterns
-
-### System Variable Integration with Operation Control
-
-**Pattern**: Use system variables to control DDL execution behavior without breaking existing workflows
-
-```go
-// In executeDdlStatements function
-if session.systemVariables.AsyncDDL {
-    return formatAsyncDdlResult(op)
-}
-// Continue with synchronous execution...
-```
-
-**Implementation Template**:
-```go
-// In internal/mycli/system_variables_registry.go
-r.Register("CLI_ASYNC_DDL",
-    BoolVar(&sv.AsyncDDL).
-        WithDescription("A boolean indicating whether DDL statements should be executed asynchronously. The default is false."))
-
-// CLI flag mapping in createSystemVariablesFromOptions
-sysVars.AsyncDDL = opts.Async
-```
-
-### CLI Flag Integration Best Practices
-
-**Location**: Process CLI flags in `createSystemVariablesFromOptions()` function
-
-**Pattern for Boolean Flags**:
-```go
-// Direct mapping approach
-sysVars.AsyncDDL = opts.Async
-```
-
-**Pattern for Complex Flags** (reference from timeout implementation):
-```go
-// Validation before system variable assignment
-if opts.ComplexFlag != "" {
-    if err := sysVars.SetFromSimple("CLI_COMPLEX_FLAG", opts.ComplexFlag); err != nil {
-        return systemVariables{}, fmt.Errorf("invalid value of --complex-flag: %v: %w", opts.ComplexFlag, err)
-    }
-}
-```
+- Read-only StartupConfig variables: add the name to
+  `TestStartupConfigVariablesAreReadOnly` (startup_config_test.go). This is
+  load-bearing for security-sensitive variables such as
+  `CLI_SKIP_SYSTEM_COMMAND`.
+- SET/GET coverage lives in system_variables_test.go; transaction-scoped
+  behavior examples are in statements_set_local_test.go (unit; runs with
+  `-short` because pending transactions need no RPCs) and
+  TestSetLocalStatements in integration_test.go (emulator).
 
 ## Related Documentation
 
 - [Development Insights](../development-insights.md) - General development patterns
 - [Architecture Guide](../architecture-guide.md) - Overall system architecture
+- [docs/system_variables.md](../../docs/system_variables.md) - User-facing reference

--- a/dev-docs/patterns/testing.md
+++ b/dev-docs/patterns/testing.md
@@ -1,5 +1,32 @@
 # Testing Best Practices
 
+## Test Tiers and Conventions
+
+The suite has two tiers, selected with the standard `-short` flag:
+
+- `go test -short ./...` - unit tests only; no Docker required; runs in a few
+  seconds. Integration tests self-skip via `testing.Short()`.
+- `make test` (`go test ./...`) - additionally runs integration tests against
+  a shared Cloud Spanner emulator (spanemuboost lazy runtime; the container
+  boots once per process and each test gets an isolated random database via
+  `initializeWithRandomDB`).
+
+Conventions:
+
+- Gate emulator-dependent tests with `testing.Short()` (usually via the
+  `runStatementTests` helper). Do NOT introduce new build tags for this:
+  tag-gated files (`//go:build integration`, `skip_slow_test`) are not built
+  by default and silently rot because nothing compiles them in CI.
+- For statement-level integration tests, prefer the `statementTestCase` /
+  `runStatementTests` table in integration_test.go with the `sr` / `srEmpty` /
+  `srKeep` / `srDML` result helpers. `compareResult` already ignores
+  `ReadTimestamp`, `CommitTimestamp`, `CommitStats`, `Stats`, and `Metrics`,
+  so expectations stay small.
+- Logic that can be exercised without RPCs should be a unit test even if the
+  feature is transactional: pending transactions (`BEGIN` before the first
+  statement) perform no RPCs, which is how statements_set_local_test.go tests
+  transaction-scoped variables under `-short`.
+
 ## Coverage Analysis
 
 - Use `go tool cover -func` for a quick, readable summary of function-level coverage


### PR DESCRIPTION
## Summary

Development-flow fixes drawn from the concrete experience of shipping #691 (SET LOCAL) and #692 (systemVariables decomposition) end-to-end with the documented workflow. Each change addresses friction actually hit during that work.

Refs #693 (Gemini sunset tracking issue).

## Changes

### 1. Gemini Code Assist sunset guidance (AGENTS.md, review-cycle / review-respond / merge-issue-pr commands)

Consumer Gemini Code Assist code review ceases on **2026-07-17**; the sunset banner already appears on every review in this repository (both #691 and #692 carried it). The documented flow waits for Gemini reviews (`reviews wait`), re-requests them after pushing fixes (`--request-review`), and suggests requesting `/gemini review` on timeout — all of which will block or no-op within two weeks.

Each affected document now carries a dated note: once reviews stop arriving, do not wait or re-request; **CI checks are the merge gate** until the replacement flow (#693) is decided.

This also reconciles a contradiction hit during the #691 merge: AGENTS.md said "use `--request-summary` right before merge" while merge-issue-pr said "do not request it manually during merge". The reconciled guidance: the summary is auto-posted on PR creation; refresh it before merge only if the PR changed substantially after creation.

### 2. dev-docs/patterns/system-variables.md: rewritten against the real API

Every code template in the old document failed to compile: `BoolVar(&sv.X).WithDescription(...)` (no such method — the description is a constructor argument), `NewReadOnlyVar(func() (string, error), ...)` (actual signature takes `func() string`), `sv.CurrentSession` (field does not exist), flat field names predating the sub-struct grouping, registration pointed at the wrong file, and testify-style tests in a package that does not use testify. Anyone following it — human or agent — would write code that does not build.

The rewrite documents what actually exists after #691/#692: the layered state model (StartupConfig / ConnectionVars / LastResult / SET-able groups) with its single-instance contract, the real registration API, the session-init-only pattern as implemented (`CustomVar` + `sv.inTransaction` check), the new SET LOCAL get/set round-trip contract that every writable variable must satisfy, flag-mapping rules (direct assignment for StartupConfig vs `SetFromSimple` for settable variables), and the actual test style.

### 3. dev-docs/patterns/testing.md: document the test tiers

The `-short` vs emulator convention was tribal knowledge; nothing documented it, which is how ~775 lines of `//go:build integration` tests silently rotted (they no longer compile and nothing builds them). New section documents: `testing.Short()` gating (explicitly not build tags), the `runStatementTests`/`statementTestCase` pattern with its global cmp ignores, and the pending-transaction trick that lets transactional logic be unit-tested without RPCs (used by the SET LOCAL tests).

### 4. Small fixes

- AGENTS.md: variable registrations live in `var_registry.go` (`registerAll`), not `system_variables_registry.go` (which holds the set/get plumbing).
- merge-issue-pr command: accept a PR number as well as an issue number (it already worked when given a PR number, but the text assumed an issue).
- .gitignore: add `!.claude/commands` exception. The command files are tracked, but the `.claude/*` ignore rule makes `git add` fail on them — friction hit while editing them for this very PR.

## Not included (noted for completeness)

- The rotted `//go:build integration` test files themselves and a CI tag-compile guard are a code/CI change, tracked as review findings, not a docs fix.
- `gh-helper reviews wait` behavior once no reviewer is installed belongs to apstndb/gh-dev-tools (mentioned in #693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ft2Q1ULY16tKgfW8xDT9f
