### PR TITLE
Rename streaming setting for table output

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Flags:
       --tee=STRING                             Append a copy of output to the specified file (both screen and file)
   -o, --output=STRING                          Redirect query/data output to file (overwrites existing file)
       --skip-column-names                      Suppress column headers in output
-      --streaming="AUTO"                       Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams
+      --table-streaming="AUTO"                 Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams
                                                table output. Non-table formats always stream.
       --color="AUTO"                           ANSI styling in output: AUTO (styled if TTY), TRUE (always styled),
                                                FALSE (never styled)
@@ -977,7 +977,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 | CLI_ENABLE_HIGHLIGHT       | READ_WRITE | `"TRUE"`                                       |
 | CLI_PROTOTEXT_MULTILINE    | READ_WRITE | `"TRUE"`                                       |
 | CLI_FIXED_WIDTH            | READ_WRITE | `80`                                           |
-| CLI_STREAMING              | READ_WRITE | `"AUTO"`                                       |
+| CLI_TABLE_STREAMING        | READ_WRITE | `"AUTO"`                                       |
 | CLI_TABLE_PREVIEW_ROWS     | READ_WRITE | `50`                                           |
 | CLI_FUZZY_FINDER_KEY       | READ_WRITE | `"C_T"`                                        |
 | CLI_FUZZY_FINDER_OPTIONS   | READ_WRITE | `""`                                           |
@@ -999,7 +999,7 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 >
 > You can change the output format at runtime using `SET CLI_FORMAT = 'CSV';` or use command-line flags `--table`, `--html`, `--xml`, `--csv`, or `--format`.
 
-> **Note**: `CLI_STREAMING` controls table streaming output mode:
+> **Note**: `CLI_TABLE_STREAMING` controls table streaming output mode:
 > - `AUTO` (default) - Buffers Table formats for accurate column width calculation; non-table formats stream
 > - `TRUE` - Streams Table formats too (reduces memory usage, faster time-to-first-byte)
 > - `FALSE` - Buffers Table formats; non-table formats still stream

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -40,6 +40,28 @@ TODO
   - When both flags are used, `--skip-system-command` takes precedence
   - Security feature to prevent shell command execution in restricted environments
 
+##### CLI_TABLE_STREAMING
+- **Type**: ENUM
+- **Default**: AUTO
+- **Description**: Controls streaming behavior for table-oriented output formats.
+- **Access**: Read/Write
+- **Valid Values**:
+  - `AUTO` (default) - Buffer table output to calculate widths for stable layout.
+  - `TRUE` - Stream table output as rows are produced for faster time-to-first-byte.
+  - `FALSE` - Never stream table output; always buffer table output for full layout.
+- **Usage**:
+  ```sql
+  SET CLI_TABLE_STREAMING = 'FALSE';
+  SELECT * FROM users;  -- Table output is buffered for width stability
+
+  SET CLI_TABLE_STREAMING = 'TRUE';
+  SELECT * FROM users;  -- Table output is streamed
+  ```
+- **Notes**:
+  - This setting only affects table formats. Non-table formats (CSV, JSONL, etc.) continue to stream regardless.
+  - `CLI_TABLE_PREVIEW_ROWS` controls how many rows are used to estimate column width before streaming.
+  - `AUTO` is the safe default for balanced memory usage and result formatting.
+
 ##### CLI_FORMAT
 - **Type**: STRING
 - **Default**: TABLE

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -170,7 +170,7 @@ type spannerOptions struct {
 	Tee             string  `name:"tee" help:"Append a copy of output to the specified file (both screen and file)"`
 	Output          string  `name:"output" short:"o" help:"Redirect query/data output to file (overwrites existing file)"`
 	SkipColumnNames bool    `name:"skip-column-names" help:"Suppress column headers in output"`
-	Streaming       string  `name:"streaming" help:"Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams table output. Non-table formats always stream." enum:"AUTO,TRUE,FALSE" default:"AUTO"`
+	TableStreaming  string  `name:"table-streaming" help:"Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams table output. Non-table formats always stream." enum:"AUTO,TRUE,FALSE" default:"AUTO"`
 	Color           string  `name:"color" help:"ANSI styling in output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled)" enum:"AUTO,TRUE,FALSE" default:"AUTO"`
 	Quiet           bool    `name:"quiet" short:"q" help:"Suppress result lines like 'rows in set' for clean output"`
 }
