### PR TITLE
Add TSV output format with lossless escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Flags:
       --html                                   Display output in HTML format.
       --xml                                    Display output in XML format.
       --csv                                    Display output in CSV format.
-      --format=STRING                          Output format (table, tab, vertical, html, xml, csv, jsonl)
+      --format=STRING                          Output format (table, tab, tsv, vertical, html, xml, csv, jsonl)
   -v, --verbose                                Display verbose output.
       --credential=STRING                      Use the specific credential file
       --prompt=PROMPT                          Set the prompt to the specified format (default: "spanner%t> ")
@@ -309,6 +309,11 @@ id      name    active
 1       foo     true
 2       bar     false
 ```
+
+`TAB` writes values as-is, so values containing tabs or newlines break the row/column structure.
+Use `--format=TSV` for the same layout with lossless escaping: tab, newline, carriage return, and
+backslash inside values are escaped as `\t`, `\n`, `\r`, and `\\`, guaranteeing one row per line
+and one field per tab-separated column.
 
 With `--skip-column-names` option, column headers are suppressed in output (useful for scripting).
 
@@ -988,7 +993,8 @@ They have almost same semantics with [Spanner JDBC properties](https://cloud.goo
 > - `TABLE_COMMENT` - Table wrapped in /* */ comments  
 > - `TABLE_DETAIL_COMMENT` - Table and execution details wrapped in /* */ comments (useful for embedding results in SQL code blocks)
 > - `VERTICAL` - Vertical format (column: value pairs)
-> - `TAB` - Tab-separated values
+> - `TAB` - Tab-separated values (raw; values containing tabs or newlines break the row/column structure)
+> - `TSV` - Tab-separated values with escaping (tab, newline, carriage return, and backslash in values are escaped as `\t`, `\n`, `\r`, `\\`)
 > - `HTML` - HTML table format (compatible with Google Cloud Spanner CLI)
 > - `XML` - XML format (compatible with Google Cloud Spanner CLI)
 > - `CSV` - Comma-separated values (RFC 4180 compliant with automatic escaping)

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -19,7 +19,7 @@ TODO
   SELECT * FROM users;  -- Output without column headers
   ```
 - **Notes**:
-  - Affects table format (`CLI_FORMAT='TABLE'`), tab format (`CLI_FORMAT='TAB'`), CSV format (`CLI_FORMAT='CSV'`), HTML format (`CLI_FORMAT='HTML'`), and XML format (`CLI_FORMAT='XML'`)
+  - Affects table format (`CLI_FORMAT='TABLE'`), tab format (`CLI_FORMAT='TAB'`), TSV format (`CLI_FORMAT='TSV'`), CSV format (`CLI_FORMAT='CSV'`), HTML format (`CLI_FORMAT='HTML'`), and XML format (`CLI_FORMAT='XML'`)
   - Headers are always preserved in vertical format (`CLI_FORMAT='VERTICAL'`) as they are integral to the format
   - Can be set via `--skip-column-names` command-line flag
   - Useful for scripting and data processing where only raw data is needed

--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -72,7 +72,8 @@ TODO
   - `TABLE_COMMENT` - Table wrapped in `/* */` comments
   - `TABLE_DETAIL_COMMENT` - Table and execution details wrapped in `/* */` comments (useful for embedding results in SQL code blocks)
   - `VERTICAL` - Vertical format with column:value pairs
-  - `TAB` - Tab-separated values
+  - `TAB` - Tab-separated values (raw; values are joined with tabs as-is, so values containing tabs or newlines break the row/column structure)
+  - `TSV` - Tab-separated values with escaping (tab, newline, carriage return, and backslash inside values are escaped as `\t`, `\n`, `\r`, and `\\`, guaranteeing one row per line and one field per column)
   - `HTML` - HTML table format
   - `XML` - XML format
   - `CSV` - Comma-separated values (RFC 4180 compliant)
@@ -109,6 +110,7 @@ TODO
   - HTML and XML formats are compatible with Google Cloud Spanner CLI
   - All special characters are properly escaped in HTML, XML, and CSV formats for security
   - CSV format follows RFC 4180 standard with automatic escaping of commas, quotes, and newlines
