### PR TITLE
ci: do not move the latest container tag on prerelease tags

### DIFF
--- a/.github/workflows/ko.yml
+++ b/.github/workflows/ko.yml
@@ -25,4 +25,9 @@ jobs:
       - run: |
           tag="${GITHUB_REF#refs/tags/}"
           export VERSION="${tag#v}"
-          ko build -t latest,"${tag}" --bare
+          # Prerelease tags (v1.2.3-alpha.1 etc.) must not move the latest tag.
+          case "${tag}" in
+            *-*) tags="${tag}" ;;
+            *)   tags="latest,${tag}" ;;
+          esac
+          ko build -t "${tags}" --bare


### PR DESCRIPTION
A v0.32.0-alpha.1-style tag would have republished ghcr `latest` pointing at the prerelease image. Tag `latest` only for final releases (tags without a hyphen). Prerequisite for cutting a verification prerelease before v0.32.0. YAML parse-checked.