### PR TITLE
Harden CI and agent harness for mechanical mistake-catching

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hooks/format-go-file.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,9 +1,11 @@
 name: goreleaser
 
+# Trigger only on v-prefixed tags, matching ko.yml, so a stray non-v tag
+# cannot create a GitHub release that has no corresponding container image.
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions:
   contents: write
@@ -11,6 +13,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -19,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - name: Install tools
         run: |
           go install tool

--- a/.github/workflows/ko.yml
+++ b/.github/workflows/ko.yml
@@ -9,16 +9,18 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
     steps:
+      # Checkout must run before setup-go so go-version-file can read go.mod.
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
-      - uses: actions/checkout@v6
+          go-version-file: go.mod
       - uses: ko-build/setup-ko@v0.9
       - run: |
           tag=$(echo ${{ github.ref }} | cut -c11-)

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -10,9 +10,11 @@ permissions:
   contents: read
 
 # Cancel superseded runs on the same ref (e.g. new pushes to a PR branch).
+# Keep main-branch runs alive so post-merge coverage/sync history is not lost
+# when merges land in quick succession.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   readme-sync:

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same ref (e.g. new pushes to a PR branch).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   readme-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -20,10 +20,17 @@ on:
   pull_request:
 
 name: CI
+
+# Cancel superseded runs on the same ref (e.g. new pushes to a PR branch).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Run linting in a separate job for parallel execution
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -31,17 +38,39 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - run: go version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.4
           args: --timeout=5m
+      # Compile-only guard: tag-gated test files (integration, skip_slow_test)
+      # are not built by default and have silently rotted before. This makes
+      # them at least compile without wiring them into any test run.
+      - name: vet tag-gated test files
+        run: go vet -tags integration,skip_slow_test ./...
+
+  # Race detector on unit tests only (short mode, no Docker/emulator needed).
+  # The full suite under -race would be too slow for PR feedback.
+  race:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: go version
+      - name: run unit tests with race detector
+        run: go test -short -race ./...
 
   # Run tests in a separate job for parallel execution
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -49,7 +78,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - run: go version
       - name: run tests with coverage
         run: make test-coverage

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -22,9 +22,11 @@ on:
 name: CI
 
 # Cancel superseded runs on the same ref (e.g. new pushes to a PR branch).
+# Keep main-branch runs alive so post-merge coverage/sync history is not lost
+# when merges land in quick succession.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Run linting in a separate job for parallel execution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ spanner-mycli is a personal fork of spanner-cli, an interactive CLI for Google C
 make check                    # REQUIRED before ANY push (test + lint + fmt-check)
 make build                    # Build the application
 make test-quick               # Quick tests during development
+make check-race               # Unit tests with race detector (CI also runs this)
 make fmt                      # Format code
 
 # Development tools (Go tool directive, managed via go.mod)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build generate clean run test test-verbose test-quick test-coverage test-coverage-open \
-	lint fmt fmt-check check all all-quick docs-update help-dev \
+	check-race lint fmt fmt-check check all all-quick docs-update help-dev \
 	worktree-setup worktree-list worktree-delete
 
 build:
@@ -25,6 +25,10 @@ test-verbose:
 # Quick tests for development cycle
 test-quick:
 	go test -short ./...
+
+# Race detector on unit tests (same gate as the CI "race" job)
+check-race:
+	go test -short -race ./...
 
 # Test with coverage profile
 test-coverage:
@@ -98,6 +102,7 @@ help-dev:
 	@echo "  make test-coverage     - Run tests with coverage report"
 	@echo "  make test-coverage-open - Run coverage and open HTML report in browser"
 	@echo "  make test-quick        - Run quick tests (go test -short)"
+	@echo "  make check-race        - Run unit tests with race detector (same as CI race job)"
 	@echo "  make lint              - Run linter (required before push)"
 	@echo "  make fmt               - Format code (modifies files)"
 	@echo "  make fmt-check         - Check if code is properly formatted"

