### PR TITLE
Show incoming parent links for plan nodes

### DIFF
--- a/docs/query_plan.md
+++ b/docs/query_plan.md
@@ -209,6 +209,7 @@ optimizer statistics: auto_20250605_10_15_54UTC
 #### `SHOW PLAN NODE`
 
 You can also print the raw plan node in the last query using `SHOW PLAN NODE <node_id>` client-side statement.
+The output now includes incoming parent-link context in addition to the YAML node dump.
 
 ```
 spanner> SHOW PLAN NODE 18;
@@ -243,7 +244,13 @@ spanner> SHOW PLAN NODE 18;
 |     total: "2"                                                                                  |
 |     unit: rows                                                                                  |
 +-------------------------------------------------------------------------------------------------+
-1 rows in set (0.00 sec)
+| Incoming Parent Links:                                                                          |
+|   - Parent Node Index: 16                                                                       |
+|     Parent Node Title: [Map] Local Distributed Union <Row>                                      |
+|     Child Link Type: Map                                                                        |
+|     Variable: AlbumId                                                                           |
++-------------------------------------------------------------------------------------------------+
+2 rows in set (0.00 sec)
 ```
 
 ## Query plan linter (EARLY EXPERIMENTAL)

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -142,11 +142,49 @@ func (s *ShowPlanNodeStatement) Execute(ctx context.Context, session *Session) (
 		return nil, err
 	}
 
+	queryPlan, err := spannerplan.New(planNodes)
+	if err != nil {
+		return nil, err
+	}
+	parentLinksInfo := formatShowPlanNodeIncomingLinks(queryPlan.ParentLinks(int32(s.NodeID)))
+
 	return &Result{
 		TableHeader:  toTableHeader(fmt.Sprintf("Content of Node %v", s.NodeID)),
-		Rows:         sliceOf(toRow(string(y))),
-		AffectedRows: 1,
+		Rows:         sliceOf(toRow(string(y)), toRow(parentLinksInfo)),
+		AffectedRows: 2,
 	}, nil
