### PR TITLE
Fix statement review backlog bugs

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -765,18 +765,26 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 
 			if groups["timestamp"] != "" {
 				timestamp := unquoteString(groups["timestamp"])
+				var parseTimeErr error
+				var parseStalenessErr error
 				if t, err := time.Parse(time.RFC3339Nano, timestamp); err == nil {
 					stmt = &BeginRoStatement{
 						TimestampBoundType: readTimestamp,
 						Timestamp:          t,
 					}
-				} else if i, err := strconv.Atoi(timestamp); err == nil {
-					stmt = &BeginRoStatement{
-						TimestampBoundType: exactStaleness,
-						Staleness:          time.Duration(i) * time.Second,
-					}
 				} else {
-					return nil, fmt.Errorf("invalid ro timestamp value %q: %w", groups["timestamp"], err)
+					parseTimeErr = err
+					if i, err := strconv.Atoi(timestamp); err == nil {
+						stmt = &BeginRoStatement{
+							TimestampBoundType: exactStaleness,
+							Staleness:          time.Duration(i) * time.Second,
+						}
+					} else {
+						parseStalenessErr = err
+					}
+				}
+				if parseTimeErr != nil && parseStalenessErr != nil {
+					return nil, fmt.Errorf("invalid ro timestamp value %q: failed to parse as RFC3339 timestamp (%v) and as seconds staleness (%v)", groups["timestamp"], parseTimeErr, parseStalenessErr)
 				}
 			}
 

