### PR TITLE
Support WITH_STATS and WITH_PLAN_AND_STATS query modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Flags:
       --log-level=STRING
       --log-grpc                               Show gRPC logs
       --query-mode=QUERY-MODE                  Mode in which the query must be processed. Allowed values: NORMAL, PLAN,
-                                               PROFILE.
+                                               PROFILE, WITH_STATS, WITH_PLAN_AND_STATS.
       --strong                                 Perform a strong query.
       --read-timestamp=STRING                  Perform a query at the given timestamp.
       --vertexai-project=STRING                Vertex AI project

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -141,7 +141,7 @@ type spannerOptions struct {
 	// Kong only accepts enum validation on optional flags when they are modeled as
 	// pointers. Keeping these as *string preserves "unset" semantics while still
 	// letting Kong validate and document the allowed values natively.
-	QueryMode                 *caseInsensitiveEnumValue `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE." enum:"NORMAL,PLAN,PROFILE"`
+	QueryMode                 *caseInsensitiveEnumValue `name:"query-mode" help:"Mode in which the query must be processed. Allowed values: NORMAL, PLAN, PROFILE, WITH_STATS, WITH_PLAN_AND_STATS." enum:"NORMAL,PLAN,PROFILE,WITH_STATS,WITH_PLAN_AND_STATS"`
 	Strong                    bool                      `name:"strong" help:"Perform a strong query."`
 	ReadTimestamp             string                    `name:"read-timestamp" help:"Perform a query at the given timestamp."`
 	VertexAIProject           string                    `name:"vertexai-project" help:"Vertex AI project"`

--- a/internal/mycli/execute_dml.go
+++ b/internal/mycli/execute_dml.go
@@ -125,17 +125,35 @@ func executeDML(ctx context.Context, session *Session, sql string) (*Result, err
 		CommitTimestamp: result.CommitResponse.CommitTs,
 	}
 
-	return &Result{
+	return buildDMLResult(result, stats, tableHeader, renderedOutput, hasRenderedOutput, session.systemVariables)
+}
+
+// buildDMLResult assembles the final Result for a regular (non-batch) DML
+// statement from its DMLResult and pre-rendered THEN RETURN output.
+//
+// It applies the same CLI_QUERY_MODE-driven presentation rules as SELECT
+// results (see applyQueryModeStatsRendering): WITH_STATS forces stats to
+// render even without CLI_VERBOSE, and WITH_PLAN_AND_STATS additionally
+// appends the query plan collected by runUpdateOnTransaction as a result
+// appendix, when a plan is available.
+func buildDMLResult(dmlResult *DMLResult, stats QueryStats, tableHeader TableHeader, renderedOutput []byte, hasRenderedOutput bool, sysVars *systemVariables) (*Result, error) {
+	result := &Result{
 		IsExecutedDML:         true, // This is a regular DML statement
-		CommitTimestamp:       result.CommitResponse.CommitTs,
-		CommitStats:           result.CommitResponse.CommitStats,
+		CommitTimestamp:       dmlResult.CommitResponse.CommitTs,
+		CommitStats:           dmlResult.CommitResponse.CommitStats,
 		Stats:                 stats,
 		TableHeader:           tableHeader,
 		RenderedOutput:        renderedOutput,
 		HasRenderedOutput:     hasRenderedOutput,
-		AffectedRows:          int(result.Affected),
+		AffectedRows:          int(dmlResult.Affected),
 		HasSQLFormattedValues: false, // DML with THEN RETURN uses regular formatting, not SQL literals
-	}, nil
+	}
+
+	if err := applyQueryModeStatsRendering(result, dmlResult.Plan, sysVars); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func renderDMLReturnedRows(sysVars *systemVariables, tableHeader TableHeader, rows []Row) ([]byte, error) {

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -17,8 +17,26 @@ import (
 	"github.com/apstndb/spanner-mycli/internal/mycli/formatsql"
 	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
 	"github.com/apstndb/spanvalue"
+	"github.com/samber/lo"
 	"google.golang.org/grpc/codes"
 )
+
+// effectiveQueryMode resolves the request-level ExecuteSqlRequest.QueryMode for
+// regular statement execution from the user-specified CLI_QUERY_MODE.
+//
+// The CLI defaults to PROFILE so execution statistics are always available for
+// verbose output, CLI_INLINE_STATS, and EXPLAIN LAST QUERY. CLI_QUERY_MODE=PLAN
+// and PROFILE are dispatched to the EXPLAIN / EXPLAIN ANALYZE execution paths
+// before reaching regular execution, so only WITH_STATS and WITH_PLAN_AND_STATS
+// need to be respected here; other values (nil, NORMAL) keep the PROFILE default.
+func effectiveQueryMode(userMode *sppb.ExecuteSqlRequest_QueryMode) sppb.ExecuteSqlRequest_QueryMode {
+	switch mode := lo.FromPtr(userMode); mode {
+	case sppb.ExecuteSqlRequest_WITH_STATS, sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS:
+		return mode
+	default:
+		return sppb.ExecuteSqlRequest_PROFILE
+	}
+}
 
 // executeSQLWithFormatAndTxn executes SQL with specific format settings and within a given transaction.
 // This is for use within withReadOnlyTransaction callbacks where we already have a transaction.
@@ -180,9 +198,10 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 		return nil, err
 	}
 
-	// Always use ExecuteSqlRequest_PROFILE mode to get execution statistics from Spanner.
+	// Resolve the request-level query mode from CLI_QUERY_MODE; the default is
+	// PROFILE so execution statistics are always available from Spanner.
 	opts := spanner.QueryOptions{
-		Mode:     sppb.ExecuteSqlRequest_PROFILE.Enum(),
+		Mode:     effectiveQueryMode(sysVars.Query.QueryMode).Enum(),
 		Priority: sysVars.Query.RPCPriority,
 	}
 	iter := txn.QueryWithOptions(ctx, stmt, opts)
@@ -213,7 +232,7 @@ func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, s
 		return nil, err
 	}
 
