### PR TITLE
lint: explicitly enable errcheck, govet, ineffassign, staticcheck, unused; fix gofumpt failure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,18 @@ formatters:
     - gofumpt  # gofumpt is a superset of gofmt with -s always enabled
 
 linters:
+  # The "standard" default group (errcheck, govet, ineffassign, staticcheck,
+  # unused) is already active in golangci-lint v2. The five linters below are
+  # listed explicitly so they stay enabled (and the codebase stays clean of
+  # their findings) even if `default` is ever changed. All five report zero
+  # violations as of enabling.
   enable:
     - copyloopvar  # Detects unnecessary loop variable copies (Go 1.22+)
+    - errcheck     # Unchecked errors (see exclude-functions below)
+    - govet        # Suspicious constructs (roughly `go vet`)
+    - ineffassign  # Assignments whose values are never used
+    - staticcheck  # staticcheck rule set
+    - unused       # Unused constants, variables, functions, and types
   settings:
     copyloopvar:
       check-alias: true  # Also check aliased loop variables

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -418,7 +418,7 @@ func (tm *TransactionManager) GetTransactionFlagsWithLock() (inTransaction bool,
 
 	inTransaction = true
 	inReadWriteTransaction = tm.tc.attrs.mode == transactionModeReadWrite
-	return
+	return inTransaction, inReadWriteTransaction
 }
 
 // TransactionOptionsBuilder helps build transaction options with proper defaults.


### PR DESCRIPTION
## Summary

Staged linter enablement from the repo review memo. Investigation showed that
golangci-lint v2's "standard" default group already runs errcheck, govet,
ineffassign, staticcheck, and unused on this repo — the `enable: [copyloopvar]`
entry adds to that default set rather than replacing it. Each linter was
measured individually (`golangci-lint run --enable-only=<linter>`):

| Linter | Violations |
|---|---|
| errcheck (with existing exclude-functions) | 0 |
| staticcheck | 0 |
| govet | 0 |
| ineffassign | 0 |
| unused | 0 |

Since the codebase is already clean, all five are now listed explicitly in
`linters.enable` so the guarantee is documented and survives any future change
to the `default` group. No code changes were required for enablement, and the
existing errcheck `exclude-functions` settings are untouched.

## Also included

- One-line gofumpt fix in `internal/mycli/transaction_manager.go`
  (`GetTransactionFlagsWithLock`): expanded a naked `return` to
  `return inTransaction, inReadWriteTransaction`. This was a pre-existing
  `make fmt-check` / `golangci-lint run` failure on main with
  golangci-lint 2.5.0, and this PR makes both fully clean (`0 issues.`).

## Verification

- `golangci-lint run`: 0 issues
- `make fmt-check`: pass
- `go test -short ./...`: pass (one pre-existing environment-only failure in
  `TestSystemVariables_ProtoDescriptorFiles/.../permission_denied_file` when
  run as root, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3)_