### PR TITLE
Harden doc-cache BatchGet against corrupt cache entries

### DIFF
--- a/internal/mycli/doc_cache.go
+++ b/internal/mycli/doc_cache.go
@@ -115,6 +115,18 @@ func (c *docCache) decompress(data []byte) (string, error) {
 	return string(b), nil
 }
 
+// decompressStaleEntry decompresses a stale cache entry and deletes it on corruption.
+// Caller must hold c.mu.
+func (c *docCache) decompressStaleEntry(name string, entry docCacheEntry) (string, error) {
+	content, err := c.decompress(entry.data)
+	if err != nil {
+		delete(c.entries, name)
+		slog.Warn("Failed to decompress stale cached document, discarding entry", "name", name, "error", err)
+		return "", err
+	}
+	return content, nil
+}
+
 // isFresh returns whether an entry is within TTL.
 func (c *docCache) isFresh(e docCacheEntry) bool {
 	if e.fetchedAt.IsZero() {
@@ -188,7 +200,11 @@ func (c *docCache) Get(ctx context.Context, name string) (string, bool) {
 			c.putLocked(name, content)
 			return content, true
 		}
-		slog.Debug("API refresh failed, using stale cache", "name", name, "error", err)
+		if exists {
+			slog.Debug("API refresh failed, using stale cache", "name", name, "error", err)
+		} else {
+			slog.Debug("API refresh failed", "name", name, "error", err)
+		}
 	}
 
 	// Return stale content if available
@@ -224,6 +240,9 @@ func (c *docCache) BatchGet(ctx context.Context, names []string) []DocResult {
 				results = append(results, DocResult{Name: name, Content: content})
 				continue
 			}
+			delete(c.entries, name)
+			exists = false
+			slog.Warn("Failed to decompress cached document, attempting refresh", "name", name, "error", err)
 		}
 		toFetch = append(toFetch, name)
 		if exists {
@@ -252,7 +271,7 @@ func (c *docCache) BatchGet(ctx context.Context, names []string) []DocResult {
 					continue
 				}
 				if stale, ok := staleEntries[name]; ok {
-					if content, err := c.decompress(stale.data); err == nil {
+					if content, err := c.decompressStaleEntry(name, stale); err == nil {
 						results = append(results, DocResult{Name: name, Content: content})
 					}
 				}
@@ -274,7 +293,7 @@ func (c *docCache) BatchGet(ctx context.Context, names []string) []DocResult {
 		}
 		// Use stale entry if available
 		if stale, ok := staleEntries[name]; ok {
-			if content, err := c.decompress(stale.data); err == nil {
+			if content, err := c.decompressStaleEntry(name, stale); err == nil {
 				results = append(results, DocResult{Name: name, Content: content})
 			}
 		}

--- a/internal/mycli/doc_cache_test.go
+++ b/internal/mycli/doc_cache_test.go
@@ -384,6 +384,75 @@ func TestDocCache_BatchGet_FallbackToIndividual(t *testing.T) {
 	}
 }
 
+func TestDocCache_BatchGet_FreshEntryCorruptDataRefetchesFromAPI(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t,
+		withDocBatchFetcher(func(_ context.Context, names []string) ([]DocResult, error) {
+			return []DocResult{{Name: "documents/test/doc", Content: "fresh from API"}}, nil
+		}),
+	)
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c.entries["documents/test/doc"] = docCacheEntry{
+		data:      []byte("bad zstd data"),
+		fetchedAt: now.Add(-time.Minute),
+	}
+
+	results := c.BatchGet(context.Background(), []string{"documents/test/doc"})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Content != "fresh from API" {
+		t.Errorf("content = %q", results[0].Content)
+	}
+	if _, exists := c.entries["documents/test/doc"]; !exists {
+		t.Fatal("expected refreshed cache entry")
+	}
+}
+
+func TestDocCache_BatchGet_FreshEntryCorruptDataWithoutAPIReturnsMiss(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newTestCache(t,
+		withNowFunc(func() time.Time { return now }),
+	)
+	c.entries["documents/test/doc"] = docCacheEntry{
+		data:      []byte("bad zstd data"),
+		fetchedAt: now.Add(-time.Minute),
+	}
+
+	results := c.BatchGet(context.Background(), []string{"documents/test/doc"})
+	if len(results) != 0 {
+		t.Fatalf("got %d results, want 0", len(results))
+	}
+	if _, exists := c.entries["documents/test/doc"]; exists {
+		t.Fatal("expected corrupted cache entry to be deleted")
+	}
+}
+
+func TestDocCache_BatchGet_StaleCorruptEntryDeletedOnFetchFailure(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	c := newTestCache(t,
+		withCacheTTL(1*time.Hour),
+		withNowFunc(func() time.Time { return now }),
+		withDocFetcher(func(_ context.Context, _ string) (string, error) {
+			return "", fmt.Errorf("API down")
+		}),
+	)
+	c.entries["documents/test/doc"] = docCacheEntry{
+		data:      []byte("bad zstd data"),
+		fetchedAt: now.Add(-2 * time.Hour),
+	}
+
+	results := c.BatchGet(context.Background(), []string{"documents/test/doc"})
+	if len(results) != 0 {
+		t.Fatalf("got %d results, want 0", len(results))
+	}
+	if _, exists := c.entries["documents/test/doc"]; exists {
+		t.Fatal("expected corrupted stale cache entry to be deleted")
+	}
+}
+
 func TestDocCache_BatchGet_StaleOnFetchFailure(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- Apply the same corrupt-entry handling from `Get` to `BatchGet`: delete bad fresh entries and refetch, discard corrupt stale fallbacks.
- Add `decompressStaleEntry` helper to centralize stale-entry corruption cleanup.
- Fix misleading "using stale cache" log when `Get` refresh fails after a corrupt fresh entry was deleted.

Addresses FEEDBACK.md 10.2 item 8.

## Test plan
- [x] `make check`
- [x] New unit tests for BatchGet corrupt fresh/stale entry paths


Made with [Cursor](https://cursor.com)