-	iter, roTxn, err := session.RunQueryWithStats(ctx, stmt, false)
+	iter, roTxn, err := session.RunQueryWithStats(ctx, stmt, false, effectiveQueryMode(sysVars.Query.QueryMode))
 	if err != nil {
 		return nil, err
 	}
@@ -320,6 +339,23 @@ func finalizeQueryResult(result *Result, stats map[string]any, roTxn *spanner.Re
 		QueryPlan:     plan,
 		QueryStats:    stats,
 		ReadTimestamp: result.ReadTimestamp,
+	}
+
+	// Reflect the user-specified stats query modes in the presentation:
+	// stats are rendered even without CLI_VERBOSE, and WITH_PLAN_AND_STATS
+	// additionally renders the query plan after the result rows.
+	switch lo.FromPtr(sysVars.Query.QueryMode) {
+	case sppb.ExecuteSqlRequest_WITH_STATS:
+		result.ForceVerbose = true
+	case sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS:
+		result.ForceVerbose = true
+		if plan != nil {
+			appendix, err := buildQueryPlanAppendix(sysVars, plan)
+			if err != nil {
+				return err
+			}
+			result.Appendices = append(result.Appendices, appendix)
+		}
 	}
 	return nil
 }

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -341,20 +341,28 @@ func finalizeQueryResult(result *Result, stats map[string]any, roTxn *spanner.Re
 		ReadTimestamp: result.ReadTimestamp,
 	}
 
