### PR TITLE
docs: fix incorrect "does not use testify" claims in testing docs

### DIFF
--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -110,7 +110,8 @@ contract on every writable variable:
 
 ## Testing
 
-Match the existing test style (std testing + go-cmp; no testify):
+Match the existing test style (std testing + go-cmp preferred; see
+[testing.md](testing.md#test-style) for notes on testify usage):
 
 ```go
 func TestMyVariable(t *testing.T) {

--- a/dev-docs/patterns/testing.md
+++ b/dev-docs/patterns/testing.md
@@ -29,9 +29,13 @@ Conventions:
 
 ## Test Style
 
-- Standard `testing` package plus `github.com/google/go-cmp` for comparisons;
-  this repository does not use testify. Report diffs as
+- Standard `testing` package plus `github.com/google/go-cmp` for comparisons
+  is the primary style. Report diffs as
   `t.Errorf("mismatch (-want +got):\n%s", diff)`.
+- A handful of test files use `github.com/stretchr/testify`
+  (`assert`/`require`), so it is a direct dependency in go.mod. Prefer
+  std `testing` + go-cmp for new tests; within a file that already uses
+  testify, matching its existing style is fine.
 - Table-driven tests with `t.Run()` subtests and descriptive case names.
 - Naming: `Test<Function>`, `Test<Type>_<Method>`, or `Test<Type>_<Scenario>`.
 - Mark helpers with `t.Helper()` so failures point at the caller.


### PR DESCRIPTION
## Summary

Fixes a factual inconsistency found during a repo review memo pass: two dev-docs
claimed this repository does not use testify, but `github.com/stretchr/testify`
v1.11.1 is a direct requirement in go.mod and is actively used by 6 test files
(~214 `assert`/`require` calls), including `var_registry_test.go` itself:

- `internal/mycli/cli_readline_test.go`
- `internal/mycli/var_registry_test.go`
- `internal/mycli/formatsql/formatsql_test.go`
- `internal/mycli/fuzzy_finder_test.go`
- `internal/mycli/show_operation_test.go`
- `internal/mycli/streaming_test.go`

Removing the dependency was considered first (`go mod why -m`, grep audit), but
it is genuinely load-bearing, so the docs are corrected instead.

## Changes

- **dev-docs/patterns/testing.md**: state that std `testing` + go-cmp is the
  *preferred* style for new tests, acknowledge existing testify usage, and note
  that matching a file's existing style is fine.
- **dev-docs/patterns/system-variables.md**: drop the duplicated "no testify"
  claim and link to testing.md's Test Style section instead (single source of
  truth).

## Notes

- Docs-only change; no code or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3)_