+  - TSV format escapes `\` as `\\`, tab as `\t`, newline as `\n`, and carriage return as `\r` in both header names and values; double quotes are not special and are emitted verbatim; empty strings produce empty fields; NULL is rendered as the literal text `NULL` (same as TAB/TABLE). Use TAB if you need the historical raw (unescaped) behavior
   - JSONL format produces type-aware JSON: INT64/ENUM as numbers, BOOL as booleans, ARRAY as JSON arrays, STRUCT as JSON objects, NULL as null
   - The format affects how query results are displayed, not how they are executed
   - `TABLE_DETAIL_COMMENT` is particularly useful with `CLI_ECHO_INPUT=TRUE` and `CLI_MARKDOWN_CODEBLOCK=TRUE` for documentation

--- a/enums/displaymode_enumer.go
+++ b/enums/displaymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _DisplayModeName = "UNSPECIFIEDTABLETABLE_COMMENTTABLE_DETAIL_COMMENTVERTICALTABHTMLXMLCSVJSONLSQL_INSERTSQL_INSERT_OR_IGNORESQL_INSERT_OR_UPDATE"
+const _DisplayModeName = "UNSPECIFIEDTABLETABLE_COMMENTTABLE_DETAIL_COMMENTVERTICALTABHTMLXMLCSVJSONLSQL_INSERTSQL_INSERT_OR_IGNORESQL_INSERT_OR_UPDATETSV"
 
-var _DisplayModeIndex = [...]uint8{0, 11, 16, 29, 49, 57, 60, 64, 67, 70, 75, 85, 105, 125}
+var _DisplayModeIndex = [...]uint8{0, 11, 16, 29, 49, 57, 60, 64, 67, 70, 75, 85, 105, 125, 128}
 
-const _DisplayModeLowerName = "unspecifiedtabletable_commenttable_detail_commentverticaltabhtmlxmlcsvjsonlsql_insertsql_insert_or_ignoresql_insert_or_update"
+const _DisplayModeLowerName = "unspecifiedtabletable_commenttable_detail_commentverticaltabhtmlxmlcsvjsonlsql_insertsql_insert_or_ignoresql_insert_or_updatetsv"
 
 func (i DisplayMode) String() string {
 	if i < 0 || i >= DisplayMode(len(_DisplayModeIndex)-1) {
@@ -37,9 +37,10 @@ func _DisplayModeNoOp() {
 	_ = x[DisplayModeSQLInsert-(10)]
 	_ = x[DisplayModeSQLInsertOrIgnore-(11)]
 	_ = x[DisplayModeSQLInsertOrUpdate-(12)]
+	_ = x[DisplayModeTSV-(13)]
 }
 
-var _DisplayModeValues = []DisplayMode{DisplayModeUnspecified, DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment, DisplayModeVertical, DisplayModeTab, DisplayModeHTML, DisplayModeXML, DisplayModeCSV, DisplayModeJSONL, DisplayModeSQLInsert, DisplayModeSQLInsertOrIgnore, DisplayModeSQLInsertOrUpdate}
+var _DisplayModeValues = []DisplayMode{DisplayModeUnspecified, DisplayModeTable, DisplayModeTableComment, DisplayModeTableDetailComment, DisplayModeVertical, DisplayModeTab, DisplayModeHTML, DisplayModeXML, DisplayModeCSV, DisplayModeJSONL, DisplayModeSQLInsert, DisplayModeSQLInsertOrIgnore, DisplayModeSQLInsertOrUpdate, DisplayModeTSV}
 
 var _DisplayModeNameToValueMap = map[string]DisplayMode{
 	_DisplayModeName[0:11]:         DisplayModeUnspecified,
@@ -68,6 +69,8 @@ var _DisplayModeNameToValueMap = map[string]DisplayMode{
 	_DisplayModeLowerName[85:105]:  DisplayModeSQLInsertOrIgnore,
 	_DisplayModeName[105:125]:      DisplayModeSQLInsertOrUpdate,
 	_DisplayModeLowerName[105:125]: DisplayModeSQLInsertOrUpdate,
+	_DisplayModeName[125:128]:      DisplayModeTSV,
+	_DisplayModeLowerName[125:128]: DisplayModeTSV,
 }
 
 var _DisplayModeNames = []string{
@@ -84,6 +87,7 @@ var _DisplayModeNames = []string{
 	_DisplayModeName[75:85],
 	_DisplayModeName[85:105],
 	_DisplayModeName[105:125],
+	_DisplayModeName[125:128],
 }
 
 // DisplayModeString retrieves an enum value from the enum constants string name.

--- a/enums/enums.go
+++ b/enums/enums.go
@@ -19,6 +19,7 @@ const (
 	DisplayModeSQLInsert
 	DisplayModeSQLInsertOrIgnore
 	DisplayModeSQLInsertOrUpdate
+	DisplayModeTSV
 )
 
 // AutocommitDMLMode represents the DML autocommit behavior

--- a/internal/mycli/cli_output_test.go
+++ b/internal/mycli/cli_output_test.go
@@ -42,12 +42,14 @@ func TestCLIFormatSystemVariable(t *testing.T) {
 		{"set TABLE", "TABLE", enums.DisplayModeTable, false},
 		{"set VERTICAL", "VERTICAL", enums.DisplayModeVertical, false},
 		{"set TAB", "TAB", enums.DisplayModeTab, false},
+		{"set TSV", "TSV", enums.DisplayModeTSV, false},
 		{"set HTML", "HTML", enums.DisplayModeHTML, false},
 		{"set XML", "XML", enums.DisplayModeXML, false},
 		{"set CSV", "CSV", enums.DisplayModeCSV, false},
 		{"set html lowercase", "html", enums.DisplayModeHTML, false},
 		{"set xml lowercase", "xml", enums.DisplayModeXML, false},
 		{"set csv lowercase", "csv", enums.DisplayModeCSV, false},
+		{"set tsv lowercase", "tsv", enums.DisplayModeTSV, false},
 		{"set invalid", "INVALID", enums.DisplayModeTable, true},
 	}
 
@@ -80,6 +82,7 @@ func TestCLIFormatSystemVariableGetter(t *testing.T) {
 		{enums.DisplayModeTableDetailComment, "TABLE_DETAIL_COMMENT"},
 		{enums.DisplayModeVertical, "VERTICAL"},
 		{enums.DisplayModeTab, "TAB"},
+		{enums.DisplayModeTSV, "TSV"},
 		{enums.DisplayModeHTML, "HTML"},
 		{enums.DisplayModeXML, "XML"},
 		{enums.DisplayModeCSV, "CSV"},

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -415,6 +415,30 @@ bar: 4
 		}
 	})
 
+	t.Run("DisplayModeTSV", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		result := &Result{
+			TableHeader: toTableHeader("foo", "bar"),
+			Rows: sliceOf(
+				toRow("tab\there", "line\nbreak"),
+				toRow("back\\slash", "NULL"),
+			),
+		}
+		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTSV}}, math.MaxInt, out, result, false, "")
+		if err != nil {
+			t.Errorf("printResult() unexpected error: %v", err)
+		}
+
+		expected := "foo\tbar\n" +
+			"tab\\there\tline\\nbreak\n" +
+			"back\\\\slash\tNULL\n"
+
+		got := out.String()
+		if got != expected {
+			t.Errorf("invalid print: expected = %s, but got = %s", expected, got)
+		}
+	})
+
 	t.Run("SkipColumnNames with DisplayModeTable", func(t *testing.T) {
 		out := &bytes.Buffer{}
 		result := &Result{

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -111,7 +111,7 @@ type spannerOptions struct {
 	HTML                bool              `name:"html" help:"Display output in HTML format."`
 	XML                 bool              `name:"xml" help:"Display output in XML format."`
 	CSV                 bool              `name:"csv" help:"Display output in CSV format."`
-	Format              string            `name:"format" help:"Output format (table, tab, vertical, html, xml, csv, jsonl)"`
+	Format              string            `name:"format" help:"Output format (table, tab, tsv, vertical, html, xml, csv, jsonl)"`
 	Verbose             bool              `name:"verbose" short:"v" help:"Display verbose output."`
 	Credential          string            `name:"credential" help:"Use the specific credential file"`
 	Prompt              *string           `name:"prompt" help:"Set the prompt to the specified format (default: ${defaultPromptQuoted})"`

--- a/internal/mycli/format/format.go
+++ b/internal/mycli/format/format.go
@@ -117,6 +117,8 @@ func NewStreamingFormatter(mode Mode, out io.Writer, config FormatConfig) (Strea
 		return NewCSVFormatter(out, config.SkipColumnNames), nil
 	case ModeTab:
 		return NewTabFormatter(out, config.SkipColumnNames), nil
+	case ModeTSV:
+		return NewTSVFormatter(out, config.SkipColumnNames), nil
 	case ModeVertical:
 		return NewVerticalFormatter(out), nil
 	case ModeHTML:

--- a/internal/mycli/format/format_test.go
+++ b/internal/mycli/format/format_test.go
@@ -17,6 +17,10 @@ func formatTab(out io.Writer, rows []Row, columnNames []string, config FormatCon
 	return ExecuteWithFormatter(NewTabFormatter(out, config.SkipColumnNames), rows, columnNames, config)
 }
 
+func formatTSV(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
+	return ExecuteWithFormatter(NewTSVFormatter(out, config.SkipColumnNames), rows, columnNames, config)
+}
+
 func formatCSV(out io.Writer, rows []Row, columnNames []string, config FormatConfig, screenWidth int) error {
 	return ExecuteWithFormatter(NewCSVFormatter(out, config.SkipColumnNames), rows, columnNames, config)
 }
@@ -45,6 +49,7 @@ func TestNewStreamingFormatter(t *testing.T) {
 	}{
 		{name: "csv", mode: ModeCSV, out: io.Discard},
 		{name: "tab", mode: ModeTab, out: io.Discard},
+		{name: "tsv", mode: ModeTSV, out: io.Discard},
 		{name: "vertical", mode: ModeVertical, out: io.Discard},
 		{name: "html", mode: ModeHTML, out: io.Discard},
 		{name: "xml", mode: ModeXML, out: io.Discard},
@@ -99,7 +104,7 @@ func TestValueFormatModeFor(t *testing.T) {
 	// No t.Parallel(): mutates global registry
 
 	// Built-in modes should return DisplayValues
-	for _, mode := range []Mode{ModeTable, ModeCSV, ModeTab, ModeVertical, ModeHTML, ModeXML} {
+	for _, mode := range []Mode{ModeTable, ModeCSV, ModeTab, ModeTSV, ModeVertical, ModeHTML, ModeXML} {
 		if got := ValueFormatModeFor(mode); got != DisplayValues {
 			t.Errorf("ValueFormatModeFor(%s) = %d, want DisplayValues", mode, got)
 		}
@@ -233,6 +238,15 @@ func TestFormatTab(t *testing.T) {
 			rows:    nil,
 			want:    "id\n",
 		},
+		{
+			// TAB is intentionally raw (backward compatible): special characters
+			// pass through unescaped even though they break the row/column structure.
+			// TSV provides the escaped variant.
+			name:    "special characters pass through raw",
+			columns: []string{"a", "b"},
+			rows:    []Row{StringsToRow("tab\there", "line\nbreak"), StringsToRow("back\\slash", "cr\rhere")},
+			want:    "a\tb\ntab\there\tline\nbreak\nback\\slash\tcr\rhere\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -241,6 +255,100 @@ func TestFormatTab(t *testing.T) {
 			var buf bytes.Buffer
 			config := FormatConfig{SkipColumnNames: tt.skipHeaders}
 			err := formatTab(&buf, tt.rows, tt.columns, config, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, buf.String()); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFormatTSV(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		columns     []string
+		rows        []Row
+		skipHeaders bool
+		want        string
+	}{
+		{
+			name:    "basic",
+			columns: []string{"id", "name"},
+			rows:    []Row{StringsToRow("1", "Alice"), StringsToRow("2", "Bob")},
+			want:    "id\tname\n1\tAlice\n2\tBob\n",
+		},
+		{
+			name:        "skip headers",
+			columns:     []string{"id", "name"},
+			rows:        []Row{StringsToRow("1", "Alice")},
+			skipHeaders: true,
+			want:        "1\tAlice\n",
+		},
+		{
+			name:    "empty rows",
+			columns: []string{"id"},
+			rows:    nil,
+			want:    "id\n",
+		},
+		{
+			name:    "tab in value",
+			columns: []string{"a", "b"},
+			rows:    []Row{StringsToRow("tab\there", "plain")},
+			want:    "a\tb\ntab\\there\tplain\n",
+		},
+		{
+			name:    "newline in value",
+			columns: []string{"a"},
+			rows:    []Row{StringsToRow("line\nbreak")},
+			want:    "a\nline\\nbreak\n",
+		},
+		{
+			name:    "carriage return in value",
+			columns: []string{"a"},
+			rows:    []Row{StringsToRow("cr\rhere"), StringsToRow("crlf\r\nhere")},
+			want:    "a\ncr\\rhere\ncrlf\\r\\nhere\n",
+		},
+		{
+			name:    "backslash in value",
+			columns: []string{"a"},
+			rows:    []Row{StringsToRow(`back\slash`), StringsToRow(`literal\t`)},
+			want:    "a\nback\\\\slash\nliteral\\\\t\n",
+		},
+		{
+			// Quotes are not special in TSV; they pass through verbatim.
+			name:    "quotes are not escaped",
+			columns: []string{"a"},
+			rows:    []Row{StringsToRow(`say "hi" and 'bye'`)},
+			want:    "a\nsay \"hi\" and 'bye'\n",
+		},
+		{
+			// Empty strings produce empty fields; NULL is whatever text the value
+			// formatter produced (the same "NULL" literal as TAB/TABLE), so an
+			// empty string and NULL remain distinguishable only if the NULL
+			// literal is non-empty (the display default).
+			name:    "empty string and NULL literal",
+			columns: []string{"a", "b", "c"},
+			rows:    []Row{StringsToRow("", "NULL", "x")},
+			want:    "a\tb\tc\n\tNULL\tx\n",
+		},
+		{
+			name:    "header names are escaped",
+			columns: []string{"col\twith\ttabs", "col\nwith\nnewlines"},
+			rows:    []Row{StringsToRow("1", "2")},
+			want:    "col\\twith\\ttabs\tcol\\nwith\\nnewlines\n1\t2\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			config := FormatConfig{SkipColumnNames: tt.skipHeaders}
+			err := formatTSV(&buf, tt.rows, tt.columns, config, 0)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -577,6 +685,19 @@ func TestTabFormatterLifecycle(t *testing.T) {
 	})
 }
 
+func TestTSVFormatterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write before init", func(t *testing.T) {
+		t.Parallel()
+		f := NewTSVFormatter(io.Discard, false)
+		err := f.WriteRow(StringsToRow("1"))
+		if err == nil {
+			t.Error("expected error writing before init")
+		}
+	})
+}
+
 func TestVerticalFormatterLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -855,6 +976,7 @@ func TestStyledCellInNonTableFormats(t *testing.T) {
 	}{
 		{"csv", formatCSV},
 		{"tab", formatTab},
+		{"tsv", formatTSV},
 		{"vertical", formatVertical},
 		{"html", formatHTML},
 		{"xml", formatXML},
@@ -1084,6 +1206,7 @@ func TestNullStyledInNonTableFormats(t *testing.T) {
 		wantNoESC bool
 	}{
 		{"tab", formatTab, true},
+		{"tsv", formatTSV, true},
 		{"vertical", formatVertical, true},
 		{"html", formatHTML, true},
 		{"xml", formatXML, true},

--- a/internal/mycli/format/mode.go
+++ b/internal/mycli/format/mode.go
@@ -15,6 +15,7 @@ const (
 	ModeTableDetailComment Mode = "TABLE_DETAIL_COMMENT"
 	ModeVertical           Mode = "VERTICAL"
 	ModeTab                Mode = "TAB"
+	ModeTSV                Mode = "TSV"
 	ModeHTML               Mode = "HTML"
 	ModeXML                Mode = "XML"
 	ModeCSV                Mode = "CSV"

--- a/internal/mycli/format/streaming_common.go
+++ b/internal/mycli/format/streaming_common.go
@@ -126,6 +126,85 @@ func (f *TabFormatter) FinishFormat() error {
 	return nil
 }
 
+// tsvEscaper escapes characters that would break the TSV row/field structure.
+// This is the conventional lossless TSV escaping (as used by MySQL's tab output,
+// Postgres COPY text format, etc.): backslash, tab, newline, and carriage return
+// are replaced by two-character backslash sequences. Quotes are NOT special in
+// TSV and are emitted verbatim.
+var tsvEscaper = strings.NewReplacer(
+	"\\", `\\`,
+	"\t", `\t`,
+	"\n", `\n`,
+	"\r", `\r`,
+)
+
+// escapeTSVFields escapes each field with tsvEscaper.
+func escapeTSVFields(fields []string) []string {
+	escaped := make([]string, len(fields))
+	for i, field := range fields {
+		escaped[i] = tsvEscaper.Replace(field)
+	}
+	return escaped
+}
+
+// TSVFormatter provides tab-separated formatting with escaping.
+// Unlike TabFormatter (which joins raw cell text and is kept for backward
+// compatibility), TSVFormatter guarantees one row per line and one field per
+// tab-separated column by escaping tab, newline, carriage return, and
+// backslash within values (and header names).
+type TSVFormatter struct {
+	out         io.Writer
+	skipHeaders bool
+	initialized bool
+}
+
+// NewTSVFormatter creates a new escaping tab-separated (TSV) formatter.
+func NewTSVFormatter(out io.Writer, skipHeaders bool) *TSVFormatter {
+	return &TSVFormatter{
+		out:         out,
+		skipHeaders: skipHeaders,
+	}
+}
+
+// InitFormat writes escaped tab-separated headers if needed.
+func (f *TSVFormatter) InitFormat(columnNames []string, config FormatConfig, previewRows []Row) error {
+	if f.initialized {
+		return nil
+	}
+
+	if len(columnNames) == 0 {
+		return nil
+	}
+
+	// Write headers unless skipping
+	if !f.skipHeaders {
+		if _, err := fmt.Fprintln(f.out, strings.Join(escapeTSVFields(columnNames), "\t")); err != nil {
+			return fmt.Errorf("failed to write TSV header: %w", err)
+		}
+	}
+
+	f.initialized = true
+	return nil
+}
+
+// WriteRow writes a single escaped tab-separated row.
+func (f *TSVFormatter) WriteRow(row Row) error {
+	if !f.initialized {
+		return fmt.Errorf("TSV formatter not initialized")
+	}
+
+	if _, err := fmt.Fprintln(f.out, strings.Join(escapeTSVFields(Texts(row)), "\t")); err != nil {
+		return fmt.Errorf("failed to write TSV row: %w", err)
+	}
+
+	return nil
+}
+
+// FinishFormat completes tab-separated output.
+func (f *TSVFormatter) FinishFormat() error {
+	return nil
+}
+
 // VerticalFormatter provides shared vertical formatting logic.
 type VerticalFormatter struct {
 	out         io.Writer

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -335,7 +335,7 @@ func (r *VarRegistry) registerAll() {
 	r.Register("AUTOCOMMIT_DML_MODE", AutocommitDMLModeVar(&sv.Transaction.AutocommitDMLMode,
 		"A STRING property indicating the autocommit mode for Data Manipulation Language (DML) statements."))
 	r.Register("CLI_FORMAT", DisplayModeVar(&sv.Display.CLIFormat,
-		"Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated), HTML (HTML table), XML (XML format), CSV (comma-separated values)."))
+		"Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated, raw values), TSV (tab-separated with tab/newline/backslash escaping), HTML (HTML table), XML (XML format), CSV (comma-separated values)."))
 	r.Register("CLI_PARSE_MODE", ParseModeVar(&sv.Query.BuildStatementMode,
 		"Controls statement parsing mode: FALLBACK (default), NO_MEMEFISH, MEMEFISH_ONLY, or UNSPECIFIED"))
 	r.Register("CLI_EXPLAIN_FORMAT", &CustomVar{

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -335,7 +335,7 @@ func (r *VarRegistry) registerAll() {
 	r.Register("AUTOCOMMIT_DML_MODE", AutocommitDMLModeVar(&sv.Transaction.AutocommitDMLMode,
 		"A STRING property indicating the autocommit mode for Data Manipulation Language (DML) statements."))
 	r.Register("CLI_FORMAT", DisplayModeVar(&sv.Display.CLIFormat,
-		"Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated, raw values), TSV (tab-separated with tab/newline/backslash escaping), HTML (HTML table), XML (XML format), CSV (comma-separated values)."))
+		"Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated, raw values), TSV (tab-separated with tab/newline/carriage-return/backslash escaping), HTML (HTML table), XML (XML format), CSV (comma-separated values)."))
 	r.Register("CLI_PARSE_MODE", ParseModeVar(&sv.Query.BuildStatementMode,
 		"Controls statement parsing mode: FALLBACK (default), NO_MEMEFISH, MEMEFISH_ONLY, or UNSPECIFIED"))
 	r.Register("CLI_EXPLAIN_FORMAT", &CustomVar{


### PR DESCRIPTION
## Summary

Fixes #644

Adds a new `CLI_FORMAT` value `TSV` alongside the existing `TAB` format. `TAB` is a raw tab-join of formatted cells and silently breaks the row/column structure when values contain tabs or newlines. Rather than changing `TAB` (backward compatibility), this PR defines true TSV semantics as a separate format with conventional lossless escaping (as used by MySQL tab output / PostgreSQL COPY text format).

`--format=tsv` and `SET CLI_FORMAT = 'TSV'` are both supported. TSV streams like other non-table formats and works for both server query results and client-side statements.

**Note:** #647 (typed buffered export) is intentionally out of scope — TSV here operates on the existing display-formatted cell pipeline, same as TAB.

## Semantics

| Input in value | TAB (unchanged) | TSV (new) |
|---|---|---|
| tab (`U+0009`) | emitted raw (breaks columns) | `\t` |
| newline (`U+000A`) | emitted raw (breaks rows) | `\n` |
| carriage return (`U+000D`) | emitted raw | `\r` |
| backslash (`\`) | emitted raw (ambiguous) | `\\` |
| double/single quotes | emitted raw | emitted raw (quotes are not special in TSV) |
| empty string | empty field | empty field |
| NULL | literal `NULL` text | literal `NULL` text (same display convention as TAB/TABLE; no new NULL literal) |

Header names are escaped the same way as values (aliases can contain tabs/newlines). Because backslash is escaped, output is losslessly round-trippable: `\t` in output always means an escaped tab, never a literal backslash-t.

## Implementation

- `enums`: add `DisplayModeTSV`, regenerate enumer code — `SET CLI_FORMAT`, `--format`, and config-file parsing accept `TSV`/`tsv` automatically
- `internal/mycli/format`: add `ModeTSV` and `TSVFormatter` (mirrors `TabFormatter` with an escaping `strings.Replacer`); wired into `NewStreamingFormatter`, which serves both the streaming and buffered output paths
- `CLI_FORMAT` sysvar description and `--format` flag help updated; README help regenerated with `make docs-update`
- Docs: TAB vs TSV semantics documented in `README.md` and `docs/system_variables.md`
- No `--tsv` shorthand flag: the individual format flags exist for spanner-cli compatibility; `--format=tsv` is sufficient

## Tests

- `TestFormatTSV`: table-driven cases for tab, newline, CR (incl. CRLF), backslash (incl. literal `\t` text), quotes-verbatim, empty string, `NULL` literal, header-name escaping, `--skip-column-names`, empty result
- `TestFormatTab`: new regression case asserting TAB's raw pass-through is byte-for-byte unchanged
- `printResult` end-to-end test with `CLI_FORMAT=TSV` (header + escaped rows)
- TSV added to formatter capability, lifecycle, value-format-mode, and ANSI-styling-stripped test matrices; `CLI_FORMAT` set/get tests cover `TSV`/`tsv`
- Verified locally: `go test -short ./...`, `golangci-lint run`, gofumpt/goimports on changed files (the only failures are pre-existing and unrelated: a root-environment permission test and a gofumpt finding in `transaction_manager.go` present on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3)_