-	// Reflect the user-specified stats query modes in the presentation:
-	// stats are rendered even without CLI_VERBOSE, and WITH_PLAN_AND_STATS
-	// additionally renders the query plan after the result rows.
+	return applyQueryModeStatsRendering(result, plan, sysVars)
+}
+
+// applyQueryModeStatsRendering reflects the user-specified stats query modes
+// in the presentation of result: stats are rendered even without
+// CLI_VERBOSE, and WITH_PLAN_AND_STATS additionally renders the query plan as
+// a result appendix, when a plan is available (e.g. absent for the Cloud
+// Spanner Emulator). This is shared between SELECT result construction
+// (finalizeQueryResult) and DML result construction (buildDMLResult) so both
+// honor CLI_QUERY_MODE identically.
+func applyQueryModeStatsRendering(result *Result, plan *sppb.QueryPlan, sysVars *systemVariables) error {
 	switch lo.FromPtr(sysVars.Query.QueryMode) {
 	case sppb.ExecuteSqlRequest_WITH_STATS:
 		result.ForceVerbose = true
 	case sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS:
 		result.ForceVerbose = true
 		if plan != nil {
-			appendix, err := buildQueryPlanAppendix(sysVars, plan)
+			appendices, err := buildQueryPlanAppendix(sysVars, plan)
 			if err != nil {
 				return err
 			}
-			result.Appendices = append(result.Appendices, appendix)
+			result.Appendices = append(result.Appendices, appendices...)
 		}
 	}
 	return nil

--- a/internal/mycli/explain_print_sections.go
+++ b/internal/mycli/explain_print_sections.go
@@ -112,27 +112,40 @@ func buildPlanAppendices(rows []plantree.RowWithPredicates, sections planref.Pri
 	return predicates, appendices
 }
 
-// buildQueryPlanAppendix renders a query plan as a titled result appendix.
-// It is used for CLI_QUERY_MODE='WITH_PLAN_AND_STATS', where the main table is
-// occupied by the query result rows, so the plan tree is rendered after the
-// table reusing the plan tree processing shared with EXPLAIN [ANALYZE].
-func buildQueryPlanAppendix(sysVars *systemVariables, plan *sppb.QueryPlan) (ResultAppendix, error) {
+// buildQueryPlanAppendix renders a query plan as one or more titled result
+// appendices. It is used for CLI_QUERY_MODE='WITH_PLAN_AND_STATS', where the
+// main table is occupied by the query result rows, so the plan tree (and any
+// requested CLI_EXPLAIN_PRINT_SECTIONS sections) are rendered after the table
+// instead of as table columns.
+//
+// It reuses the same section-resolution and appendix-building machinery as
+// EXPLAIN [ANALYZE] (see buildExplainAnalyzeResult): resolveExplainPrintSections
+// resolves CLI_EXPLAIN_PRINT_SECTIONS, and buildPlanAppendices turns the
+// resolved sections into additional appendices (e.g. Predicates, Ordering)
+// following the plan-tree appendix.
+func buildQueryPlanAppendix(sysVars *systemVariables, plan *sppb.QueryPlan) ([]ResultAppendix, error) {
+	sections := resolveExplainPrintSections(sysVars, nil)
+
 	rows, err := processPlanNodes(plan.GetPlanNodes(), sysVars.Display.ParsedInlineStats,
 		sysVars.Display.ExplainFormat, sysVars.Display.ExplainWrapWidth, sysVars.Display.ExplainHangingIndent)
 	if err != nil {
-		return ResultAppendix{}, err
+		return nil, err
 	}
 
 	var maxIDLength int
 	for _, row := range rows {
-		maxIDLength = max(maxIDLength, len(fmt.Sprint(row.ID)))
+		maxIDLength = max(maxIDLength, len(formatPlanRowID(row, sections)))
 	}
 
 	lines := make([]string, 0, len(rows))
 	for _, row := range rows {
-		lines = append(lines, fmt.Sprintf("%*d: %s", maxIDLength, row.ID, row.Text()))
+		lines = append(lines, fmt.Sprintf("%*s: %s", maxIDLength, formatPlanRowID(row, sections), row.Text()))
 	}
-	return ResultAppendix{Title: "Query Plan(identified by ID):", Lines: lines}, nil
+	planAppendix := ResultAppendix{Title: "Query Plan(identified by ID):", Lines: lines}
+
+	_, sectionAppendices := buildPlanAppendices(rows, sections)
+
+	return append([]ResultAppendix{planAppendix}, sectionAppendices...), nil
 }
 
 func formatPlanRowID(row plantree.RowWithPredicates, sections planref.PrintSections) string {

--- a/internal/mycli/explain_print_sections.go
+++ b/internal/mycli/explain_print_sections.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strings"
 
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spannerplan/plantree"
 	planref "github.com/apstndb/spannerplan/plantree/reference"
 )
@@ -109,6 +110,29 @@ func buildPlanAppendices(rows []plantree.RowWithPredicates, sections planref.Pri
 		}
 	}
 	return predicates, appendices
+}
+
+// buildQueryPlanAppendix renders a query plan as a titled result appendix.
+// It is used for CLI_QUERY_MODE='WITH_PLAN_AND_STATS', where the main table is
+// occupied by the query result rows, so the plan tree is rendered after the
+// table reusing the plan tree processing shared with EXPLAIN [ANALYZE].
+func buildQueryPlanAppendix(sysVars *systemVariables, plan *sppb.QueryPlan) (ResultAppendix, error) {
+	rows, err := processPlanNodes(plan.GetPlanNodes(), sysVars.Display.ParsedInlineStats,
+		sysVars.Display.ExplainFormat, sysVars.Display.ExplainWrapWidth, sysVars.Display.ExplainHangingIndent)
+	if err != nil {
+		return ResultAppendix{}, err
+	}
+
+	var maxIDLength int
+	for _, row := range rows {
+		maxIDLength = max(maxIDLength, len(fmt.Sprint(row.ID)))
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, row := range rows {
+		lines = append(lines, fmt.Sprintf("%*d: %s", maxIDLength, row.ID, row.Text()))
+	}
+	return ResultAppendix{Title: "Query Plan(identified by ID):", Lines: lines}, nil
 }
 
 func formatPlanRowID(row plantree.RowWithPredicates, sections planref.PrintSections) string {

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -649,7 +649,10 @@ func TestParseFlagsValidation(t *testing.T) {
 		{arg: "NORMAL", want: "NORMAL"},
 		{arg: "PLAN", want: "PLAN"},
 		{arg: "PROFILE", want: "PROFILE"},
+		{arg: "WITH_STATS", want: "WITH_STATS"},
+		{arg: "WITH_PLAN_AND_STATS", want: "WITH_PLAN_AND_STATS"},
 		{arg: "plan", want: "PLAN"},
+		{arg: "with_stats", want: "WITH_STATS"},
 	} {
 		tests = append(tests, struct {
 			name        string
@@ -1950,7 +1953,7 @@ func TestHelpOutputDocumentsDefaultsAndAllowedValues(t *testing.T) {
 		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt)),
 		fmt.Sprintf("default: %s", strconv.Quote(defaultPrompt2)),
 		"default: ~/.spanner_mycli_history",
-		"Allowed values: NORMAL, PLAN, PROFILE.",
+		"Allowed values: NORMAL, PLAN, PROFILE, WITH_STATS, WITH_PLAN_AND_STATS.",
 		fmt.Sprintf("default: %s", defaultVertexAIModel),
 		fmt.Sprintf("default: %s", defaultVertexAILocation),
 		"Allowed values: POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this flag to leave it unset.",

--- a/internal/mycli/query_mode_test.go
+++ b/internal/mycli/query_mode_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"strings"
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
+)
+
+func TestEffectiveQueryMode(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		desc     string
+		userMode *sppb.ExecuteSqlRequest_QueryMode
+		want     sppb.ExecuteSqlRequest_QueryMode
+	}{
+		{
+			desc:     "unset defaults to PROFILE",
+			userMode: nil,
+			want:     sppb.ExecuteSqlRequest_PROFILE,
+		},
+		{
+			desc:     "NORMAL keeps internal PROFILE default",
+			userMode: sppb.ExecuteSqlRequest_NORMAL.Enum(),
+			want:     sppb.ExecuteSqlRequest_PROFILE,
+		},
+		{
+			desc:     "PLAN is handled by EXPLAIN dispatch, PROFILE here",
+			userMode: sppb.ExecuteSqlRequest_PLAN.Enum(),
+			want:     sppb.ExecuteSqlRequest_PROFILE,
+		},
+		{
+			desc:     "PROFILE stays PROFILE",
+			userMode: sppb.ExecuteSqlRequest_PROFILE.Enum(),
+			want:     sppb.ExecuteSqlRequest_PROFILE,
+		},
+		{
+			desc:     "WITH_STATS is respected",
+			userMode: sppb.ExecuteSqlRequest_WITH_STATS.Enum(),
+			want:     sppb.ExecuteSqlRequest_WITH_STATS,
+		},
+		{
+			desc:     "WITH_PLAN_AND_STATS is respected",
+			userMode: sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum(),
+			want:     sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			if got := effectiveQueryMode(tt.userMode); got != tt.want {
+				t.Errorf("effectiveQueryMode(%v) = %v, want %v", tt.userMode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetCLIQueryModeStatsValues(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		value   string
+		want    sppb.ExecuteSqlRequest_QueryMode
+		wantErr bool
+	}{
+		{value: "WITH_STATS", want: sppb.ExecuteSqlRequest_WITH_STATS},
+		{value: "with_stats", want: sppb.ExecuteSqlRequest_WITH_STATS},
+		{value: "WITH_PLAN_AND_STATS", want: sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS},
+		{value: "WITH_BOGUS", wantErr: true},
+	} {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+			sysVars := newSystemVariablesWithDefaultsForTest()
+			err := sysVars.SetFromSimple("CLI_QUERY_MODE", tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SetFromSimple(CLI_QUERY_MODE, %q) error = nil, want error", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SetFromSimple(CLI_QUERY_MODE, %q) error = %v, want nil", tt.value, err)
+			}
+			if sysVars.Query.QueryMode == nil || *sysVars.Query.QueryMode != tt.want {
+				t.Errorf("Query.QueryMode = %v, want %v", sysVars.Query.QueryMode, tt.want)
+			}
+
+			got, err := sysVars.Get("CLI_QUERY_MODE")
+			if err != nil {
+				t.Fatalf("Get(CLI_QUERY_MODE) error = %v, want nil", err)
+			}
+			if got["CLI_QUERY_MODE"] != tt.want.String() {
+				t.Errorf("SHOW CLI_QUERY_MODE = %q, want %q", got["CLI_QUERY_MODE"], tt.want.String())
+			}
+		})
+	}
+}
+
+// testQueryPlan returns a minimal two-node relational plan for rendering tests.
+func testQueryPlan(t *testing.T) *sppb.QueryPlan {
+	t.Helper()
+	return &sppb.QueryPlan{
+		PlanNodes: []*sppb.PlanNode{
+			{
+				Index:       0,
+				DisplayName: "Serialize Result",
+				Kind:        sppb.PlanNode_RELATIONAL,
+				ChildLinks:  []*sppb.PlanNode_ChildLink{{ChildIndex: 1}},
+			},
+			{
+				Index:       1,
+				DisplayName: "Scan",
+				Kind:        sppb.PlanNode_RELATIONAL,
+				Metadata:    mustNewStruct(map[string]interface{}{"scan_type": "TableScan", "scan_target": "Songs"}),
+			},
+		},
+	}
+}
+
+func TestBuildQueryPlanAppendix(t *testing.T) {
+	t.Parallel()
+
+	sysVars := newSystemVariablesWithDefaultsForTest()
+	appendix, err := buildQueryPlanAppendix(sysVars, testQueryPlan(t))
+	if err != nil {
+		t.Fatalf("buildQueryPlanAppendix() error = %v, want nil", err)
+	}
+
+	if want := "Query Plan(identified by ID):"; appendix.Title != want {
+		t.Errorf("appendix.Title = %q, want %q", appendix.Title, want)
+	}
+	if len(appendix.Lines) != 2 {
+		t.Fatalf("len(appendix.Lines) = %d, want 2; lines: %q", len(appendix.Lines), appendix.Lines)
+	}
+	if !strings.HasPrefix(appendix.Lines[0], "0: ") || !strings.Contains(appendix.Lines[0], "Serialize Result") {
+		t.Errorf("appendix.Lines[0] = %q, want prefix \"0: \" and operator \"Serialize Result\"", appendix.Lines[0])
+	}
+	if !strings.HasPrefix(appendix.Lines[1], "1: ") || !strings.Contains(appendix.Lines[1], "Scan") {
+		t.Errorf("appendix.Lines[1] = %q, want prefix \"1: \" and operator \"Scan\"", appendix.Lines[1])
+	}
+}
+
+func TestFinalizeQueryResultQueryModeRendering(t *testing.T) {
+	t.Parallel()
+
+	stats := map[string]any{
+		"elapsed_time": "1 msec",
+		"cpu_time":     "0.5 msecs",
+	}
+
+	for _, tt := range []struct {
+		desc             string
+		userMode         *sppb.ExecuteSqlRequest_QueryMode
+		plan             *sppb.QueryPlan
+		wantForceVerbose bool
+		wantPlanAppendix bool
+	}{
+		{
+			desc:     "default mode keeps normal rendering",
+			userMode: nil,
+			plan:     nil,
+		},
+		{
+			desc:     "NORMAL keeps normal rendering",
+			userMode: sppb.ExecuteSqlRequest_NORMAL.Enum(),
+			// The internal PROFILE request returns a plan, but NORMAL must not render it.
+			plan: nil,
+		},
+		{
+			desc:             "WITH_STATS renders stats without plan",
+			userMode:         sppb.ExecuteSqlRequest_WITH_STATS.Enum(),
+			plan:             nil,
+			wantForceVerbose: true,
+		},
+		{
+			desc:             "WITH_PLAN_AND_STATS renders stats and plan appendix",
+			userMode:         sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum(),
+			plan:             nil, // set below
+			wantForceVerbose: true,
+			wantPlanAppendix: true,
+		},
+		{
+			desc:             "WITH_PLAN_AND_STATS tolerates missing plan (emulator)",
+			userMode:         sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum(),
+			plan:             nil,
+			wantForceVerbose: true,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			plan := tt.plan
+			if tt.wantPlanAppendix {
+				plan = testQueryPlan(t)
+			}
+
+			sysVars := newSystemVariablesWithDefaultsForTest()
+			sysVars.Query.QueryMode = tt.userMode
+
+			result := &Result{}
+			if err := finalizeQueryResult(result, stats, nil, plan, sysVars, &metrics.ExecutionMetrics{}); err != nil {
+				t.Fatalf("finalizeQueryResult() error = %v, want nil", err)
+			}
+
+			if result.ForceVerbose != tt.wantForceVerbose {
+				t.Errorf("result.ForceVerbose = %v, want %v", result.ForceVerbose, tt.wantForceVerbose)
+			}
+
+			if result.Stats.ElapsedTime != "1 msec" {
+				t.Errorf("result.Stats.ElapsedTime = %q, want %q", result.Stats.ElapsedTime, "1 msec")
+			}
+
+			var gotPlanAppendix bool
+			for _, appendix := range result.Appendices {
+				if appendix.Title == "Query Plan(identified by ID):" {
+					gotPlanAppendix = true
+				}
+			}
+			if gotPlanAppendix != tt.wantPlanAppendix {
+				t.Errorf("plan appendix rendered = %v, want %v; appendices: %+v", gotPlanAppendix, tt.wantPlanAppendix, result.Appendices)
+			}
+
+			if sysVars.LastResult.QueryCache == nil {
+				t.Error("LastResult.QueryCache = nil, want non-nil")
+			}
+		})
+	}
+}

--- a/internal/mycli/query_mode_test.go
+++ b/internal/mycli/query_mode_test.go
@@ -136,10 +136,17 @@ func TestBuildQueryPlanAppendix(t *testing.T) {
 	t.Parallel()
 
 	sysVars := newSystemVariablesWithDefaultsForTest()
-	appendix, err := buildQueryPlanAppendix(sysVars, testQueryPlan(t))
+	appendices, err := buildQueryPlanAppendix(sysVars, testQueryPlan(t))
 	if err != nil {
 		t.Fatalf("buildQueryPlanAppendix() error = %v, want nil", err)
 	}
+
+	// testQueryPlan has no predicates, so the default CLI_EXPLAIN_PRINT_SECTIONS
+	// (basic preset, predicates only) yields no additional section appendices.
+	if len(appendices) != 1 {
+		t.Fatalf("len(appendices) = %d, want 1; appendices: %+v", len(appendices), appendices)
+	}
+	appendix := appendices[0]
 
 	if want := "Query Plan(identified by ID):"; appendix.Title != want {
 		t.Errorf("appendix.Title = %q, want %q", appendix.Title, want)
@@ -152,6 +159,64 @@ func TestBuildQueryPlanAppendix(t *testing.T) {
 	}
 	if !strings.HasPrefix(appendix.Lines[1], "1: ") || !strings.Contains(appendix.Lines[1], "Scan") {
 		t.Errorf("appendix.Lines[1] = %q, want prefix \"1: \" and operator \"Scan\"", appendix.Lines[1])
+	}
+}
+
+// TestBuildQueryPlanAppendixHonorsPrintSections verifies that WITH_PLAN_AND_STATS
+// plan rendering (buildQueryPlanAppendix) reuses resolveExplainPrintSections and
+// buildPlanAppendices, so CLI_EXPLAIN_PRINT_SECTIONS is respected the same way it
+// is for EXPLAIN / EXPLAIN ANALYZE, instead of always ignoring it.
+func TestBuildQueryPlanAppendixHonorsPrintSections(t *testing.T) {
+	t.Parallel()
+
+	// filter.input.json contains a Filter operator with a predicate, and a
+	// FilterScan with a seek condition, so it exercises the Predicates section.
+	plan := loadTestPlan(t, "testdata/plans/filter.input.json")
+
+	for _, tt := range []struct {
+		desc               string
+		explicitEmptyPrint bool // SetFromSimple(CLI_EXPLAIN_PRINT_SECTIONS, "") to suppress all sections
+		wantPredicates     bool
+	}{
+		{
+			desc:           "default basic preset includes a predicates appendix",
+			wantPredicates: true,
+		},
+		{
+			desc:               "CLI_EXPLAIN_PRINT_SECTIONS='' suppresses the predicates appendix",
+			explicitEmptyPrint: true,
+			wantPredicates:     false,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			sysVars := newSystemVariablesWithDefaultsForTest()
+			if tt.explicitEmptyPrint {
+				if err := sysVars.SetFromSimple("CLI_EXPLAIN_PRINT_SECTIONS", ""); err != nil {
+					t.Fatalf("SetFromSimple(CLI_EXPLAIN_PRINT_SECTIONS, \"\") error = %v", err)
+				}
+			}
+
+			appendices, err := buildQueryPlanAppendix(sysVars, plan)
+			if err != nil {
+				t.Fatalf("buildQueryPlanAppendix() error = %v, want nil", err)
+			}
+
+			if len(appendices) == 0 || appendices[0].Title != "Query Plan(identified by ID):" {
+				t.Fatalf("appendices[0] missing or wrong title; appendices: %+v", appendices)
+			}
+
+			var gotPredicates bool
+			for _, appendix := range appendices[1:] {
+				if appendix.Title == "Predicates(identified by ID):" {
+					gotPredicates = true
+				}
+			}
+			if gotPredicates != tt.wantPredicates {
+				t.Errorf("predicates appendix present = %v, want %v; appendices: %+v", gotPredicates, tt.wantPredicates, appendices)
+			}
+		})
 	}
 }
 
@@ -237,6 +302,86 @@ func TestFinalizeQueryResultQueryModeRendering(t *testing.T) {
 
 			if sysVars.LastResult.QueryCache == nil {
 				t.Error("LastResult.QueryCache = nil, want non-nil")
+			}
+		})
+	}
+}
+
+// TestBuildDMLResultQueryModeRendering verifies that DML results honor
+// CLI_QUERY_MODE the same way SELECT results do (finalizeQueryResult):
+// WITH_STATS must force verbose stats rendering, and WITH_PLAN_AND_STATS must
+// additionally append the query plan collected by runUpdateOnTransaction,
+// when a plan is available. Before this fix, buildDMLResult's predecessor
+// ignored CLI_QUERY_MODE entirely for DML.
+func TestBuildDMLResultQueryModeRendering(t *testing.T) {
+	t.Parallel()
+
+	stats := QueryStats{ElapsedTime: "1 msec"}
+
+	for _, tt := range []struct {
+		desc             string
+		userMode         *sppb.ExecuteSqlRequest_QueryMode
+		plan             *sppb.QueryPlan
+		wantForceVerbose bool
+		wantPlanAppendix bool
+	}{
+		{
+			desc:     "default mode keeps normal rendering",
+			userMode: nil,
+		},
+		{
+			desc:     "NORMAL keeps normal rendering",
+			userMode: sppb.ExecuteSqlRequest_NORMAL.Enum(),
+		},
+		{
+			desc:             "WITH_STATS forces verbose stats rendering",
+			userMode:         sppb.ExecuteSqlRequest_WITH_STATS.Enum(),
+			wantForceVerbose: true,
+		},
+		{
+			desc:             "WITH_PLAN_AND_STATS forces verbose stats and appends the plan appendix",
+			userMode:         sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum(),
+			plan:             testQueryPlan(t),
+			wantForceVerbose: true,
+			wantPlanAppendix: true,
+		},
+		{
+			desc:             "WITH_PLAN_AND_STATS tolerates a missing plan (emulator)",
+			userMode:         sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum(),
+			plan:             nil,
+			wantForceVerbose: true,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			sysVars := newSystemVariablesWithDefaultsForTest()
+			sysVars.Query.QueryMode = tt.userMode
+
+			dmlResult := &DMLResult{Affected: 3, Plan: tt.plan}
+			result, err := buildDMLResult(dmlResult, stats, nil, nil, false, sysVars)
+			if err != nil {
+				t.Fatalf("buildDMLResult() error = %v, want nil", err)
+			}
+
+			if !result.IsExecutedDML {
+				t.Error("result.IsExecutedDML = false, want true")
+			}
+			if result.AffectedRows != 3 {
+				t.Errorf("result.AffectedRows = %d, want 3", result.AffectedRows)
+			}
+			if result.ForceVerbose != tt.wantForceVerbose {
+				t.Errorf("result.ForceVerbose = %v, want %v", result.ForceVerbose, tt.wantForceVerbose)
+			}
+
+			var gotPlanAppendix bool
+			for _, appendix := range result.Appendices {
+				if appendix.Title == "Query Plan(identified by ID):" {
+					gotPlanAppendix = true
+				}
+			}
+			if gotPlanAppendix != tt.wantPlanAppendix {
+				t.Errorf("plan appendix rendered = %v, want %v; appendices: %+v", gotPlanAppendix, tt.wantPlanAppendix, result.Appendices)
 			}
 		})
 	}

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -596,8 +596,8 @@ func (s *Session) ClosePendingTransaction() error {
 	return s.txn.ClosePendingTransaction()
 }
 
