### PR TITLE
Harden file and cache handling

### DIFF
--- a/internal/mycli/cli_mcp.go
+++ b/internal/mycli/cli_mcp.go
@@ -58,7 +58,7 @@ func executeStatementHandler(cli *Cli) func(context.Context, *mcp.CallToolReques
 			"timestamp", start)
 
 		// Parse the statement
-		statement := strings.TrimSuffix(params.Statement, ";")
+		statement := strings.TrimSuffix(strings.TrimSpace(params.Statement), ";")
 		stmt, err := cli.parseStatement(&inputStatement{statement: statement, statementWithoutComments: statement, delim: ";"})
 		if err != nil {
 			slog.Debug("MCP request failed during parsing",

--- a/internal/mycli/doc_cache.go
+++ b/internal/mycli/doc_cache.go
@@ -169,6 +169,8 @@ func (c *docCache) Get(ctx context.Context, name string) (string, bool) {
 	if exists && c.isFresh(entry) {
 		content, err := c.decompress(entry.data)
 		if err != nil {
+			delete(c.entries, name)
+			exists = false
 			slog.Warn("Failed to decompress cached document, attempting refresh", "name", name, "error", err)
 			if c.fetch == nil {
 				return "", false

--- a/internal/mycli/doc_cache.go
+++ b/internal/mycli/doc_cache.go
@@ -169,10 +169,10 @@ func (c *docCache) Get(ctx context.Context, name string) (string, bool) {
 	if exists && c.isFresh(entry) {
 		content, err := c.decompress(entry.data)
 		if err != nil {
-			slog.Warn("Failed to decompress cached document", "name", name, "error", err)
-			return "", false
+			slog.Warn("Failed to decompress cached document, attempting refresh", "name", name, "error", err)
+		} else {
+			return content, true
 		}
-		return content, true
 	}
 
 	// Stale or missing — try API refresh if available.

--- a/internal/mycli/doc_cache.go
+++ b/internal/mycli/doc_cache.go
@@ -170,6 +170,9 @@ func (c *docCache) Get(ctx context.Context, name string) (string, bool) {
 		content, err := c.decompress(entry.data)
 		if err != nil {
 			slog.Warn("Failed to decompress cached document, attempting refresh", "name", name, "error", err)
+			if c.fetch == nil {
+				return "", false
+			}
 		} else {
 			return content, true
 		}

--- a/internal/mycli/doc_cache_test.go
+++ b/internal/mycli/doc_cache_test.go
@@ -191,6 +191,26 @@ func TestDocCache_GetFreshEntryCorruptDataRefetchesFromAPI(t *testing.T) {
 	}
 }
 
+func TestDocCache_GetFreshEntryCorruptDataWithoutAPIReturnsMiss(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newTestCache(t,
+		withNowFunc(func() time.Time { return now }),
+	)
+	c.entries["documents/test/doc"] = docCacheEntry{
+		data:      []byte("bad zstd data"),
+		fetchedAt: now.Add(-time.Minute), // fresh under default TTL
+	}
+
+	content, ok := c.Get(context.Background(), "documents/test/doc")
+	if ok {
+		t.Fatal("expected cache miss for corrupted fresh entry without fetcher")
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty", content)
+	}
+}
+
 func TestDocCache_EmbeddedDocRefreshedWhenAPIAvailable(t *testing.T) {
 	t.Parallel()
 	c := newTestCache(t,

--- a/internal/mycli/doc_cache_test.go
+++ b/internal/mycli/doc_cache_test.go
@@ -170,6 +170,27 @@ func TestDocCache_TTL_StaleEntryReturnedOnFetchError(t *testing.T) {
 	}
 }
 
+func TestDocCache_GetFreshEntryCorruptDataRefetchesFromAPI(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t,
+		withDocFetcher(func(_ context.Context, _ string) (string, error) {
+			return "fresh from API", nil
+		}),
+	)
+	c.entries["documents/test/doc"] = docCacheEntry{
+		data:      []byte("bad zstd data"),
+		fetchedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	content, ok := c.Get(context.Background(), "documents/test/doc")
+	if !ok {
+		t.Fatal("expected cache hit from API refresh")
+	}
+	if content != "fresh from API" {
+		t.Errorf("content = %q", content)
+	}
+}
+
 func TestDocCache_EmbeddedDocRefreshedWhenAPIAvailable(t *testing.T) {
 	t.Parallel()
 	c := newTestCache(t,

--- a/internal/mycli/doc_cache_test.go
+++ b/internal/mycli/doc_cache_test.go
@@ -209,6 +209,40 @@ func TestDocCache_GetFreshEntryCorruptDataWithoutAPIReturnsMiss(t *testing.T) {
 	if content != "" {
 		t.Errorf("content = %q, want empty", content)
 	}
+	if _, exists := c.entries["documents/test/doc"]; exists {
+		t.Fatal("expected corrupted cache entry to be deleted")
+	}
+}
+
+func TestDocCache_GetFreshEntryCorruptDataWithFetcherFailure(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	fetchCalls := 0
+	c := newTestCache(t,
+		withNowFunc(func() time.Time { return now }),
+		withDocFetcher(func(_ context.Context, _ string) (string, error) {
+			fetchCalls++
+			return "", fmt.Errorf("API down")
+		}),
+	)
+	c.entries["documents/test/doc"] = docCacheEntry{
+		data:      []byte("bad zstd data"),
+		fetchedAt: now.Add(-time.Minute), // fresh under default TTL
+	}
+
+	content, ok := c.Get(context.Background(), "documents/test/doc")
+	if ok {
+		t.Fatal("expected cache miss when refresh fails for corrupted fresh entry")
+	}
+	if content != "" {
+		t.Errorf("content = %q, want empty", content)
+	}
+	if fetchCalls != 1 {
+		t.Errorf("fetchCalls = %d, want 1", fetchCalls)
+	}
+	if _, exists := c.entries["documents/test/doc"]; exists {
+		t.Fatal("expected corrupted cache entry to be deleted on refresh failure")
+	}
 }
 
 func TestDocCache_EmbeddedDocRefreshedWhenAPIAvailable(t *testing.T) {

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -39,16 +39,20 @@ type FileSafetyOptions struct {
 	AllowNonRegular bool
 }
 
+func maxFileSize(opts *FileSafetyOptions) int64 {
+	if opts == nil || opts.MaxSize == 0 {
+		return DefaultMaxFileSize
+	}
+	return opts.MaxSize
+}
+
 // ValidateFileSafety checks if a file is safe to read based on the given options
 func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) error {
 	if opts == nil {
 		opts = &FileSafetyOptions{}
 	}
 
-	maxSize := opts.MaxSize
-	if maxSize == 0 {
-		maxSize = DefaultMaxFileSize
-	}
+	maxSize := maxFileSize(opts)
 
 	// Directories are never readable as files, regardless of AllowNonRegular;
 	// reject them here for a clear error instead of a system-dependent
@@ -63,6 +67,8 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 			// Check specific modes for better error messages
 			mode := fi.Mode()
 			switch {
+			case mode&os.ModeCharDevice != 0:
+				return fmt.Errorf("cannot read character device %s", path)
 			case mode&os.ModeDevice != 0:
 				return fmt.Errorf("cannot read device file %s", path)
 			case mode&os.ModeNamedPipe != 0:
@@ -104,10 +110,7 @@ func SafeReadFile(path string, opts *FileSafetyOptions) ([]byte, error) {
 		return os.ReadFile(path)
 	}
 
-	maxSize := int64(DefaultMaxFileSize)
-	if opts != nil && opts.MaxSize != 0 {
-		maxSize = opts.MaxSize
-	}
+	maxSize := maxFileSize(opts)
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -75,8 +75,6 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 				return fmt.Errorf("cannot read named pipe %s", path)
 			case mode&os.ModeSocket != 0:
 				return fmt.Errorf("cannot read socket file %s", path)
-			case mode&os.ModeCharDevice != 0:
-				return fmt.Errorf("cannot read character device %s", path)
 			default:
 				return fmt.Errorf("cannot read special file %s (mode: %v)", path, mode)
 			}

--- a/internal/mycli/filesafety/file_safety_test.go
+++ b/internal/mycli/filesafety/file_safety_test.go
@@ -23,7 +23,21 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
+
+type mockFileInfo struct {
+	name string
+	mode os.FileMode
+	size int64
+}
+
+func (f mockFileInfo) Name() string       { return f.name }
+func (f mockFileInfo) Size() int64        { return f.size }
+func (f mockFileInfo) Mode() os.FileMode  { return f.mode }
+func (f mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (f mockFileInfo) IsDir() bool        { return false }
+func (f mockFileInfo) Sys() interface{}   { return nil }
 
 func TestValidateFileSafety(t *testing.T) {
 	t.Parallel()
@@ -122,6 +136,23 @@ func TestValidateFileSafety(t *testing.T) {
 				t.Errorf("ValidateFileSafety() error = %v, want error containing %q", err, tt.errMsg)
 			}
 		})
+	}
+}
+
+func TestValidateFileSafety_ModeCharDevice(t *testing.T) {
+	t.Parallel()
+	fi := mockFileInfo{
+		name: "char-device",
+		mode: os.ModeCharDevice,
+		size: 0,
+	}
+
+	err := ValidateFileSafety(fi, "/dev/null", nil)
+	if err == nil {
+		t.Fatalf("expected error for character device")
+	}
+	if !strings.Contains(err.Error(), "character device") {
+		t.Errorf("error = %v, want char device error", err)
 	}
 }
 

--- a/internal/mycli/integration_mcp_test.go
+++ b/internal/mycli/integration_mcp_test.go
@@ -317,6 +317,12 @@ func TestRunMCP(t *testing.T) {
 			wantOutput: "tbl", // Should show the test table
 		},
 		{
+			desc:       "MCP execute_statement trims statement before removing semicolon",
+			ddls:       testTableDDLs,
+			statement:  "SHOW TABLES ;  ",
+			wantOutput: "tbl",
+		},
+		{
 			desc:       "MCP execute_statement with SELECT",
 			ddls:       testTableDDLs,
 			dmls:       sliceOf("INSERT INTO tbl (id, active) VALUES (1, true), (2, false)"),

--- a/internal/mycli/sample_databases.go
+++ b/internal/mycli/sample_databases.go
@@ -25,7 +25,6 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -178,7 +177,9 @@ func discoverBuiltinSamples() map[string]SampleDatabase {
 
 // loadSampleFromMetadata loads sample from metadata file path (JSON or YAML)
 func loadSampleFromMetadata(metadataPath string) (*SampleDatabase, error) {
-	data, err := os.ReadFile(metadataPath)
+	data, err := filesafety.SafeReadFile(metadataPath, &filesafety.FileSafetyOptions{
+		MaxSize: filesafety.SampleDatabaseMaxFileSize,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to read metadata: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Route sample metadata file loading through `filesafety.SafeReadFile` with the sample-database size limit, matching schema/data file handling.
- Tighten file safety and cache edge cases: character devices now get the intended error path, max-size defaulting is shared, and fresh-but-corrupt doc cache entries refresh from the API instead of failing immediately.
- Trim MCP statement input before removing a trailing semicolon so whitespace after the semicolon does not break parsing.

## Validation

- `make check`
