### PR TITLE
Migrate to context-first developerknowledge-go API (v0.2.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/alecthomas/kong v1.15.0
 	github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c
-	github.com/apstndb/developerknowledge-go v0.1.2
+	github.com/apstndb/developerknowledge-go v0.1.3-0.20260705140616-7dd29210f40a
 	github.com/apstndb/genaischema v0.2.0
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe
 	github.com/apstndb/go-tabwrap v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -2471,8 +2471,8 @@ github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2
 github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4fPBx7Q=
 github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c h1:YDz0azy3d3QpwAf65m7y7EHn0G8dGG07ukYrIJK3pPQ=
 github.com/apstndb/adcplus v0.0.0-20241227140857-9f127090f91c/go.mod h1:6rE+3Wp06EaBJAUacxlXON90ZbvaFhNkg/4QCyxAepY=
-github.com/apstndb/developerknowledge-go v0.1.2 h1:ejpPuozEUEl6W7kCAeK3N9OzwfZEqSuTABckOSsNA9A=
-github.com/apstndb/developerknowledge-go v0.1.2/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
+github.com/apstndb/developerknowledge-go v0.1.3-0.20260705140616-7dd29210f40a h1:n70M+x0GkOsz+0FgTjF6GbcyComh78rWk2XPXFKf//M=
+github.com/apstndb/developerknowledge-go v0.1.3-0.20260705140616-7dd29210f40a/go.mod h1:SkrYUXrudPdwg//GnGSnLsjYilMI+9n2+TGUuHo/CcE=
 github.com/apstndb/genaischema v0.2.0 h1:Xy19ye4xUjU46ZGC7iHLQ6hCKNCin1+IqMCpjel+gfo=
 github.com/apstndb/genaischema v0.2.0/go.mod h1:qUY4LNMs5MeXLcbY3Ic4cW5I1iMnj9USzTTDf1BeezU=
 github.com/apstndb/gh-dev-tools v0.0.0-20250726094924-b386827f58e6 h1:Say3K7FyeOgvYi8/lsn2iDuFmKXA35XlPBNMHIptdo8=

--- a/internal/mycli/statements_llm_tooluse.go
+++ b/internal/mycli/statements_llm_tooluse.go
@@ -257,16 +257,11 @@ func newDevKnowledgeClient(apiKey string) *devKnowledgeClient {
 }
 
 func (c *devKnowledgeClient) doGet(ctx context.Context, reqURL string) ([]byte, error) {
-	client := *c.client
-	client.Context = ctx
-	return client.DoGet(reqURL)
+	return c.client.DoGet(ctx, reqURL)
 }
 
 func (c *devKnowledgeClient) batchGetDocuments(ctx context.Context, names []string) ([]dkapi.Document, error) {
-	client := *c.client
-	client.BaseURL = c.baseURL
-	client.Context = ctx
-	return client.BatchGetDocuments(names)
+	return c.client.BatchGetDocuments(ctx, names)
 }
 
 // devKnowledgeDocSearcher implements document operations using the Developer Knowledge REST API.


### PR DESCRIPTION
## Summary
- Bump `github.com/apstndb/developerknowledge-go` to the v0.2.0 main-line pseudo-version (`v0.1.3-0.20260705140616-7dd29210f40a`) until the `v0.2.0` tag is published
- Remove the `Client` copy hack that set `Context`; call `DoGet` and `BatchGetDocuments` with per-request context

Part of apstndb/developerknowledge-go#9.

## Test plan
- [x] `go test -race ./internal/mycli/ -run DevKnowledge`


Made with [Cursor](https://cursor.com)