@@ -590,7 +590,7 @@ func initializeSystemVariables(opts *spannerOptions) (*systemVariables, error) {
 		{"RPC_PRIORITY", cmp.Or(opts.Priority, "MEDIUM"), "--priority"},
 		{"CLI_QUERY_MODE", string(lo.FromPtr(opts.QueryMode)), "--query-mode"},
 		{"CLI_TRY_PARTITION_QUERY", lo.Ternary(opts.TryPartitionQuery, "TRUE", ""), "--try-partition-query"},
-		{"CLI_STREAMING", lo.Ternary(opts.Streaming != "" && opts.Streaming != "AUTO", opts.Streaming, ""), "--streaming"},
+		{"CLI_TABLE_STREAMING", lo.Ternary(opts.TableStreaming != "" && opts.TableStreaming != "AUTO", opts.TableStreaming, ""), "--table-streaming"},
 		{"CLI_STYLED_OUTPUT", lo.Ternary(opts.Color != "" && opts.Color != "AUTO", opts.Color, ""), "--color"},
 	}); err != nil {
 		return nil, err

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -371,7 +371,7 @@ func executeStreamingSQL(ctx context.Context, qe *queryExecution) (*Result, erro
 
 // createStreamingProcessor creates the appropriate streaming processor based on format and streaming mode.
 // Non-table formats are always streaming because they do not benefit from row buffering.
-// For table formats, CLI_STREAMING controls whether to trade layout quality for immediate output.
+// For table formats, CLI_TABLE_STREAMING controls whether to trade layout quality for immediate output.
 func createStreamingProcessor(sysVars *systemVariables, out io.Writer, screenWidth int) (RowProcessor, error) {
 	fmtMode := format.Mode(sysVars.Display.CLIFormat.String())
 	if fmtMode.IsTableMode() || fmtMode == format.ModeUnspecified {
@@ -384,7 +384,7 @@ func createStreamingProcessor(sysVars *systemVariables, out io.Writer, screenWid
 		}
 	}
 
-	// Non-table formats always stream regardless of CLI_STREAMING; only
+	// Non-table formats always stream regardless of CLI_TABLE_STREAMING; only
 	// guard against an unexpected enum value.
 	switch sysVars.Query.StreamingMode {
 	case enums.StreamingModeTrue, enums.StreamingModeFalse, enums.StreamingModeAuto:

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -433,6 +433,36 @@ func TestParseFlagsCombinations(t *testing.T) {
 	}
 }
 
+// TestTableStreamingFlagMapping verifies the new table-specific streaming CLI flag name and behavior.
+func TestTableStreamingFlagMapping(t *testing.T) {
+	t.Parallel()
+
+	gopts, err := parseTestFlags(withRequiredFlags("--table-streaming", "FALSE"))
+	if err != nil {
+		t.Fatalf("parseTestFlags() unexpected error for --table-streaming: %v", err)
+	}
+
+	sysVars, err := initializeSystemVariables(&gopts.Spanner)
+	if err != nil {
+		t.Fatalf("initializeSystemVariables() unexpected error: %v", err)
+	}
+
+	gotMode, err := sysVars.Get("CLI_TABLE_STREAMING")
+	if err != nil {
+		t.Fatalf("Get(CLI_TABLE_STREAMING) unexpected error: %v", err)
+	}
+	if got, ok := gotMode["CLI_TABLE_STREAMING"]; !ok || got != "FALSE" {
+		t.Fatalf("Get(CLI_TABLE_STREAMING) = %v, want FALSE", got)
+	}
+	if sysVars.Query.StreamingMode != enums.StreamingModeFalse {
+		t.Fatalf("Query.StreamingMode = %v, want %v", sysVars.Query.StreamingMode, enums.StreamingModeFalse)
+	}
+
+	if _, err := parseTestFlags(withRequiredFlags("--streaming", "FALSE")); err == nil {
+		t.Fatal("expected parse failure for deprecated --streaming flag, got nil")
+	}
+}
+
 // TestParseFlagsValidation tests flag value validation
 func TestParseFlagsValidation(t *testing.T) {
 	t.Parallel()

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -65,7 +65,7 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 	}
 	outStream := session.systemVariables.StreamManager.GetWriter()
 	// Use streaming whenever there is a real output stream. DUMP output is not a
-	// table layout, so CLI_STREAMING=false should not force row buffering here.
+	// table layout, so CLI_TABLE_STREAMING=false should not force row buffering here.
 	if outStream != nil && outStream != io.Discard {
 		return executeDumpStreaming(ctx, session, mode, specificTables, outStream)
 	}

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -142,7 +142,7 @@ type QueryVars struct {
 	QueryMode                  *sppb.ExecuteSqlRequest_QueryMode // CLI_QUERY_MODE
 	TryPartitionQuery          bool                              // CLI_TRY_PARTITION_QUERY
 	DirectedRead               *sppb.DirectedReadOptions         // CLI_DIRECT_READ
-	StreamingMode              enums.StreamingMode               // CLI_STREAMING
+	StreamingMode              enums.StreamingMode               // CLI_TABLE_STREAMING
 	TablePreviewRows           int64                             // CLI_TABLE_PREVIEW_ROWS
 	BuildStatementMode         enums.ParseMode                   // CLI_PARSE_MODE
 	Profile                    bool                              // CLI_PROFILE

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -221,7 +221,7 @@ func (r *VarRegistry) registerAll() {
 		"Key binding for fuzzy finder. Uses go-readline-ny key names (e.g., C_T, M_F, F1). Set to empty string to disable. The default is C_T (Ctrl+T)."))
 	r.Register("CLI_FUZZY_FINDER_OPTIONS", StringVar(&sv.Feature.FuzzyFinderOptions,
 		"Additional fzf options passed to the fuzzy finder. Appended after built-in defaults, so user options take precedence. Example: --color=dark --no-select-1"))
-	r.Register("CLI_STREAMING", StreamingModeVar(&sv.Query.StreamingMode,
+	r.Register("CLI_TABLE_STREAMING", StreamingModeVar(&sv.Query.StreamingMode,
 		"Controls table streaming output mode: AUTO/FALSE buffer table output for layout quality, TRUE streams table output. Non-table formats always stream. Default is AUTO."))
 	r.Register("CLI_STYLED_OUTPUT", StyledModeVar(&sv.Display.StyledOutput,
 		"Controls ANSI styling in table output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled). Default is AUTO."))


### PR DESCRIPTION
## Summary

- Rename the table-only streaming system variable from `CLI_STREAMING` to `CLI_TABLE_STREAMING`.
- Rename the CLI flag from `--streaming` to `--table-streaming`.
- Update docs, help output snapshots, config mapping, and tests for the new table-specific naming.

Fixes #653

## Breaking Change

- `CLI_STREAMING` and `--streaming` are no longer accepted.

## Validation

- `make check`
