### PR TITLE
docs: migrate review workflow to CI-gated merges for Gemini sunset (#693)

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -61,9 +61,15 @@ Fixes #ISSUE_NUMBER
    go tool gh-helper labels add-from-issues --pr <PR_NUMBER>
    ```
 
-5. Wait for initial Gemini review:
+5. Wait for CI checks — they are the merge gate:
 ```bash
-go tool gh-helper reviews wait --timeout 15m
+go tool gh-helper reviews wait --exclude-reviews --timeout 15m
 ```
+
+6. Check once (non-blocking) whether review feedback arrived, and address any unresolved threads with `/review-cycle`:
+```bash
+go tool gh-helper reviews fetch --unresolved-only
+```
+Gemini review is best-effort until 2026-07-17 and unavailable after (issue #693) — if none arrived, do not wait for one or request one.
 
 **Important**: Use `--body-file` or heredoc for PR body content with special characters. Never pass backtick-containing strings directly in shell commands.

--- a/.claude/commands/merge-issue-pr.md
+++ b/.claude/commands/merge-issue-pr.md
@@ -11,14 +11,14 @@ You are completing the PR workflow for #$ARGUMENTS in the spanner-mycli reposito
 ## Your task
 
 1. Identify the PR: if #$ARGUMENTS is a PR, use it directly; if it is an issue, find the PR associated with it
-2. Wait for reviews and checks to complete using `go tool gh-helper reviews wait <PR>`
-3. Squash merge the PR with a descriptive commit message that includes:
+2. Wait for CI checks to complete using `go tool gh-helper reviews wait <PR> --exclude-reviews` — passing checks are the merge gate
+3. Check for unresolved review threads with `go tool gh-helper reviews fetch <PR> --unresolved-only`; if any exist, address and resolve them before merging. Do not wait for new reviews to arrive.
+4. Squash merge the PR with a descriptive commit message that includes:
    - Clear summary of changes
    - Reference to the issue being fixed (if any)
-4. Clean up the phantom worktree for this issue if it exists
+5. Clean up the phantom worktree for this issue if it exists
 
 Important notes:
-- `/gemini summary` is posted automatically on PR creation. Do not request it manually during merge.
-- **Gemini sunset (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17**. If `reviews wait` times out with checks green because no review will arrive, proceed on green checks — they are the merge gate until the replacement flow in #693 is decided.
+- **CI checks are the merge gate.** Gemini review is best-effort until its sunset on **2026-07-17** and unavailable after (issue #693): if a review already arrived, address its feedback; never wait for one or request one (no `--request-review`, no `--request-summary`, no `/gemini` comments).
 - Use the squash merge method as enforced by the repository ruleset
 - Include a meaningful commit message that describes the changes made in the PR

--- a/.claude/commands/review-cycle.md
+++ b/.claude/commands/review-cycle.md
@@ -1,21 +1,16 @@
 ---
 name: Review Cycle
-description: Wait for Gemini review and check feedback
+description: Wait for CI checks and address any review feedback
 ---
 
 # Review Cycle Management
 
 Please execute the following steps:
 
-1. Wait for Gemini code review:
-!go tool gh-helper reviews wait
+1. Wait for CI checks to complete — they are the merge gate:
+!go tool gh-helper reviews wait --exclude-reviews
 
-**IMPORTANT**: `/gemini summary` and `/gemini review` are DIFFERENT commands.
-- `/gemini summary` generates a "Summary of Changes" — this is posted **automatically** on PR creation. Never request it manually.
-- `/gemini review` triggers an **inline code review** — this is also automatic but may take several minutes for large PRs.
-- If the wait times out without a review, **wait longer or request `/gemini review`** (NOT `/gemini summary`).
-
-**Gemini sunset (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17**. On or after that date (or whenever reviews stop arriving), skip the retry advice above: do not re-request `/gemini review` or extend the wait. Verify CI checks pass and continue; checks are the merge gate until the replacement flow in #693 is decided.
+**Gemini review is best-effort (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17** and is unavailable after. Until then a review may still arrive automatically; if one has, address its feedback in the steps below. Never wait for a review, extend the timeout for one, or request one (no `/gemini review`, no `/gemini summary`, no `--request-review`).
 
 2. Check for unresolved threads:
 !go tool gh-helper reviews fetch --unresolved-only
@@ -52,7 +47,7 @@ go tool gh-helper threads reply THREAD_ID --message "Thank you!" --resolve
 
 5. After addressing all threads with code changes, commit and push the fixes.
 
-6. With the new commit hash, reply to and resolve all code-fix threads, then request a new review to re-validate:
-!go tool gh-helper reviews wait --request-review
+6. With the new commit hash, reply to and resolve all code-fix threads, then wait for CI checks on the new commits:
+!go tool gh-helper reviews wait --exclude-reviews
 
-7. Repeat from step 2 until there are no unresolved threads.
+7. Repeat from step 2 until there are no unresolved threads and checks are green.

--- a/.claude/commands/review-respond.md
+++ b/.claude/commands/review-respond.md
@@ -53,7 +53,7 @@ go tool gh-helper threads reply THREAD_ID --resolve \
 
 Note: Even threads marked as "outdated" should be replied to and resolved, as they may contain valuable feedback that was addressed.
 
-3. After all threads are resolved, request a new review:
-!go tool gh-helper reviews wait --request-review
+3. After all threads are resolved, wait for CI checks on the pushed fixes — they are the merge gate:
+!go tool gh-helper reviews wait --exclude-reviews
 
-**Gemini sunset (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17**. On or after that date (or whenever reviews stop arriving), skip step 3 — a re-requested review will never come. Verify CI checks pass instead; checks are the merge gate until the replacement flow in #693 is decided.
+**Gemini review is best-effort (issue #693)**: consumer Gemini Code Assist code review ceases on **2026-07-17** and is unavailable after. Do not request a new review (`--request-review`) or wait for one; if another review happens to arrive before the sunset, handle its threads by repeating steps 1-2.

--- a/.claude/commands/review-status.md
+++ b/.claude/commands/review-status.md
@@ -13,4 +13,4 @@ Please show me:
 2. PR merge status:
 !gh pr status --json "number,title,state,mergeable,statusCheckRollup"
 
-3. Summary of what needs to be done before merging.
+3. Summary of what needs to be done before merging. CI checks are the merge gate; unresolved threads must be addressed, but do not wait for or request new reviews (Gemini sunset, issue #693).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,7 @@ spanner-mycli is a personal fork of spanner-cli, an interactive CLI for Google C
 2. **Resolve conflicts with origin/main** - ensure branch can merge cleanly
 3. **Never push/commit directly to main branch** - always use feature branches + PRs
 4. **Squash merge only** - enforced via Repository Ruleset
-5. **PR merge process**: Use `go tool gh-helper reviews wait` before merging. Gemini review and summary are auto-triggered on PR creation — do NOT use `--request-review` or `--request-summary` at that point. After additional commits: use `--request-review` to get a new Gemini review. Use `--request-summary` only right before merge, and only if the PR changed substantially after creation. Do not request Copilot reviews for this repository.
-   - **Gemini sunset (#693)**: consumer Gemini Code Assist code review ceases on 2026-07-17. If no Gemini review arrives (timeout, or after that date), do NOT keep re-requesting or waiting; CI checks (item 8) are the merge gate. Replacement flow is tracked in issue #693.
+5. **PR merge process**: CI checks are the merge gate (item 8). Before merging, run `go tool gh-helper reviews wait <PR> --exclude-reviews` to wait for checks. Gemini review is best-effort until its sunset on 2026-07-17 and unavailable after (#693): if one arrives, address its feedback; never block on it, re-request it (`--request-review`), or request summaries (`--request-summary`). Do not request Copilot reviews for this repository.
 6. **Squash merge commits**: MUST include descriptive summary of PR changes
 7. **GitHub comment editing**: NEVER use `gh pr comment --edit-last` - always specify exact comment ID
 8. **GitHub checks must pass**: All CI checks MUST pass before merging. Always investigate failures - never assume they are transient.
@@ -53,7 +52,7 @@ make fmt                      # Format code
 # Development tools (Go tool directive, managed via go.mod)
 go tool gh-helper reviews fetch <PR>                    # Fetch review data
 go tool gh-helper reviews fetch <PR> --unresolved-only  # Only unresolved threads
-go tool gh-helper reviews wait <PR>                     # Wait for reviews + checks
+go tool gh-helper reviews wait <PR> --exclude-reviews   # Wait for CI checks (merge gate)
 go tool gh-helper threads reply <THREAD_ID> --commit-hash <HASH> --resolve
 go tool gh-helper issues show <N> --include-sub         # Show issue with sub-issues
 go tool gh-helper issues edit <N> --parent <P>          # Link as sub-issue
@@ -126,7 +125,7 @@ Details: [dev-docs/issue-management.md#phantom-worktree-management](dev-docs/iss
 
 - **Language**: ALL GitHub communications MUST be in English
 - **Tool priority**: `gh-helper` → `gh` CLI → GitHub MCP
-- **Review workflow**: `go tool gh-helper reviews fetch` for feedback analysis (CRITICAL - prevents missing issues). Plan fixes → commit & push → reply with commit hash and resolve threads. Request follow-up reviews only through Gemini/`gh-helper`; never request Copilot review.
+- **Review workflow**: `go tool gh-helper reviews fetch` for feedback analysis (CRITICAL - prevents missing issues). Plan fixes → commit & push → reply with commit hash and resolve threads. Do not request follow-up reviews (Gemini sunset, #693); never request Copilot review.
 - **Safe content handling**: ALWAYS use stdin, variables, or `--body-file` for content with special characters. NEVER pass backtick-containing strings directly in shell commands.
 - **Documentation labels**: `docs-user` (README, docs/), `docs-dev` (dev-docs/, AGENTS.md, CLAUDE.md), `ignore-for-release` (dev-docs only PRs)
 - **Gemini style guide** (`.gemini/styleguide.md`): MUST obtain user permission before modifying

--- a/dev-docs/issue-management.md
+++ b/dev-docs/issue-management.md
@@ -53,19 +53,27 @@ creation with `issues show <parent> --include-sub`.
 
 ## Review Workflow
 
+**CI checks are the merge gate.** Consumer Gemini Code Assist code review is
+best-effort until its sunset on 2026-07-17 and unavailable after that date
+(#693). Until then a review may still arrive automatically on PR creation;
+if it does, address the feedback like any other review. Never block on a
+Gemini review, extend waits for one, or re-request one (`--request-review`
+and `--request-summary` are no longer part of the workflow).
+
 ```bash
-# 1. Create PR (Gemini review and summary are auto-triggered; no flags needed)
+# 1. Create PR
 gh pr create --title "feat: new feature" --body-file body.md
 
-# 2. Wait for the automatic review
-go tool gh-helper reviews wait <PR> --timeout 15m
+# 2. Merge gate: wait for CI checks to pass
+go tool gh-helper reviews wait <PR> --exclude-reviews --timeout 15m
 
-# 3. After additional commits: request a new review
+# 3. Best-effort (until 2026-07-17): check once whether review feedback
+#    arrived — non-blocking; do not wait or re-request if it did not
+go tool gh-helper reviews fetch <PR> --unresolved-only
+
+# 4. After additional commits: push, then re-run the checks gate
 git push
-go tool gh-helper reviews wait <PR> --request-review --timeout 15m
-
-# 4. Right before merge, only if the PR changed substantially: update summary
-go tool gh-helper reviews wait <PR> --request-summary --timeout 15m
+go tool gh-helper reviews wait <PR> --exclude-reviews --timeout 15m
 ```
 
 Thread resolution order matters: commit, push, then reply with the commit
@@ -73,9 +81,8 @@ hash and resolve (`threads reply <ID> --commit-hash <HASH> --resolve`). A
 reply without a pushed commit is not verifiable. Also read review bodies, not
 just threads - severity notes ("critical", "high") may appear only there.
 
-See AGENTS.md for the authoritative merge-gate rules, including the Gemini
-Code Assist sunset (#693): if no review arrives, CI checks are the merge gate;
-do not keep re-requesting. Never request Copilot reviews for this repository.
+See AGENTS.md for the authoritative merge-gate rules. Never request Copilot
+reviews for this repository.
 
 ## Issue Management
 


### PR DESCRIPTION
## Summary
Consumer Gemini Code Assist code review ceases on 2026-07-17 (#693). This PR migrates the documented PR review workflow so that **CI checks are the merge gate**. Gemini review becomes best-effort until the sunset and unavailable after: if a review arrives, its feedback is addressed like any other review, but the workflow never blocks on, waits for, or re-requests one.

## New flow
1. Create PR (`gh pr create`)
2. Merge gate: `go tool gh-helper reviews wait <PR> --exclude-reviews` (waits for CI checks only — a real, verified gh-helper flag)
3. Best-effort (until 2026-07-17): one non-blocking `reviews fetch <PR> --unresolved-only`; address any threads that exist, never wait for new reviews
4. After fixes: push, reply/resolve threads with commit hash, re-run the checks gate
5. Squash merge on green checks with all threads resolved

`--request-review` and `--request-summary` (and `/gemini` comments) are removed from the workflow entirely.

## Key Changes
- **AGENTS.md**: CRITICAL item 5 now states the CI-gated merge process tersely; essential-commands example and review-workflow bullet updated
- **dev-docs/issue-management.md**: Review Workflow section rewritten around the checks gate with a non-blocking feedback check
- **.claude/commands/{create-pr,merge-issue-pr,review-cycle,review-respond,review-status}.md**: gate on `reviews wait --exclude-reviews`; keep transition-window handling of already-arrived reviews; drop all wait/retry/re-request steps
- **.claude/commands/start-issue.md**: no change needed (no review-waiting steps)

## Notes
- Docs-only; `.gemini/styleguide.md` intentionally untouched.
- Suggested labels: `docs-dev`, `ignore-for-release`.

Part of #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3)_