### PR TITLE
Treat EOF in confirm() as declining the prompt

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -522,7 +522,9 @@ func confirm(in io.Reader, out io.Writer, msg string) bool {
 
 	s := bufio.NewScanner(in)
 	for {
-		s.Scan()
+		if !s.Scan() {
+			return false
+		}
 		switch strings.ToLower(s.Text()) {
 		case "yes":
 			return true

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -1189,6 +1189,11 @@ func Test_confirm(t *testing.T) {
 			input:    "invalid\nno\n",
 			expected: false,
 		},
+		{
+			desc:     "EOF returns false",
+			input:    "",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Return `false` from `confirm()` when `Scan()` hits EOF or a read error, instead of spinning forever reprinting the prompt.
- Prevents a hot loop when stdin closes during DROP DATABASE confirmation.

Addresses FEEDBACK.md section 1 proposal 5 / 10.1 architecture tail.

## Test plan
- [x] `make check`
- [x] Added `Test_confirm` case for empty input (EOF)


Made with [Cursor](https://cursor.com)