-func (s *Session) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
-	return s.txn.RunQueryWithStats(ctx, stmt, implicit)
+func (s *Session) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool, mode sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
+	return s.txn.RunQueryWithStats(ctx, stmt, implicit, mode)
 }
 
 func (s *Session) RunQuery(ctx context.Context, stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {

--- a/internal/mycli/session_slow_test.go
+++ b/internal/mycli/session_slow_test.go
@@ -133,7 +133,7 @@ func TestRequestPriority(t *testing.T) {
 			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority); err != nil {
 				t.Fatalf("failed to begin read only transaction: %v", err)
 			}
-			iter, _, err = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"), false)
+			iter, _, err = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"), false, sppb.ExecuteSqlRequest_PROFILE)
 			if err != nil {
 				t.Fatalf("failed to run query with stats: %v", err)
 			}

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -76,6 +76,9 @@ func (s *SelectStatement) Execute(ctx context.Context, session *Session) (*Resul
 	case qm != nil && *qm == sppb.ExecuteSqlRequest_PROFILE:
 		return executeExplainAnalyze(ctx, session, s.Query, enums.ExplainFormatUnspecified, 0, nil)
 	default:
+		// NORMAL, WITH_STATS, and WITH_PLAN_AND_STATS use regular execution;
+		// effectiveQueryMode() resolves the request-level mode and
+		// finalizeQueryResult() adjusts stats/plan rendering.
 		if !inTransaction && session.systemVariables.Query.AutoPartitionMode {
 			return runPartitionedQuery(ctx, session, s.Query)
 		}
@@ -102,6 +105,8 @@ func (s *DmlStatement) Execute(ctx context.Context, session *Session) (*Result, 
 	case lo.FromPtr(session.systemVariables.Query.QueryMode) == sppb.ExecuteSqlRequest_PROFILE:
 		return executeExplainAnalyzeDML(ctx, session, s.Dml, enums.ExplainFormatUnspecified, 0, nil)
 	default:
+		// NORMAL, WITH_STATS, and WITH_PLAN_AND_STATS use regular DML
+		// execution; effectiveQueryMode() resolves the request-level mode.
 		return bufferOrExecuteDML(ctx, session, s.Dml)
 	}
 }

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -322,7 +322,9 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		return nil, err
 	}
 
-	iter, roTxn, err := session.RunQueryWithStats(ctx, stmt, false)
+	// EXPLAIN ANALYZE requires the query plan, so PROFILE is forced here
+	// regardless of CLI_QUERY_MODE.
+	iter, roTxn, err := session.RunQueryWithStats(ctx, stmt, false, sppb.ExecuteSqlRequest_PROFILE)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -418,7 +418,7 @@ func (tm *TransactionManager) GetTransactionFlagsWithLock() (inTransaction bool,
 
 	inTransaction = true
 	inReadWriteTransaction = tm.tc.attrs.mode == transactionModeReadWrite
-	return
+	return inTransaction, inReadWriteTransaction
 }
 
 // TransactionOptionsBuilder helps build transaction options with proper defaults.
@@ -854,6 +854,8 @@ func (tm *TransactionManager) ClosePendingTransaction() error {
 // runQueryWithStatsOnTransaction executes a query on the given transaction with statistics
 // This is a helper function to be used within transaction closures to avoid direct tc access
 // NOTE: This method is called from within transaction callbacks where mu is already held.
+// PROFILE is intentionally hardcoded: this path serves EXPLAIN ANALYZE for DML,
+// which requires the query plan regardless of CLI_QUERY_MODE.
 func (tm *TransactionManager) runQueryWithStatsOnTransaction(ctx context.Context, tx transaction, stmt spanner.Statement, implicit bool) *spanner.RowIterator {
 	opts := tm.queryOptionsLocked(sppb.ExecuteSqlRequest_PROFILE.Enum())
 	opts.LastStatement = implicit
@@ -894,7 +896,9 @@ func (tm *TransactionManager) runUpdateOnTransaction(ctx context.Context, tx *sp
 		return nil, err
 	}
 
-	opts := tm.queryOptionsLocked(sppb.ExecuteSqlRequest_PROFILE.Enum())
+	// Respect a user-specified CLI_QUERY_MODE (WITH_STATS / WITH_PLAN_AND_STATS);
+	// otherwise default to PROFILE to get execution statistics.
+	opts := tm.queryOptionsLocked(effectiveQueryMode(tm.sysVars.Query.QueryMode).Enum())
 	opts.LastStatement = implicit
 
 	// Reset STATEMENT_TAG
@@ -919,15 +923,18 @@ func (tm *TransactionManager) runUpdateOnTransaction(ctx context.Context, tx *sp
 
 // RunQueryWithStats executes a statement with stats either on the running transaction or on the temporal read-only transaction.
 // It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
+// The mode must be a QueryMode that returns execution statistics: PROFILE,
+// WITH_STATS, or WITH_PLAN_AND_STATS. Callers that need the query plan
+// (e.g. EXPLAIN ANALYZE) must pass PROFILE; regular execution should pass
+// effectiveQueryMode() so a user-specified CLI_QUERY_MODE is respected.
 // An error is returned when no database connection is available; this should not
 // happen if DetachedCompatible interface validation is working correctly.
-func (tm *TransactionManager) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
+func (tm *TransactionManager) RunQueryWithStats(ctx context.Context, stmt spanner.Statement, implicit bool, mode sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
 	// Validate that we have a database client for query operations
 	if err := tm.ValidateDatabaseOperation(); err != nil {
 		return nil, nil, err
 	}
 
-	mode := sppb.ExecuteSqlRequest_PROFILE
 	opts := tm.buildQueryOptions(&mode)
 	opts.LastStatement = implicit
 	iter, roTxn := tm.runQueryWithOptions(ctx, stmt, opts)


### PR DESCRIPTION
Fixes #170

## Summary

Adds `WITH_STATS` and `WITH_PLAN_AND_STATS` as first-class `CLI_QUERY_MODE` / `--query-mode` values, and stops unconditionally hardcoding `PROFILE` at the request level where a user-specified mode should be respected.

## Implementation

- **Flag surface**: the `--query-mode` kong enum now accepts `WITH_STATS` and `WITH_PLAN_AND_STATS` (`SET CLI_QUERY_MODE` already accepted them since `QueryModeVar` is backed by the full `sppb.ExecuteSqlRequest_QueryMode_value` map).
- **`effectiveQueryMode()`** (execute_sql.go): resolves the request-level `ExecuteSqlRequest.QueryMode` for regular execution. `WITH_STATS` / `WITH_PLAN_AND_STATS` are sent as-is; all other values (unset, `NORMAL`) keep the internal `PROFILE` default so execution stats remain available for verbose output, `CLI_INLINE_STATS`, and `EXPLAIN LAST QUERY`. `PLAN` / `PROFILE` are dispatched to the EXPLAIN / EXPLAIN ANALYZE paths before regular execution, unchanged.
- **Hardcoded PROFILE removal**: `TransactionManager.RunQueryWithStats` now takes an explicit mode; `executeSQLImplWithTxn` and `runUpdateOnTransaction` (regular DML) use `effectiveQueryMode()`. `EXPLAIN ANALYZE` (query and DML variants) intentionally keeps forcing `PROFILE` because it requires the query plan regardless of `CLI_QUERY_MODE`.
- **Rendering** (`finalizeQueryResult`, shared by buffered and both streaming paths):
  - `WITH_STATS`: result rows + query stats (`ForceVerbose`), no plan (none is returned on the wire).
  - `WITH_PLAN_AND_STATS`: result rows + query stats + the query plan rendered as a result appendix (`Query Plan(identified by ID):`) via `buildQueryPlanAppendix()`, reusing the plan tree processing shared with `EXPLAIN [ANALYZE]` (honors `CLI_EXPLAIN_FORMAT`, `CLI_EXPLAIN_WRAP_WIDTH`, `CLI_INLINE_STATS`). A missing plan (e.g. emulator) is tolerated.
- `README.md` help section regenerated with `make docs-update`.

## Tests

- `TestEffectiveQueryMode`: table-driven resolution coverage for all six input states.
- `TestSetCLIQueryModeStatsValues`: `SET CLI_QUERY_MODE` parsing (incl. case-insensitivity), SHOW output, and rejection of invalid values.
- `TestFinalizeQueryResultQueryModeRendering`: stats-only display (`ForceVerbose`, no plan appendix) for `WITH_STATS`; plan appendix for `WITH_PLAN_AND_STATS`; unchanged rendering for default/`NORMAL`; missing-plan tolerance.
- `TestBuildQueryPlanAppendix`: appendix title/line rendering from a plan fixture.
- `--query-mode` flag tests and help-output assertions extended with the new values.

Note: Docker is unavailable in the development environment, so emulator-backed tests (`session_slow_test.go`, integration tests) could not run locally and must be validated by CI. `TestSystemVariables_ProtoDescriptorFiles/permission_denied_file` fails locally only because the environment runs as root (pre-existing on main, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf5L7KM76D3GkTacNDWcg3)_