### PR TITLE
Fix SET fuzzy completion regressions from the SET PARAM precedence change

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -49,7 +49,7 @@ const (
 	fuzzyCompleteModel
 	fuzzyCompleteSchema
 	fuzzyCompleteParam
-	fuzzyCompleteSetKeyword
+	fuzzyCompleteSetTarget
 )
 
 func (t fuzzyCompletionType) String() string {
@@ -80,8 +80,8 @@ func (t fuzzyCompletionType) String() string {
 		return "schema"
 	case fuzzyCompleteParam:
 		return "param"
-	case fuzzyCompleteSetKeyword:
-		return "set_keyword"
+	case fuzzyCompleteSetTarget:
+		return "set_target"
 	default:
 		return fmt.Sprintf("unhandled fuzzyCompletionType: %d", t)
 	}
@@ -947,8 +947,13 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 			return &SetParamTypeStatement{Name: groups["name"], Type: groups["type"]}, nil
 		},
 		Completion: []fuzzyArgCompletion{{
-			// Name completion: SET PARAM [<partial_name>]
-			PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+PARAM\b\s*([^\s=]*)$`),
+			// Name completion: SET PARAM <partial_name>. Whitespace after
+			// PARAM is required: without it (input "SET PARAM"), the argument
+			// group would start immediately after the M and the completion
+			// would be glued into "SET PARAMname". Bare "SET PARAM" instead
+			// falls through to the generic SET target completion, which
+			// re-completes the PARAM token itself.
+			PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+PARAM\s+([^\s=]*)$`),
 			CompletionType: fuzzyCompleteParam,
 			Suffix:         " ",
 		}},
@@ -966,20 +971,19 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		},
 		Completion: []fuzzyArgCompletion{
 			{
-				// Discover query-parameter completion via the reserved keyword `PARAM`.
-				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+()$`),
-				CompletionType: fuzzyCompleteSetKeyword,
-				Suffix:         " ",
-			},
-			{
 				// Value completion: SET <name> = <partial_value>
 				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+(\S+)\s*=\s*(\S*)$`),
 				CompletionType: fuzzyCompleteVariableValue,
 			},
 			{
-				// Name completion: SET <partial_name>
+				// Target completion: SET <partial_name>. Candidates are the
+				// system variables plus the PARAM keyword in one list, so
+				// bare `SET ` offers everything and a partial "PARAM" token
+				// (including bare "SET PARAM" without a trailing space)
+				// completes to "SET PARAM ". The PARAM item overrides the
+				// " = " suffix per-item (fzfItem.Suffix).
 				PrefixPattern:  regexp.MustCompile(`(?i)^\s*SET\s+([^\s=]*)$`),
-				CompletionType: fuzzyCompleteVariable,
+				CompletionType: fuzzyCompleteSetTarget,
 				Suffix:         " = ",
 			},
 		},

--- a/internal/mycli/fuzzy_finder.go
+++ b/internal/mycli/fuzzy_finder.go
@@ -69,6 +69,10 @@ func (e *fuzzyCacheEntry) valid(session *Session, checkSchema bool) bool {
 type fzfItem struct {
 	Value string // inserted into buffer
 	Label string // displayed/searched in fzf; empty means use Value
+	// Suffix, when non-empty, overrides the completion entry's Suffix for
+	// this item. Used when one candidate list mixes insertion shapes (e.g.
+	// SET completion: variables insert "<name> = " but PARAM inserts "PARAM ").
+	Suffix string
 }
 
 // toFzfItems converts a plain string slice to fzfItems where Value == Label.
@@ -140,8 +144,8 @@ func (f *fuzzyFinderCommand) Call(ctx context.Context, B *readline.Buffer) readl
 
 	var selected string
 	if result.completionType != 0 {
-		// Argument completion: insert the candidate with optional suffix
-		selected = chosen + result.suffix
+		// Argument completion: insert the candidate with optional suffix.
+		selected = chosen + resolveCompletionSuffix(candidates, chosen, result.suffix)
 	} else {
 		// Statement name completion: insert the fixed prefix text.
 		// No-arg statements (no trailing space) get a semicolon for immediate submit.
@@ -162,6 +166,20 @@ func (f *fuzzyFinderCommand) Call(ctx context.Context, B *readline.Buffer) readl
 	B.InsertAndRepaint(selected)
 
 	return readline.CONTINUE
+}
+
+// resolveCompletionSuffix returns the suffix to append after the chosen
+// candidate: the candidate's own Suffix when set, otherwise the completion
+// entry's default. Per-item suffixes let one candidate list mix insertion
+// shapes (SET completion: variables take " = ", the PARAM/LOCAL keywords
+// take " ").
+func resolveCompletionSuffix(candidates []fzfItem, chosen, defaultSuffix string) string {
+	for _, c := range candidates {
+		if c.Value == chosen && c.Suffix != "" {
+			return c.Suffix
+		}
+	}
+	return defaultSuffix
 }
 
 // fuzzyContextResult holds the detected context, the argument prefix typed so far,
@@ -246,8 +264,8 @@ func completionHeader(ct fuzzyCompletionType) string {
 		return "Schemas"
 	case fuzzyCompleteParam:
 		return "Query Parameters"
-	case fuzzyCompleteSetKeyword:
-		return "Query Parameter Keywords"
+	case fuzzyCompleteSetTarget:
+		return "System Variables / PARAM"
 	default:
 		return "Statements"
 	}
@@ -776,8 +794,8 @@ func (f *fuzzyFinderCommand) fetchCandidates(ctx context.Context, ct fuzzyComple
 		return f.fetchSchemaCandidates(ctx)
 	case fuzzyCompleteParam:
 		return f.fetchParamCandidates(), nil
-	case fuzzyCompleteSetKeyword:
-		return toFzfItems([]string{"PARAM"}), nil
+	case fuzzyCompleteSetTarget:
+		return f.fetchSetTargetCandidates(), nil
 	default:
 		return nil, nil
 	}
@@ -805,6 +823,23 @@ func (f *fuzzyFinderCommand) fetchDatabaseCandidates(ctx context.Context) ([]fzf
 		}
 	}
 	return items, nil
