### PR TITLE
ci: align ko container version string with goreleaser releases

### DIFF
--- a/.github/workflows/ko.yml
+++ b/.github/workflows/ko.yml
@@ -23,5 +23,6 @@ jobs:
           go-version-file: go.mod
       - uses: ko-build/setup-ko@v0.10
       - run: |
-          tag=$(echo ${{ github.ref }} | cut -c11-)
-          ko build -t latest,${tag} --bare
+          tag="${GITHUB_REF#refs/tags/}"
+          export VERSION="${tag#v}"
+          ko build -t latest,"${tag}" --bare

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -9,5 +9,5 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X main.version={{.Git.Tag}}
+      - -X main.version={{.Env.VERSION}}
       - -X main.installFrom=ghcr.io/apstndb/spanner-mycli:{{.Git.Tag}}


### PR DESCRIPTION
## Summary

Aligns the version string embedded in ko-published container images with goreleaser release binaries:

- `.ko.yaml` now injects `main.version` from `{{.Env.VERSION}}` instead of `{{.Git.Tag}}`.
- The `ko` publish workflow exports `VERSION` without the `v` prefix (e.g. `0.32.0`), matching goreleaser's `{{.Version}}`.

Image tags and `installFrom` still use the full git tag (`v0.32.0`).

## Test plan

- [x] `make check`
- [ ] Smoke-check on the first real tag build: `docker run ghcr.io/apstndb/spanner-mycli:<tag> --version`


Made with [Cursor](https://cursor.com)