+}
+
+func formatShowPlanNodeIncomingLinks(links []spannerplan.ResolvedParentLink) string {
+	if len(links) == 0 {
+		return "Incoming Parent Links:\n  - No incoming parent links"
+	}
+
+	var lines []string
+	lines = append(lines, "Incoming Parent Links:")
+
+	for _, link := range links {
+		childType := link.ChildLink.GetType()
+		if childType == "" {
+			childType = "(not set)"
+		}
+
+		parentNodeIndex := -1
+		parentTitle := "unknown"
+		if link.Parent != nil {
+			parentNodeIndex = int(link.Parent.GetIndex())
+			parentTitle = spannerplan.NodeTitle(link.Parent)
+		}
+
+		lines = append(lines, fmt.Sprintf("  - Parent Node Index: %d", parentNodeIndex))
+		lines = append(lines, fmt.Sprintf("    Parent Node Title: %s", parentTitle))
+		lines = append(lines, fmt.Sprintf("    Child Link Type: %s", childType))
+		if link.ChildLink.GetVariable() != "" {
+			lines = append(lines, fmt.Sprintf("    Variable: %s", link.ChildLink.GetVariable()))
+		}
+	}
+
+	return strings.Join(lines, "\n")
 }
 
 func hasCompound(fields map[string]*structpb.Value) bool {

--- a/internal/mycli/statements_explain_describe_test.go
+++ b/internal/mycli/statements_explain_describe_test.go
@@ -3,16 +3,17 @@ package mycli
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/plantree"
 	planref "github.com/apstndb/spannerplan/plantree/reference"
+	"github.com/apstndb/spannerplan/protoyaml"
 	"github.com/apstndb/spannerplan/stats"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -878,33 +879,69 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 		name           string
 		statement      *ShowPlanNodeStatement
 		lastQueryCache *LastQueryCache
-		want           *Result
+		wantIncoming   string
 		wantErr        bool
 	}{
 		{
-			"EXPLAIN ANALYZE",
+			"node with incoming parent link",
 			&ShowPlanNodeStatement{NodeID: 1},
 			&LastQueryCache{
 				QueryPlan:  selectProfileResultSet.GetStats().GetQueryPlan(),
 				QueryStats: selectProfileResultSet.GetStats().GetQueryStats().AsMap(),
 			},
-			&Result{
-				Rows: sliceOf(toRow(heredoc.Doc(`
-index: 1
-kind: 1
-display_name: Unit Relation
-child_links:
-- {child_index: 2}
-metadata: {execution_method: Row}
-execution_stats:
-  cpu_time: {total: "0", unit: msecs}
-  execution_summary: {num_executions: "1"}
-  latency: {total: "0", unit: msecs}
-  rows: {total: "1", unit: rows}
-`))),
-				AffectedRows: 1,
-				TableHeader:  toTableHeader("Content of Node 1"),
-			}, false,
+			"Incoming Parent Links:\n  - Parent Node Index: 0\n    Parent Node Title: Serialize Result (execution_method: Row)\n    Child Link Type: (not set)",
+			false,
+		},
+		{
+			"node with parent link including variable",
+			&ShowPlanNodeStatement{NodeID: 1},
+			&LastQueryCache{
+				QueryPlan: &sppb.QueryPlan{
+					PlanNodes: []*sppb.PlanNode{
+						{
+							Index:       0,
+							DisplayName: "Root",
+							Kind:        sppb.PlanNode_RELATIONAL,
+							ChildLinks: []*sppb.PlanNode_ChildLink{
+								{
+									ChildIndex: 1,
+									Type:       "Map",
+									Variable:   "v",
+								},
+							},
+						},
+						{
+							Index:       1,
+							DisplayName: "Child",
+							Kind:        sppb.PlanNode_RELATIONAL,
+						},
+					},
+				},
+			},
+			"Incoming Parent Links:\n  - Parent Node Index: 0\n    Parent Node Title: Root\n    Child Link Type: Map\n    Variable: v",
+			false,
+		},
+		{
+			"node without incoming parent links",
+			&ShowPlanNodeStatement{NodeID: 0},
+			&LastQueryCache{
+				QueryPlan: &sppb.QueryPlan{
+					PlanNodes: []*sppb.PlanNode{
+						{
+							Index:       0,
+							DisplayName: "Root",
+							Kind:        sppb.PlanNode_RELATIONAL,
+						},
+						{
+							Index:       1,
+							DisplayName: "Child",
+							Kind:        sppb.PlanNode_RELATIONAL,
+						},
+					},
+				},
+			},
+			"Incoming Parent Links:\n  - No incoming parent links",
+			false,
 		},
 	}
 	for _, tt := range tests {
@@ -917,7 +954,25 @@ execution_stats:
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(got, tt.want); diff != "" {
+			if tt.wantErr {
+				if got != nil {
+					t.Errorf("Execute() got = %v, want nil", got)
+				}
+				return
+			}
+
+			planNode := tt.lastQueryCache.QueryPlan.GetPlanNodes()[tt.statement.NodeID]
+			y, err := protoyaml.Marshal(planNode, getGlobalOpts()...)
+			if err != nil {
+				t.Fatalf("yaml.Marshal(planNode, getGlobalOpts()) error = %v", err)
+			}
+
+			want := &Result{
+				Rows:         sliceOf(toRow(string(y)), toRow(tt.wantIncoming)),
+				AffectedRows: 2,
+				TableHeader:  toTableHeader(fmt.Sprintf("Content of Node %v", tt.statement.NodeID)),
+			}
+			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("Execute() diff = %v", diff)
 				return
 			}


### PR DESCRIPTION
## Summary

- Add incoming parent-link context to `SHOW PLAN NODE <node_id>` output.
- Keep the existing raw YAML node dump and append parent node index, parent title, link type, and variable when present.
- Document the additional output in the query plan guide.

Fixes #625

## Validation

- `make check`