+}
+
+// fetchSetTargetCandidates returns the candidates for `SET <target>`: the
+// PARAM keyword (query parameter definition) followed by all system variable
+// names. PARAM carries a per-item suffix because it is followed by a name,
+// not by " = " like variables. Keeping both in one list preserves variable
+// completion on bare `SET ` (a single-candidate list would be auto-accepted
+// by fzf's --select-1 with no picker shown) while keeping PARAM discoverable.
+func (f *fuzzyFinderCommand) fetchSetTargetCandidates() []fzfItem {
+	items := []fzfItem{
+		{Value: "PARAM", Label: "PARAM (define query parameter)", Suffix: " "},
+		{Value: "LOCAL", Label: "LOCAL (transaction-scoped SET)", Suffix: " "},
+	}
+	for _, name := range f.fetchVariableCandidates() {
+		items = append(items, fzfItem{Value: name})
+	}
+	return items
 }
 
 // fetchVariableCandidates returns sorted system variable names from the registry.

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -69,11 +69,16 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantArgPrefix:      "",
 			wantArgStartPos:    6,
 		},
-		// Argument completion: SET → query-parameter keyword or variable (with " = " suffix)
+		// Argument completion: SET → one merged candidate list (system
+		// variables with " = " suffix, plus the PARAM/LOCAL keywords with a
+		// per-item " " suffix). A separate keyword-only completion for bare
+		// `SET ` would have exactly one candidate, which fzf's --select-1
+		// auto-accepts without showing a picker (regression: `SET ` + Ctrl+T
+		// force-inserted `SET PARAM `).
 		{
 			name:               "SET with partial name",
 			input:              "SET CLI_",
-			wantCompletionType: fuzzyCompleteVariable,
+			wantCompletionType: fuzzyCompleteSetTarget,
 			wantArgPrefix:      "CLI_",
 			wantArgStartPos:    4,
 			wantSuffix:         " = ",
@@ -81,15 +86,15 @@ func TestDetectFuzzyContext(t *testing.T) {
 		{
 			name:               "SET with no name",
 			input:              "SET ",
-			wantCompletionType: fuzzyCompleteSetKeyword,
+			wantCompletionType: fuzzyCompleteSetTarget,
 			wantArgPrefix:      "",
 			wantArgStartPos:    4,
-			wantSuffix:         " ",
+			wantSuffix:         " = ",
 		},
 		{
 			name:               "set lowercase",
 			input:              "set cli_f",
-			wantCompletionType: fuzzyCompleteVariable,
+			wantCompletionType: fuzzyCompleteSetTarget,
 			wantArgPrefix:      "cli_f",
 			wantArgStartPos:    4,
 			wantSuffix:         " = ",
@@ -516,12 +521,16 @@ func TestDetectFuzzyContext(t *testing.T) {
 		},
 		// Argument completion: SET PARAM → param
 		{
-			name:               "SET PARAM",
+			// Without a trailing space the PARAM token itself is still being
+			// typed: it is re-completed as a SET target from position 4
+			// (completing a param name from position 9 would glue it into
+			// "SET PARAMname").
+			name:               "SET PARAM without trailing space re-completes the keyword",
 			input:              "SET PARAM",
-			wantCompletionType: fuzzyCompleteParam,
-			wantArgPrefix:      "",
-			wantArgStartPos:    9,
-			wantSuffix:         " ",
+			wantCompletionType: fuzzyCompleteSetTarget,
+			wantArgPrefix:      "PARAM",
+			wantArgStartPos:    4,
+			wantSuffix:         " = ",
 		},
 		{
 			name:               "SET PARAM with trailing space",
@@ -548,17 +557,17 @@ func TestDetectFuzzyContext(t *testing.T) {
 			wantSuffix:         " ",
 		},
 		{
-			name:               "SET PARAMETER stays variable completion",
+			name:               "SET PARAMETER stays target completion",
 			input:              "SET PARAMETER",
-			wantCompletionType: fuzzyCompleteVariable,
+			wantCompletionType: fuzzyCompleteSetTarget,
 			wantArgPrefix:      "PARAMETER",
 			wantArgStartPos:    4,
 			wantSuffix:         " = ",
 		},
 		{
-			name:               "SET PARAM_FOO stays variable completion",
+			name:               "SET PARAM_FOO stays target completion",
 			input:              "SET PARAM_FOO",
-			wantCompletionType: fuzzyCompleteVariable,
+			wantCompletionType: fuzzyCompleteSetTarget,
 			wantArgPrefix:      "PARAM_FOO",
 			wantArgStartPos:    4,
 			wantSuffix:         " = ",
@@ -1120,6 +1129,60 @@ func TestRunFzfFilter_SQLSkeletons(t *testing.T) {
 				assert.Contains(t, results, want)
 			}
 		})
+	}
+}
+
+// TestFetchSetTargetCandidates verifies the merged SET completion list:
+// the PARAM and LOCAL keywords (with per-item " " suffix) followed by all
+// system variables (no per-item suffix; the entry default " = " applies).
+// A keyword-only list would be auto-accepted by fzf's --select-1 with no
+// picker, which is the regression this list shape prevents.
+func TestFetchSetTargetCandidates(t *testing.T) {
+	t.Parallel()
+
+	sysVars := newSystemVariablesWithDefaults()
+	f := &fuzzyFinderCommand{cli: &Cli{SystemVariables: &sysVars}}
+
+	items := f.fetchSetTargetCandidates()
+	if len(items) < 3 {
+		t.Fatalf("got %d candidates, want keywords plus variables", len(items))
+	}
+	if items[0].Value != "PARAM" || items[0].Suffix != " " {
+		t.Errorf("items[0] = %+v, want PARAM with per-item suffix %q", items[0], " ")
+	}
+	if items[1].Value != "LOCAL" || items[1].Suffix != " " {
+		t.Errorf("items[1] = %+v, want LOCAL with per-item suffix %q", items[1], " ")
+	}
+	sawVariable := false
+	for _, it := range items[2:] {
+		if it.Suffix != "" {
+			t.Errorf("variable item %q has per-item suffix %q, want none (entry default applies)", it.Value, it.Suffix)
+		}
+		if it.Value == "CLI_FORMAT" {
+			sawVariable = true
+		}
+	}
+	if !sawVariable {
+		t.Errorf("candidates do not include system variable CLI_FORMAT")
+	}
+}
+
+// TestResolveCompletionSuffix verifies per-item suffix override resolution.
+func TestResolveCompletionSuffix(t *testing.T) {
+	t.Parallel()
+
+	candidates := []fzfItem{
+		{Value: "PARAM", Suffix: " "},
+		{Value: "CLI_FORMAT"},
+	}
+	if got := resolveCompletionSuffix(candidates, "PARAM", " = "); got != " " {
+		t.Errorf("PARAM suffix = %q, want %q", got, " ")
+	}
+	if got := resolveCompletionSuffix(candidates, "CLI_FORMAT", " = "); got != " = " {
+		t.Errorf("CLI_FORMAT suffix = %q, want %q (entry default)", got, " = ")
+	}
+	if got := resolveCompletionSuffix(candidates, "not-in-list", " = "); got != " = " {
+		t.Errorf("unknown suffix = %q, want %q (entry default)", got, " = ")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two Ctrl+T regressions introduced by d7ba418 (SET PARAM completion precedence):

1. **Bare `SET ` lost variable completion.** The first-priority completion for `SET ` had exactly one candidate (`PARAM`), and the fuzzy finder always passes `--select-1`, so fzf auto-accepted it without showing a picker: typing `SET ` + Ctrl+T force-inserted `SET PARAM `, and the system-variable list became unreachable.
2. **`SET PARAM` without a trailing space glued the completion.** The param-name completion pattern matched with the argument group starting immediately after the `M`, so selecting a name produced `SET PARAMmy_param`. The existing test codified this position (`wantArgStartPos: 9`).

## Fix

- `SET <partial>` now completes from **one merged candidate list**: the `PARAM` and `LOCAL` keywords followed by all system variables. Since the list always has multiple candidates, `--select-1` no longer bypasses the picker on bare `SET `, while a distinctive partial token (e.g. `SET PA`) still auto-accepts as before.
- New per-item `Suffix` on `fzfItem` (resolved by `resolveCompletionSuffix`): keywords insert a trailing space (`SET PARAM `), variables keep the entry-level `" = "` (`SET CLI_FORMAT = `).
- The `SET PARAM <name>` completion now requires whitespace after `PARAM`; bare `SET PARAM` falls through to the merged target completion, which re-completes the keyword token itself from position 4 (yielding `SET PARAM ` on selection instead of gluing).
- Corrected the test that codified the glued position and added coverage for the merged candidate list and per-item suffix resolution.

Pre-release item 1 from the v0.32.0 release plan (FEEDBACK.md section 12).

## Validation

- `make check` passes locally (full suite, lint, fmt).
- `TestDetectFuzzyContext` covers: bare `SET `, partial variable, `SET PARAM` (no space), `SET PARAM ` (with space), `SET PARAMETER`/`SET PARAM_FOO` non-keyword tokens, lowercase variants.