--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -764,17 +764,19 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 			}
 
 			if groups["timestamp"] != "" {
-				if t, err := time.Parse(time.RFC3339Nano, unquoteString(groups["timestamp"])); err == nil {
+				timestamp := unquoteString(groups["timestamp"])
+				if t, err := time.Parse(time.RFC3339Nano, timestamp); err == nil {
 					stmt = &BeginRoStatement{
 						TimestampBoundType: readTimestamp,
 						Timestamp:          t,
 					}
-				}
-				if i, err := strconv.Atoi(groups["timestamp"]); err == nil {
+				} else if i, err := strconv.Atoi(timestamp); err == nil {
 					stmt = &BeginRoStatement{
 						TimestampBoundType: exactStaleness,
 						Staleness:          time.Duration(i) * time.Second,
 					}
+				} else {
+					return nil, fmt.Errorf("invalid ro timestamp value %q: %w", groups["timestamp"], err)
 				}
 			}
 

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -95,8 +95,18 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 		return formatAsyncDdlResult(op)
 	}
 
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
 	for !op.Done() {
-		time.Sleep(5 * time.Second)
+		select {
+		case <-ticker.C:
+			// continue
+		case <-ctx.Done():
+			teardown()
+			return nil, ctx.Err()
+		}
+
 		err := op.Poll(ctx)
 		if err != nil {
 			teardown()

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -115,6 +115,9 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	if bars != nil {
 		progresses := metadata.GetProgress()
 		for i, progress := range progresses {
+			if i >= len(bars) {
+				break
+			}
 			bar := bars[i]
 			if bar.Completed() {
 				continue
@@ -142,6 +145,9 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 		if bars != nil {
 			progresses := metadata.GetProgress()
 			for i, progress := range progresses {
+				if i >= len(bars) {
+					break
+				}
 				bar := bars[i]
 				if bar.Completed() {
 					continue

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -98,6 +98,32 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
+	pollDdl := func() (*databasepb.UpdateDatabaseDdlMetadata, error) {
+		if err := op.Poll(ctx); err != nil {
+			return nil, err
+		}
+
+		return op.Metadata()
+	}
+
+	metadata, err := pollDdl()
+	if err != nil {
+		teardown()
+		return nil, err
+	}
+
+	if bars != nil {
+		progresses := metadata.GetProgress()
+		for i, progress := range progresses {
+			bar := bars[i]
+			if bar.Completed() {
+				continue
+			}
+			progressPercent := int64(progress.ProgressPercent)
+			bar.SetCurrent(progressPercent)
+		}
+	}
+
 	for !op.Done() {
 		select {
 		case <-ticker.C:
@@ -107,13 +133,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 			return nil, ctx.Err()
 		}
 
-		err := op.Poll(ctx)
-		if err != nil {
-			teardown()
-			return nil, err
-		}
-
-		metadata, err := op.Metadata()
+		metadata, err = pollDdl()
 		if err != nil {
 			teardown()
 			return nil, err
@@ -132,7 +152,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 		}
 	}
 
-	metadata, err := op.Metadata()
+	metadata, err = op.Metadata()
 	if err != nil {
 		teardown()
 		return nil, err

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -112,7 +112,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 		return nil, err
 	}
 
-	if bars != nil {
+	if metadata != nil && bars != nil {
 		progresses := metadata.GetProgress()
 		for i, progress := range progresses {
 			if i >= len(bars) {
@@ -142,7 +142,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 			return nil, err
 		}
 
-		if bars != nil {
+		if metadata != nil && bars != nil {
 			progresses := metadata.GetProgress()
 			for i, progress := range progresses {
 				if i >= len(bars) {

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -1120,6 +1120,21 @@ func TestBuildStatement_InvalidCase(t *testing.T) {
 	}
 }
 
+func TestBuildStatement_BeginRoInvalidTimestampValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildStatement("BEGIN RO foo")
+	if err == nil {
+		t.Fatal("BuildStatement(BEGIN RO foo) expected error, but got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse as RFC3339 timestamp") {
+		t.Fatalf("BuildStatement(BEGIN RO foo) error=%q, want RFC3339 parse failure", err)
+	}
+	if !strings.Contains(err.Error(), "seconds staleness") {
+		t.Fatalf("BuildStatement(BEGIN RO foo) error=%q, want seconds staleness parse failure", err)
+	}
+}
+
 func TestIsCreateDDL(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -1107,6 +1107,7 @@ func TestBuildStatement_InvalidCase(t *testing.T) {
 		"EXPLAIN FORMAT SELECT * FROM t1",
 		"EXPLAIN WIDTH= SELECT * FROM t1",
 		"EXPLAIN WIDTH SELECT * FROM t1",
+		"BEGIN RO foo",
 	}
 
 	for _, input := range invalidInputs {

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -684,11 +684,7 @@ func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (*Result,
 	s := session.cqlSession
 
 	q := s.Query(cs.CQL)
-	if err := q.Exec(); err != nil {
-		return nil, err
-	}
-
-	it := s.Query(cs.CQL).WithContext(ctx).Iter()
+	it := q.WithContext(ctx).Iter()
 	defer it.Close()
 
 	var headers []string

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -694,6 +694,9 @@ func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (result *
 			err = closeErr
 			return
 		}
+		if errors.Is(err, closeErr) {
+			return
+		}
 		err = errors.Join(err, closeErr)
 	}()
 

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -655,7 +655,7 @@ type CQLStatement struct {
 	CQL string
 }
 
-func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (result *Result, err error) {
 	// lazy initialize gocql.ClusterConfig
 	if session.cqlCluster == nil {
 		cluster := spancql.NewCluster(&spancql.Options{
@@ -685,7 +685,17 @@ func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (*Result,
 
 	q := s.Query(cs.CQL)
 	it := q.WithContext(ctx).Iter()
-	defer it.Close()
+	defer func() {
+		closeErr := it.Close()
+		if closeErr == nil {
+			return
+		}
+		if err == nil {
+			err = closeErr
+			return
+		}
+		err = errors.Join(err, closeErr)
+	}()
 
 	var headers []string
 	for _, col := range it.Columns() {
@@ -711,7 +721,8 @@ func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (*Result,
 		rows = append(rows, row)
 	}
 
-	return &Result{TableHeader: toTableHeader(headers), Rows: rows, AffectedRows: len(rows)}, nil
+	result = &Result{TableHeader: toTableHeader(headers), Rows: rows, AffectedRows: len(rows)}
+	return result, nil
 }
 
 func formatCassandraTypeName(typeInfo gocql.TypeInfo) string {

--- a/internal/mycli/statements_partitioned_query.go
+++ b/internal/mycli/statements_partitioned_query.go
@@ -29,6 +29,10 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 			return toRow(base64.StdEncoding.EncodeToString(partition.GetPartitionToken()))
 		},
 	))
+	defer func() {
+		batchROTx.Cleanup(ctx)
+		batchROTx.Close()
+	}()
 
 	ts, err := batchROTx.Timestamp()
 	if err != nil {

--- a/internal/mycli/statements_partitioned_query.go
+++ b/internal/mycli/statements_partitioned_query.go
@@ -22,6 +22,10 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		batchROTx.Cleanup(ctx)
+		batchROTx.Close()
+	}()
 
 	rows := slices.Collect(loi.Map(
 		slices.Values(partitions),
@@ -29,10 +33,6 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 			return toRow(base64.StdEncoding.EncodeToString(partition.GetPartitionToken()))
 		},
 	))
-	defer func() {
-		batchROTx.Cleanup(ctx)
-		batchROTx.Close()
-	}()
 
 	ts, err := batchROTx.Timestamp()
 	if err != nil {

--- a/internal/mycli/statements_schema.go
+++ b/internal/mycli/statements_schema.go
@@ -114,7 +114,7 @@ func (s *ShowIndexStatement) Execute(ctx context.Context, session *Session) (*Re
 FROM
   INFORMATION_SCHEMA.INDEXES I
 WHERE
-  LOWER(I.TABLE_SCHEMA) = @table_schema AND LOWER(TABLE_NAME) = LOWER(@table_name)`,
+  LOWER(I.TABLE_SCHEMA) = LOWER(@table_schema) AND LOWER(TABLE_NAME) = LOWER(@table_name)`,
 		Params: map[string]any{"table_name": s.Table, "table_schema": s.Schema},
 	}
 


### PR DESCRIPTION
## Summary

- Fix CQL statement execution so the query is only sent once instead of running an `Exec` preflight and then iterating the same CQL again.
- Tighten client-side statement behavior: reject invalid `BEGIN RO` staleness tokens, make `SHOW INDEX` schema matching case-insensitive, and make DDL polling observe context cancellation.
- Clean up partitioned-query resource handling by closing and cleaning up the `BatchReadOnlyTransaction` created by `PARTITION`.

## Validation

- `make check`
