### PR TITLE
Fix READONLY guard bypass for batch DDL, RUN BATCH DML, and CREATE DATABASE

### DIFF
--- a/internal/mycli/readonly_guard_test.go
+++ b/internal/mycli/readonly_guard_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the MIT License.
+
+package mycli
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+// TestReadOnlyGuardCoversBatchStatements is the regression test for issue
+// #695: CreateDatabaseStatement, BulkDdlStatement, and BatchDMLStatement
+// declared an exported IsMutationStatement method instead of the unexported
+// marker, silently dropping them out of the MutationStatement interface and
+// bypassing the READONLY guard in Session.ExecuteStatement.
+func TestReadOnlyGuardCoversBatchStatements(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		desc string
+		stmt Statement
+	}{
+		{desc: "single DDL", stmt: &DdlStatement{Ddl: "CREATE TABLE t (id INT64) PRIMARY KEY (id)"}},
+		{desc: "batch DDL", stmt: &BulkDdlStatement{Ddls: []string{"CREATE TABLE t (id INT64) PRIMARY KEY (id)"}}},
+		{desc: "batch DML", stmt: &BatchDMLStatement{DMLs: []spanner.Statement{spanner.NewStatement("UPDATE t SET id = 1 WHERE TRUE")}}},
+		{desc: "CREATE DATABASE", stmt: &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d"}},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			session := newSessionForLocalVarTest(t)
+			session.systemVariables.Transaction.ReadOnly = true
+
+			_, err := session.ExecuteStatement(t.Context(), tt.stmt)
+			if !errors.Is(err, errReadOnly) {
+				t.Errorf("%s in READONLY mode: got error %v, want errReadOnly", tt.desc, err)
+			}
+		})
+	}
+}

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -46,6 +46,25 @@ type MutationStatement interface {
 	isMutationStatement()
 }
 
+// Compile-time assertions for every MutationStatement implementation.
+// The marker method is unexported, so a typo (e.g. an exported
+// IsMutationStatement) silently drops the type out of the interface and
+// bypasses the READONLY guard in Session.ExecuteStatement (issue #695).
+// Keep this list in sync when adding a mutation statement.
+var (
+	_ MutationStatement = (*MutateStatement)(nil)
+	_ MutationStatement = (*ExplainAnalyzeDmlStatement)(nil)
+	_ MutationStatement = (*BeginRwStatement)(nil)
+	_ MutationStatement = (*DmlStatement)(nil)
+	_ MutationStatement = (*DdlStatement)(nil)
+	_ MutationStatement = (*CreateDatabaseStatement)(nil)
+	_ MutationStatement = (*DropDatabaseStatement)(nil)
+	_ MutationStatement = (*TruncateTableStatement)(nil)
+	_ MutationStatement = (*PartitionedDmlStatement)(nil)
+	_ MutationStatement = (*BulkDdlStatement)(nil)
+	_ MutationStatement = (*BatchDMLStatement)(nil)
+)
+
 // DetachedCompatible is a marker interface for statements that can run in Detached session mode (admin operation only mode).
 // Statements implementing this interface can execute when session.IsDetached() is true.
 type DetachedCompatible interface {

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -128,7 +128,7 @@ func (s *CreateDatabaseStatement) String() string {
 	return s.CreateStatement
 }
 
-func (CreateDatabaseStatement) IsMutationStatement() {}
+func (CreateDatabaseStatement) isMutationStatement() {}
 
 func (s *CreateDatabaseStatement) isDetachedCompatible() {}
 
@@ -587,7 +587,7 @@ func (s *BulkDdlStatement) String() string {
 	return strings.Join(s.Ddls, ";\n")
 }
 
-func (BulkDdlStatement) IsMutationStatement() {}
+func (BulkDdlStatement) isMutationStatement() {}
 
 func (s *BulkDdlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	return executeDdlStatements(ctx, session, s.Ddls)
@@ -597,7 +597,7 @@ type BatchDMLStatement struct {
 	DMLs []spanner.Statement
 }
 
-func (BatchDMLStatement) IsMutationStatement() {}
+func (BatchDMLStatement) isMutationStatement() {}
 
 func (s *BatchDMLStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	return executeBatchDML(ctx, session, s.DMLs)


### PR DESCRIPTION
## Summary

Fixes #695: `CreateDatabaseStatement`, `BulkDdlStatement`, and `BatchDMLStatement` declared an exported `IsMutationStatement()` while the `MutationStatement` marker interface requires the unexported `isMutationStatement()`, so all three silently failed the `stmt.(MutationStatement)` assertion in `Session.ExecuteStatement`.

## Impact

With `SET READONLY = TRUE` (or `--readonly`):

- DDL typed interactively (`DdlStatement`) was correctly rejected, but the same DDL arriving as a batch (`BulkDdlStatement`: batch input files, `--execute` with multiple DDLs, `RUN BATCH` after `START BATCH DDL`) bypassed the guard and executed.
- `RUN BATCH` DML (`BatchDMLStatement`) and `CREATE DATABASE` similarly bypassed the guard.
- The three types also skipped pending-transaction determination.

## Fix

- Rename the three methods to the unexported marker.
- Add compile-time assertions (`var _ MutationStatement = (*BulkDdlStatement)(nil)`, ...) for every implementation next to the interface definition, so a future marker-method typo fails the build instead of silently changing behavior. This is a deliberate guardrail for low-attention edits: the same fragile unexported-marker pattern is used by `isDetachedCompatible` and `isMetaCommand`.
- Regression test `TestReadOnlyGuardCoversBatchStatements` asserts all four statement shapes are rejected in READONLY mode (unit test; no emulator needed).

## Testing

`make check` passes (full suite incl. emulator, lint, fmt-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ft2Q1ULY16tKgfW8xDT9f
