### PR TITLE
fix: close remaining READONLY guard gaps before v0.32.0

### DIFF
--- a/internal/mycli/readonly_guard_test.go
+++ b/internal/mycli/readonly_guard_test.go
@@ -27,6 +27,7 @@ func TestReadOnlyGuardCoversBatchStatements(t *testing.T) {
 		{desc: "batch DDL", stmt: &BulkDdlStatement{Ddls: []string{"CREATE TABLE t (id INT64) PRIMARY KEY (id)"}}},
 		{desc: "batch DML", stmt: &BatchDMLStatement{DMLs: []spanner.Statement{spanner.NewStatement("UPDATE t SET id = 1 WHERE TRUE")}}},
 		{desc: "CREATE DATABASE", stmt: &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d"}},
+		{desc: "SYNC PROTO BUNDLE", stmt: &SyncProtoStatement{UpsertPaths: []string{"examples.ProtoType"}}},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
@@ -38,5 +39,33 @@ func TestReadOnlyGuardCoversBatchStatements(t *testing.T) {
 				t.Errorf("%s in READONLY mode: got error %v, want errReadOnly", tt.desc, err)
 			}
 		})
+	}
+}
+
+// TestReadOnlyGuardPreservesActiveBatch verifies RUN BATCH rejects in READONLY
+// mode without consuming the buffered batch (issue from FEEDBACK.md 10.2 item 5).
+func TestReadOnlyGuardPreservesActiveBatch(t *testing.T) {
+	t.Parallel()
+
+	session := newSessionForLocalVarTest(t)
+	if err := session.batch.Start(batchModeDDL); err != nil {
+		t.Fatalf("batch.Start: %v", err)
+	}
+	bulk, ok := session.batch.Current().(*BulkDdlStatement)
+	if !ok {
+		t.Fatalf("batch.Current() = %T, want *BulkDdlStatement", session.batch.Current())
+	}
+	bulk.Ddls = append(bulk.Ddls, "CREATE TABLE t (id INT64) PRIMARY KEY (id)")
+	session.systemVariables.Transaction.ReadOnly = true
+
+	_, err := session.ExecuteStatement(t.Context(), &RunBatchStatement{})
+	if !errors.Is(err, errReadOnly) {
+		t.Fatalf("RUN BATCH in READONLY mode: got %v, want errReadOnly", err)
+	}
+	if !session.batch.IsActive() {
+		t.Fatal("RUN BATCH readonly rejection should leave the active batch intact")
+	}
+	if len(bulk.Ddls) != 1 {
+		t.Fatalf("batch DDLs = %d, want 1", len(bulk.Ddls))
 	}
 }

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -986,13 +986,10 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 	}()
 	if _, ok := stmt.(MutationStatement); ok {
 		result := &Result{}
-		_, err := s.DetermineTransaction(ctx)
-		if err != nil {
+		if err := s.failStatementIfReadOnly(); err != nil {
 			return result, err
 		}
-
-		err = s.failStatementIfReadOnly()
-		if err != nil {
+		if _, err := s.DetermineTransaction(ctx); err != nil {
 			return result, err
 		}
 		return stmt.Execute(ctx, s)

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -63,6 +63,7 @@ var (
 	_ MutationStatement = (*PartitionedDmlStatement)(nil)
 	_ MutationStatement = (*BulkDdlStatement)(nil)
 	_ MutationStatement = (*BatchDMLStatement)(nil)
+	_ MutationStatement = (*SyncProtoStatement)(nil)
 )
 
 // DetachedCompatible is a marker interface for statements that can run in Detached session mode (admin operation only mode).

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -633,6 +633,9 @@ func (s *RunBatchStatement) Execute(ctx context.Context, session *Session) (*Res
 }
 
 func runBatch(ctx context.Context, session *Session) (*Result, error) {
+	if err := session.failStatementIfReadOnly(); err != nil {
+		return nil, err
+	}
 	batch, err := session.batch.TakeForExecution()
 	if err != nil {
 		return nil, err

--- a/internal/mycli/statements_proto.go
+++ b/internal/mycli/statements_proto.go
@@ -38,6 +38,8 @@ type SyncProtoStatement struct {
 	DeletePaths []string
 }
 
+func (SyncProtoStatement) isMutationStatement() {}
+
 func (s *SyncProtoStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	_, fds, err := session.GetDatabaseSchema(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes the remaining READONLY-mode gaps called out in the v0.32.0 release prep review (FEEDBACK.md section 12):

- **SYNC PROTO BUNDLE** now implements `isMutationStatement`, so direct DDL sync is blocked under `--readonly` (with a compile-time assertion).
- **RUN BATCH** checks `failStatementIfReadOnly()` before `TakeForExecution()`, so a rejected run no longer destroys the buffered batch.
- **Mutation guard ordering** checks READONLY before `DetermineTransaction()` to avoid starting transaction work that will be rejected.

## Test plan

- [x] `make check`
- [x] `go test -run TestReadOnlyGuard ./internal/mycli/ -v`


Made with [Cursor](https://cursor.com)