### PR TITLE
Fix dev-docs inaccuracies for build tags and gh-helper

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -47,9 +47,10 @@ jobs:
         with:
           version: v2.4
           args: --timeout=5m
-      # Compile-only guard: tag-gated test files (integration, skip_slow_test)
-      # are not built by default and have silently rotted before. This makes
-      # them at least compile without wiring them into any test run.
+      # Compile-only guard: integration-tagged files are excluded from default
+      # go test; this vet step builds them. skip_slow_test is defined here so
+      # !skip_slow_test files are excluded from this check (they still compile
+      # in the default test and lint jobs above).
       - name: vet tag-gated test files
         run: go vet -tags integration,skip_slow_test ./...
 

--- a/dev-docs/issue-management.md
+++ b/dev-docs/issue-management.md
@@ -16,7 +16,6 @@ Tools are managed via the Go tool directive (`go install tool` installs them).
 # Review operations
 go tool gh-helper reviews fetch <PR>                     # Fetch review data including threads
 go tool gh-helper reviews fetch <PR> --unresolved-only   # Only unresolved threads
-go tool gh-helper reviews fetch <PR> --needs-reply-only  # Only threads needing replies
 go tool gh-helper reviews fetch <PR> --no-bodies         # Exclude review bodies (lightweight)
 go tool gh-helper reviews wait <PR>                      # Wait for reviews and checks
 go tool gh-helper reviews wait <PR> --async              # Check once (non-blocking)

--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -65,9 +65,9 @@ r.Register("CLI_VERSION", NewReadOnlyVar(getVersion, "The version of spanner-myc
 // Enums: enumer-generated types in enums/ with a small typed constructor
 r.Register("CLI_FORMAT", DisplayModeVar(&sv.Display.CLIFormat, "..."))
 
-// Validation hook
-r.Register("CLI_PROMPT2", StringVar(&sv.Display.Prompt2, "...").
-	WithValidator(func(s string) error { /* reject invalid values */ return nil }))
+// Validation hook (duration bounds via WithValidator)
+r.Register("STATEMENT_TIMEOUT", NullableDurationVar(&sv.Query.StatementTimeout, "...").
+	WithValidator(durationValidator(durationPtr(0), nil)))
 ```
 
 ### Session-init-only variables

--- a/dev-docs/patterns/testing.md
+++ b/dev-docs/patterns/testing.md
@@ -14,9 +14,12 @@ The suite has two tiers, selected with the standard `-short` flag:
 Conventions:
 
 - Gate emulator-dependent tests with `testing.Short()` (usually via the
-  `runStatementTests` helper). Do NOT introduce new build tags for this:
-  tag-gated files (`//go:build integration`, `skip_slow_test`) are not built
-  by default and silently rot because nothing compiles them in CI.
+  `runStatementTests` helper). Do NOT introduce new build tags for this.
+  Legacy tags remain in a few files: `//go:build integration` excludes
+  those files from default `go test` (CI compile-checks them with
+  `go vet -tags integration,skip_slow_test`). Files marked
+  `//go:build !skip_slow_test` are built by default and excluded only when
+  the `skip_slow_test` tag is defined (as in that CI vet step).
 - For statement-level integration tests, prefer the `statementTestCase` /
   `runStatementTests` table in integration_test.go with the `sr` / `srEmpty` /
   `srKeep` / `srDML` result helpers. `compareResult` already ignores


### PR DESCRIPTION
## Summary
- Correct `skip_slow_test` build-tag polarity in `dev-docs/patterns/testing.md` and the CI workflow comment.
- Remove nonexistent `--needs-reply-only` flag from `dev-docs/issue-management.md`.
- Replace misleading `CLI_PROMPT2` WithValidator example with duration vars in `dev-docs/patterns/system-variables.md`.

Addresses FEEDBACK.md 10.2 items 11–13.

## Test plan
- [x] `make check` (doc-only change; no code behavior affected)


Made with [Cursor](https://cursor.com)