--- a/internal/mycli/integration_meta_command_test.go
+++ b/internal/mycli/integration_meta_command_test.go
@@ -32,7 +32,7 @@ func TestMetaCommandIntegration(t *testing.T) {
 
 	t.Run("interactive shell command execution", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.SkipSystemCommand = false
+		sysVars.Config.SkipSystemCommand = false
 
 		// Create a simulated interactive session with shell commands
 		input := io.NopCloser(strings.NewReader("\\! echo hello\n\\! echo world\nexit;\n"))
@@ -66,7 +66,7 @@ func TestMetaCommandIntegration(t *testing.T) {
 
 	t.Run("shell command execution in batch mode", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.SkipSystemCommand = false
+		sysVars.Config.SkipSystemCommand = false
 
 		// Create a mock stdin with a shell command
 		input := strings.NewReader("\\! echo hello\nexit;\n")
@@ -95,7 +95,7 @@ func TestMetaCommandIntegration(t *testing.T) {
 
 	t.Run("shell command disabled", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.SkipSystemCommand = true
+		sysVars.Config.SkipSystemCommand = true
 
 		input := strings.NewReader("")
 		output := &bytes.Buffer{}
@@ -124,7 +124,7 @@ func TestMetaCommandIntegration(t *testing.T) {
 
 	t.Run("interactive shell command disabled", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.SkipSystemCommand = true
+		sysVars.Config.SkipSystemCommand = true
 
 		// Create a simulated interactive session
 		input := strings.NewReader("\\! echo hello\nexit;\n")
@@ -164,9 +164,9 @@ SELECT "foo" AS s;`
 		}
 
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
 
 		// Create a mock session handler with a test client
 		session := &Session{
@@ -211,9 +211,9 @@ SELECT "foo" AS s;`
 
 	t.Run("source command with non-existent file", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
 
 		// Create a mock session handler with a test client
 		session := &Session{
@@ -278,9 +278,9 @@ SELECT "foo" AS s;`
 
 	t.Run("prompt command execution", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
 
 		// Create a mock session handler with a test client
 		session := &Session{
@@ -310,8 +310,8 @@ SELECT "foo" AS s;`
 		}
 
 		// Verify the prompt was changed (with trailing space added)
-		if sysVars.Prompt != "custom-prompt> " {
-			t.Errorf("Expected prompt to be 'custom-prompt> ', got %q", sysVars.Prompt)
+		if sysVars.Display.Prompt != "custom-prompt> " {
+			t.Errorf("Expected prompt to be 'custom-prompt> ', got %q", sysVars.Display.Prompt)
 		}
 
 		// Check that SHOW VARIABLE output contains the expected table format
@@ -329,9 +329,9 @@ SELECT "foo" AS s;`
 
 	t.Run("prompt command with percent expansion", func(t *testing.T) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
 
 		// Create a mock session handler with a test client
 		session := &Session{
@@ -361,8 +361,8 @@ SELECT "foo" AS s;`
 		}
 
 		// Verify the prompt was changed (expansion happens during display, with trailing space added)
-		if sysVars.Prompt != "[%p/%i/%d]> " {
-			t.Errorf("Expected prompt to be '[%%p/%%i/%%d]> ', got %q", sysVars.Prompt)
+		if sysVars.Display.Prompt != "[%p/%i/%d]> " {
+			t.Errorf("Expected prompt to be '[%%p/%%i/%%d]> ', got %q", sysVars.Display.Prompt)
 		}
 
 		// Note: This test verifies that the prompt is stored with percent patterns intact.
@@ -478,9 +478,9 @@ SELECT "foo" AS s;`
 	// Helper functions for tee tests
 	setupTeeTestCLI := func(commands string) (*Cli, *bytes.Buffer) {
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
 
 		// Use buffers for tee's console output to keep tests hermetic and verifiable.
 		consoleBuf := &bytes.Buffer{}

--- a/internal/mycli/integration_source_echo_test.go
+++ b/internal/mycli/integration_source_echo_test.go
@@ -35,10 +35,10 @@ DESCRIBE SELECT * FROM users;`
 
 		// Create system variables with ECHO enabled
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
-		sysVars.EchoInput = true // Enable ECHO
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
+		sysVars.Feature.EchoInput = true // Enable ECHO
 
 		// Create a mock session
 		session := &Session{
@@ -103,10 +103,10 @@ DESCRIBE SELECT * FROM users;`
 
 		// Create system variables with ECHO disabled
 		sysVars := newSystemVariablesWithDefaults()
-		sysVars.Project = "test-project"
-		sysVars.Instance = "test-instance"
-		sysVars.Database = "test-database"
-		sysVars.EchoInput = false // Disable ECHO
+		sysVars.Connection.Project = "test-project"
+		sysVars.Connection.Instance = "test-instance"
+		sysVars.Connection.Database = "test-database"
+		sysVars.Feature.EchoInput = false // Disable ECHO
 
 		// Create a mock session
 		session := &Session{

--- a/scripts/hooks/format-go-file.sh
+++ b/scripts/hooks/format-go-file.sh
@@ -14,13 +14,13 @@ payload=$(cat)
 if command -v jq >/dev/null 2>&1; then
     file_path=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 else
-    # Fallback without jq: extract the first "file_path" string value.
-    # Good enough for the plain absolute paths Claude Code sends; paths with
-    # embedded escaped quotes are not expected.
+    # Fallback without jq: extract the first "file_path" string value with
+    # POSIX sed only (grep -o is a GNU extension). Good enough for the plain
+    # absolute paths Claude Code sends; paths with embedded escaped quotes
+    # are not expected.
     file_path=$(printf '%s' "$payload" |
-        grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' |
-        head -n 1 |
-        sed 's/.*:[[:space:]]*"\(.*\)"/\1/')
+        sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+        head -n 1)
 fi
 
 [ -n "$file_path" ] || exit 0

--- a/scripts/hooks/format-go-file.sh
+++ b/scripts/hooks/format-go-file.sh
@@ -14,12 +14,16 @@ payload=$(cat)
 if command -v jq >/dev/null 2>&1; then
     file_path=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 else
-    # Fallback without jq: extract the first "file_path" string value with
-    # POSIX sed only (grep -o is a GNU extension). Good enough for the plain
-    # absolute paths Claude Code sends; paths with embedded escaped quotes
-    # are not expected.
+    # Fallback without jq: extract a "file_path" JSON key value with POSIX
+    # sed only (grep -o is a GNU extension). The key must be preceded by a
+    # brace, comma, or whitespace so keys merely ending in file_path do not
+    # match. This is best-effort: payload text inside old_string/new_string
+    # can still false-match, but the .go suffix check, the -f check, and the
+    # fact that the only action is running the formatter bound the impact to
+    # formatting an unintended Go file, which is harmless. jq is the primary
+    # path.
     file_path=$(printf '%s' "$payload" |
-        sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+        sed -n 's/.*[[:space:],{]"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
         head -n 1)
 fi
 

--- a/scripts/hooks/format-go-file.sh
+++ b/scripts/hooks/format-go-file.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Copyright 2026 apstndb
+#
+# Claude Code PostToolUse hook: auto-format a Go file after Edit/Write.
+#
+# Receives the hook payload as JSON on stdin, extracts .tool_input.file_path,
+# and runs the repository formatter (golangci-lint fmt: gofumpt + goimports)
+# on it when it is an existing .go file. Always exits 0 so a missing
+# formatter or unexpected payload never blocks the edit itself; formatting
+# problems are still caught later by `make check` / CI.
+
+payload=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+    file_path=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+else
+    # Fallback without jq: extract the first "file_path" string value.
+    # Good enough for the plain absolute paths Claude Code sends; paths with
+    # embedded escaped quotes are not expected.
+    file_path=$(printf '%s' "$payload" |
+        grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' |
+        head -n 1 |
+        sed 's/.*:[[:space:]]*"\(.*\)"/\1/')
+fi
+
+[ -n "$file_path" ] || exit 0
+
+case "$file_path" in
+*.go) ;;
+*) exit 0 ;;
+esac
+
+[ -f "$file_path" ] || exit 0
+
+if command -v golangci-lint >/dev/null 2>&1; then
+    golangci-lint fmt "$file_path" >/dev/null 2>&1 || true
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

This PR hardens CI and the Claude Code harness so that mistakes by coding agents (especially weaker/cheaper models) are caught mechanically by CI and hooks rather than relying on model judgment.

## Changes

### CI workflows

- **`go-version-file: go.mod` everywhere**: `run-tests.yaml`, `goreleaser.yml`, and `ko.yml` hardcoded Go versions (`'1.25'` / `'1.25.x'`). All workflows now read the version from `go.mod`, so bumping the module's Go version cannot silently drift from what CI builds and releases with. In `ko.yml`, checkout was moved before setup-go so `go-version-file` can read `go.mod`.
- **`timeout-minutes` on every job**: lint: 10; test, race, goreleaser, ko publish: 30. A hung test or release job now fails instead of consuming a runner for GitHub's 6-hour default.
- **Concurrency groups with `cancel-in-progress: true`** on PR-triggered workflows (CI, README sync), keyed on workflow + ref, so superseded pushes cancel stale runs instead of wasting runners and reporting stale results.
- **Compile-only guard for tag-gated test files**: a new lint-job step runs `go vet -tags integration,skip_slow_test ./...`. These files are not built by default and had silently rotted; this makes them at least compile on every PR without wiring them into any test run.
- **New `race` job**: `go test -short -race ./...` (unit tests only, no Docker/emulator). Concurrency bugs introduced by an agent now fail PR CI instead of surfacing later. The full suite under `-race` would be too slow for PR feedback.
- **goreleaser tag trigger aligned to `'v*'`** to match `ko.yml`. Previously a stray non-v tag would create a GitHub release with no corresponding container image.

### Integration-tagged test repairs (compile-only)

`internal/mycli/integration_meta_command_test.go` and `internal/mycli/integration_source_echo_test.go` (both under `//go:build integration`) no longer compiled after the systemVariables state-group refactor (#692). Field references were updated minimally (`SkipSystemCommand` -> `Config.SkipSystemCommand`, `Project`/`Instance`/`Database` -> `Connection.*`, `EchoInput` -> `Feature.EchoInput`, `Prompt` -> `Display.Prompt`). No assertions or test logic were changed, and the files are still not wired into any test run; the new vet step only keeps them compiling.

### Claude Code harness

New tracked `.claude/settings.json` registers a PostToolUse hook (`scripts/hooks/format-go-file.sh`) that runs `golangci-lint fmt` (the repo's formatter config: gofumpt + goimports) on any `.go` file after an Edit/Write tool call. Agents can no longer fail `make check` on formatting because files are formatted as they are written. The hook is POSIX sh, uses `jq` with a grep/sed fallback, and always exits 0 so a missing formatter never blocks an edit (formatting is still enforced by `make check`/CI). The existing `.gitignore` exception `!.claude/settings.json` already covers the new file.

### Makefile / AGENTS.md

`make check-race` runs the same gate as the CI `race` job (`go test -short -race ./...`) so agents can reproduce it locally; documented in the AGENTS.md Essential Commands block.

## Verification

- `make check` (full suite with emulator via Docker): pass
- `go vet -tags integration,skip_slow_test ./...`: pass (after the test repairs; failed on main)
- `go test -short -race ./...`: pass
- Workflow YAML parsed with PyYAML; hook script tested manually for: misformatted Go file (formatted correctly, with and without `jq` on PATH), non-Go path (ignored), missing file, garbage stdin, and `golangci-lint` absent (all exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ft2Q1ULY16tKgfW8xDT9f
