### PR TITLE
fix: order output decorations and pager correctly around streamed results

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -18,7 +18,6 @@ package mycli
 
 import (
 	"bufio"
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -26,14 +25,12 @@ import (
 	"log/slog"
 	"math"
 	"os"
-	"os/exec"
 	"os/signal"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/hymkor/go-multiline-ny"
-	"github.com/kballard/go-shellquote"
 	"golang.org/x/term"
 
 	"github.com/apstndb/go-tabwrap"
@@ -373,50 +370,22 @@ func (c *Cli) PrintBatchError(err error) {
 	printError(c.GetErrStream(), err)
 }
 
+// PrintResult prints a buffered result with the output decorations and the
+// CLI_USE_PAGER pager applied. Statement execution does not go through this
+// method (executeStatement shares one resultSink between streamed rows and
+// the buffered display); it remains for direct callers holding a Result.
 func (c *Cli) PrintResult(screenWidth int, result *Result, interactive bool, input string, w io.Writer) error {
 	// If no writer is provided, use the CLI's OutStream
 	if w == nil {
 		w = c.GetWriter()
 	}
 
-	ostream := w
-	var cmd *exec.Cmd
-	if c.SystemVariables.Display.UsePager {
-		pagerpath := cmp.Or(os.Getenv("PAGER"), "less")
-
-		split, err := shellquote.Split(pagerpath)
-		if err != nil {
-			return fmt.Errorf("failed to parse pager command: %w", err)
-		}
-		// A whitespace-only PAGER yields an empty slice; reject it instead of
-		// panicking on split[0].
-		if len(split) == 0 {
-			return fmt.Errorf("invalid pager command: %q", pagerpath)
-		}
-		cmd = exec.CommandContext(context.Background(), split[0], split[1:]...)
-
-		pr, pw := io.Pipe()
-		ostream = pw
-		cmd.Stdin = pr
-		cmd.Stdout = w
-
-		err = cmd.Start()
-		if err != nil {
-			slog.Error("failed to start pager command", "err", err)
-			return fmt.Errorf("failed to start pager: %w", err)
-		}
-		defer func() {
-			err := pw.Close()
-			if err != nil {
-				slog.Error("failed to close pipe", "err", err)
-			}
-			err = cmd.Wait()
-			if err != nil {
-				slog.Error("failed to wait for pager command", "err", err)
-			}
-		}()
+	sink := c.newResultSink(w, input)
+	if err := printResult(c.SystemVariables, screenWidth, sink, result, interactive); err != nil {
+		sink.abort()
+		return err
 	}
-	return printResult(c.SystemVariables, screenWidth, ostream, result, interactive, input)
+	return sink.finish()
 }
 
 func (c *Cli) PrintProgressingMark(w io.Writer) func() {
@@ -562,8 +531,26 @@ func (c *Cli) executeStatement(ctx context.Context, stmt Statement, interactive 
 	// Execute the statement, routing streamed output to the caller-provided
 	// writer. This keeps streaming formats and DUMP on the same destination
 	// as buffered display (notably the MCP handler's capture buffer).
+	//
+	// Non-meta statements stream through a resultSink so the output
+	// decorations (markdown fence, input echo) and the CLI_USE_PAGER pager
+	// apply to streamed rows in the correct order; buffered display below
+	// shares the same sink. Meta commands keep the undecorated, unpaged
+	// direct writer (they also skip displayResult).
+	_, isMetaCommand := stmt.(MetaCommandStatement)
+	outW := w
+	var sink *resultSink
+	if !isMetaCommand {
+		sink = c.newResultSink(w, input)
+		// On the error path abort() closes a fence opened by already-streamed
+		// rows and releases the pager; if nothing was written it stays silent.
+		defer sink.abort()
+		outW = sink
+	}
 	out := outputContext{
-		w:           w,
+		w: outW,
+		// Resolve the width against the caller's writer, not the sink: the
+		// pager pipe is never a terminal.
 		screenWidth: func() int { return c.resolveScreenWidth(w) },
 	}
 	result, err := c.SessionHandler.ExecuteStatementWithOutput(ctx, stmt, out)
@@ -597,8 +584,8 @@ func (c *Cli) executeStatement(ctx context.Context, stmt Statement, interactive 
 	c.updateResultStats(result, elapsed)
 
 	// Display the result (skip for meta commands)
-	if _, isMetaCommand := stmt.(MetaCommandStatement); !isMetaCommand {
-		if err := c.displayResult(result, interactive, input, w); err != nil {
+	if !isMetaCommand {
+		if err := c.displayResult(sink, result, interactive, w); err != nil {
 			return "", fmt.Errorf("failed to display result: %w", err)
 		}
 	}
@@ -712,15 +699,22 @@ func (c *Cli) resolveScreenWidth(w io.Writer) int {
 	return width
 }
 
-// displayResult displays the result of the statement execution.
+// displayResult displays the result of the statement execution through the
+// per-statement sink (which may already carry streamed rows) and finalizes
+// the sink: closing decoration, pager shutdown. w is the undecorated
+// destination used for width resolution and the interactive trailing newline
+// (written after the pager exits, as before).
 // It returns an error if the output operation fails.
-func (c *Cli) displayResult(result *Result, interactive bool, input string, w io.Writer) error {
+func (c *Cli) displayResult(sink *resultSink, result *Result, interactive bool, w io.Writer) error {
 	// If no writer is provided, use the CLI's OutStream
 	if w == nil {
 		w = c.GetWriter()
 	}
 
-	if err := c.PrintResult(c.resolveScreenWidth(w), result, interactive, input, w); err != nil {
+	if err := printResult(c.SystemVariables, c.resolveScreenWidth(w), sink, result, interactive); err != nil {
+		return err
+	}
+	if err := sink.finish(); err != nil {
 		return err
 	}
 

--- a/internal/mycli/cli_output.go
+++ b/internal/mycli/cli_output.go
@@ -101,18 +101,12 @@ func printTableData(sysVars *systemVariables, screenWidth int, out io.Writer, re
 	})
 }
 
-func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result, interactive bool, input string) error {
-	if sysVars.Display.MarkdownCodeblock {
-		fmt.Fprintln(out, "```sql")
-	}
-
-	// Echo the input SQL if CLI_ECHO_INPUT is enabled
-	// This output is intentionally sent to 'out' (not TtyOutStream) so it's captured in tee files
-	// This provides complete context in logs showing which queries produced which results
-	if sysVars.Feature.EchoInput && input != "" {
-		fmt.Fprintln(out, input+";")
-	}
-
+// printResult writes the result body (table data, appendices, result line) to
+// out. The surrounding decorations (CLI_MARKDOWN_CODEBLOCK fence,
+// CLI_ECHO_INPUT echo) and the CLI_USE_PAGER pager are owned by resultSink so
+// they order correctly around streamed rows; pass a resultSink as out to get
+// the decorated output.
+func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, result *Result, interactive bool) error {
 	// Skip table data if already streamed or pre-rendered by an execution path
 	// that needs atomic output after side effects such as implicit DML commit.
 	if !result.Streamed {
@@ -168,10 +162,6 @@ func printResult(sysVars *systemVariables, screenWidth int, out io.Writer, resul
 
 	if sysVars.Display.CLIFormat == enums.DisplayModeTableDetailComment {
 		fmt.Fprintln(out, "*/")
-	}
-
-	if sysVars.Display.MarkdownCodeblock {
-		fmt.Fprintln(out, "```")
 	}
 
 	return nil

--- a/internal/mycli/cli_output_test.go
+++ b/internal/mycli/cli_output_test.go
@@ -236,7 +236,7 @@ func TestPrintResultWritesRenderedOutput(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := printResult(sysVars, 80, &buf, result, true, ""); err != nil {
+	if err := printResult(sysVars, 80, &buf, result, true); err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
 
@@ -257,7 +257,7 @@ func testResultLineSuppression(t *testing.T, sysVars *systemVariables, result *R
 	t.Helper()
 
 	var buf bytes.Buffer
-	err := printResult(sysVars, 80, &buf, result, interactive, "")
+	err := printResult(sysVars, 80, &buf, result, interactive)
 	if err != nil {
 		t.Fatalf("printResult failed: %v", err)
 	}

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -349,7 +349,15 @@ Empty set
 		for _, test := range tests {
 			t.Run(test.desc, func(t *testing.T) {
 				out := &bytes.Buffer{}
-				err := printResult(test.sysVars, test.screenWidth, out, test.result, false, test.input)
+				// Compose printResult with resultSink the same way
+				// displayResult does, so decorated cases (markdown fence,
+				// echo) assert the full byte-identical output.
+				cli := &Cli{SystemVariables: test.sysVars}
+				sink := cli.newResultSink(out, test.input)
+				err := printResult(test.sysVars, test.screenWidth, sink, test.result, false)
+				if err == nil {
+					err = sink.finish()
+				}
 				if err != nil {
 					t.Errorf("printResult() unexpected error: %v", err)
 				}
@@ -371,7 +379,7 @@ Empty set
 				toRow("3", "4"),
 			),
 		}
-		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeVertical}}, math.MaxInt, out, result, false, "")
+		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeVertical}}, math.MaxInt, out, result, false)
 		if err != nil {
 			t.Errorf("printResult() unexpected error: %v", err)
 		}
@@ -400,7 +408,7 @@ bar: 4
 				toRow("3", "4"),
 			),
 		}
-		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTab}}, math.MaxInt, out, result, false, "")
+		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTab}}, math.MaxInt, out, result, false)
 		if err != nil {
 			t.Errorf("printResult() unexpected error: %v", err)
 		}
@@ -424,7 +432,7 @@ bar: 4
 				toRow("back\\slash", "NULL"),
 			),
 		}
-		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTSV}}, math.MaxInt, out, result, false, "")
+		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTSV}}, math.MaxInt, out, result, false)
 		if err != nil {
 			t.Errorf("printResult() unexpected error: %v", err)
 		}
@@ -448,7 +456,7 @@ bar: 4
 				toRow("3", "4"),
 			),
 		}
-		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTable, SkipColumnNames: true}}, math.MaxInt, out, result, false, "")
+		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTable, SkipColumnNames: true}}, math.MaxInt, out, result, false)
 		if err != nil {
 			t.Errorf("printResult() unexpected error: %v", err)
 		}
@@ -475,7 +483,7 @@ bar: 4
 				toRow("3", "4"),
 			),
 		}
-		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTab, SkipColumnNames: true}}, math.MaxInt, out, result, false, "")
+		err := printResult(&systemVariables{Display: DisplayVars{CLIFormat: enums.DisplayModeTab, SkipColumnNames: true}}, math.MaxInt, out, result, false)
 		if err != nil {
 			t.Errorf("printResult() unexpected error: %v", err)
 		}
@@ -1098,7 +1106,7 @@ optimizer statistics: auto_20250421_21_29_41UTC
 			}
 
 			var sb strings.Builder
-			err = printResult(tcase.sysVars, 0, &sb, result, false, "")
+			err = printResult(tcase.sysVars, 0, &sb, result, false)
 			if err != nil {
 				t.Errorf("printResult() unexpected error: %v", err)
 			}

--- a/internal/mycli/result_sink.go
+++ b/internal/mycli/result_sink.go
@@ -1,0 +1,185 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"github.com/kballard/go-shellquote"
+)
+
+// resultSink is the per-statement output sink shared by streamed rows (via
+// outputContext) and buffered display (via printResult). It owns the output
+// decorations (CLI_MARKDOWN_CODEBLOCK fence, CLI_ECHO_INPUT echo) and the
+// CLI_USE_PAGER pager so both apply in the correct order regardless of
+// whether the statement streams.
+//
+// Whether a statement will stream is not knowable with certainty before
+// execution (shouldUseStreaming is a heuristic probe; Result.Streamed is the
+// truth only afterwards). Instead of predicting, the sink binds lazily: the
+// pager is started and the pre-result decorations are emitted on the first
+// byte written through it, wherever that byte comes from. For streamed
+// statements the first byte is the first row, so the fence/echo precede the
+// rows and the rows flow through the pager; for buffered statements the first
+// byte arrives at display time, reproducing the historical post-execution
+// behavior byte for byte (including SET statements whose own result reflects
+// the just-changed decoration flags, because the flags are read at emission
+// time, not at statement submission).
+type resultSink struct {
+	c     *Cli
+	dst   io.Writer // caller-provided destination
+	input string    // raw statement text for CLI_ECHO_INPUT
+
+	out       io.Writer    // active destination once started (pager pipe or dst)
+	startErr  error        // sticky pager start failure
+	fenceOpen bool         // opening ```sql fence was written
+	stopPager func() error // closes the pager pipe and waits; nil without pager
+	done      bool
+}
+
+// newResultSink returns a sink writing to dst. input is echoed when
+// CLI_ECHO_INPUT is enabled.
+func (c *Cli) newResultSink(dst io.Writer, input string) *resultSink {
+	return &resultSink{c: c, dst: dst, input: input}
+}
+
+// start lazily initializes the sink: it starts the pager when CLI_USE_PAGER
+// is enabled and emits the pre-result decorations. Decoration flags are read
+// here (at first output) rather than at sink construction so statements that
+// change them (SET CLI_MARKDOWN_CODEBLOCK=TRUE) decorate their own result,
+// matching the historical post-execution evaluation.
+func (s *resultSink) start() error {
+	if s.out != nil || s.startErr != nil {
+		return s.startErr
+	}
+
+	out := s.dst
+	if s.c.SystemVariables.Display.UsePager {
+		pw, stop, err := startPager(s.dst)
+		if err != nil {
+			s.startErr = err
+			return err
+		}
+		out = pw
+		s.stopPager = stop
+	}
+	s.out = out
+
+	if s.c.SystemVariables.Display.MarkdownCodeblock {
+		fmt.Fprintln(out, "```sql")
+		s.fenceOpen = true
+	}
+	// The echo is intentionally sent through the sink (not TtyOutStream) so it
+	// is captured in tee files, providing complete context in logs showing
+	// which queries produced which results.
+	if s.c.SystemVariables.Feature.EchoInput && s.input != "" {
+		fmt.Fprintln(out, s.input+";")
+	}
+	return nil
+}
+
+func (s *resultSink) Write(p []byte) (int, error) {
+	if err := s.start(); err != nil {
+		return 0, err
+	}
+	return s.out.Write(p)
+}
+
+// finish emits the closing decoration and shuts the pager down. It
+// force-starts the sink so statements that produced no other output still
+// emit the decoration pair (e.g. an empty ```sql fence), matching the
+// historical printResult output byte for byte. Call it only on the success
+// path; use abort for error unwinding.
+func (s *resultSink) finish() error {
+	if s.done {
+		return nil
+	}
+	s.done = true
+	if err := s.start(); err != nil {
+		return err
+	}
+	if s.fenceOpen {
+		fmt.Fprintln(s.out, "```")
+	}
+	if s.stopPager != nil {
+		return s.stopPager()
+	}
+	return nil
+}
+
+// abort unwinds the sink on the error path without forcing decorations: a
+// statement that failed before writing anything keeps the historical silent
+// error path, while a failure after rows already streamed still closes the
+// fence (keeping the markdown block well-formed) and releases the pager.
+func (s *resultSink) abort() {
+	if s.done {
+		return
+	}
+	s.done = true
+	if s.out == nil {
+		return // never started; nothing to unwind
+	}
+	if s.fenceOpen {
+		fmt.Fprintln(s.out, "```")
+	}
+	if s.stopPager != nil {
+		_ = s.stopPager() // errors already logged by stopPager
+	}
+}
+
+// startPager launches the pager command from $PAGER (default "less") writing
+// to w and returns the pipe feeding it plus a function that closes the pipe
+// and waits for the pager to exit. Close/wait failures are logged, not
+// returned, preserving the historical behavior of the pager teardown.
+func startPager(w io.Writer) (io.Writer, func() error, error) {
+	pagerpath := cmp.Or(os.Getenv("PAGER"), "less")
+
+	split, err := shellquote.Split(pagerpath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse pager command: %w", err)
+	}
+	// A whitespace-only PAGER yields an empty slice; reject it instead of
+	// panicking on split[0].
+	if len(split) == 0 {
+		return nil, nil, fmt.Errorf("invalid pager command: %q", pagerpath)
+	}
+	cmd := exec.CommandContext(context.Background(), split[0], split[1:]...)
+
+	pr, pw := io.Pipe()
+	cmd.Stdin = pr
+	cmd.Stdout = w
+
+	if err := cmd.Start(); err != nil {
+		slog.Error("failed to start pager command", "err", err)
+		return nil, nil, fmt.Errorf("failed to start pager: %w", err)
+	}
+
+	stop := func() error {
+		if err := pw.Close(); err != nil {
+			slog.Error("failed to close pipe", "err", err)
+		}
+		if err := cmd.Wait(); err != nil {
+			slog.Error("failed to wait for pager command", "err", err)
+		}
+		return nil
+	}
+	return pw, stop, nil
+}

--- a/internal/mycli/result_sink_test.go
+++ b/internal/mycli/result_sink_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// newDecorationTestCli builds a Cli around a detached-mode session (CSV
+// format, streaming-capable) suitable for exercising Cli.executeStatement
+// with client-side statements and no emulator.
+func newDecorationTestCli() *Cli {
+	session := newDetachedTestSession(io.Discard)
+	return &Cli{
+		SessionHandler:  NewSessionHandler(session),
+		SystemVariables: session.systemVariables,
+	}
+}
+
+// TestExecuteStatement_decorationsPrecedeStreamedRows is the regression test
+// for FEEDBACK C2 (ordering): with CLI_MARKDOWN_CODEBLOCK and CLI_ECHO_INPUT
+// enabled, the opening ```sql fence and the echoed input must appear BEFORE
+// streamed rows, and the closing fence after them. Before the fix, both
+// decorations were emitted post-hoc by printResult, so streamed rows came
+// first.
+func TestExecuteStatement_decorationsPrecedeStreamedRows(t *testing.T) {
+	t.Parallel()
+
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.MarkdownCodeblock = true
+	cli.SystemVariables.Feature.EchoInput = true
+
+	var buf bytes.Buffer
+	if _, err := cli.executeStatement(context.Background(), &ShowVariablesStatement{}, false, "SHOW VARIABLES", &buf); err != nil {
+		t.Fatalf("executeStatement: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "```sql\nSHOW VARIABLES;\n") {
+		t.Errorf("output must start with the opening fence and the echoed input, got prefix %q", firstLines(out, 3))
+	}
+	rowIdx := strings.Index(out, "CLI_FORMAT")
+	echoIdx := strings.Index(out, "SHOW VARIABLES;\n")
+	if rowIdx < 0 {
+		t.Fatalf("streamed CSV rows missing from output:\n%s", out)
+	}
+	if echoIdx < 0 || echoIdx > rowIdx {
+		t.Errorf("echoed input must precede streamed rows (echo at %d, rows at %d)", echoIdx, rowIdx)
+	}
+	if !strings.HasSuffix(out, "```\n") {
+		t.Errorf("output must end with the closing fence, got suffix %q", lastLines(out, 2))
+	}
+	closeIdx := strings.LastIndex(out, "```\n")
+	if closeIdx < rowIdx {
+		t.Errorf("closing fence must come after streamed rows (close at %d, rows at %d)", closeIdx, rowIdx)
+	}
+}
+
+// TestExecuteStatement_pagerCoversStreamedRows is the regression test for
+// FEEDBACK C2 (pager coverage): with CLI_USE_PAGER enabled, streamed rows
+// must flow through the pager process, not bypass it. The pager is a sed
+// command that prefixes every line, so any unprefixed output proves a bypass.
+func TestExecuteStatement_pagerCoversStreamedRows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test pager command uses sed")
+	}
+	t.Setenv("PAGER", "sed s/^/paged:/")
+
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+
+	var buf bytes.Buffer
+	if _, err := cli.executeStatement(context.Background(), &ShowVariablesStatement{}, false, "SHOW VARIABLES", &buf); err != nil {
+		t.Fatalf("executeStatement: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "CLI_FORMAT") {
+		t.Fatalf("streamed CSV rows missing from output:\n%s", out)
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		if !strings.HasPrefix(line, "paged:") {
+			t.Errorf("line bypassed the pager: %q", line)
+		}
+	}
+}
+
+// TestExecuteStatement_errorBeforeOutputEmitsNoDecorations pins the error
+// path: a statement that fails before writing anything must not leave a
+// dangling opening fence (or any decoration) behind.
+func TestExecuteStatement_errorBeforeOutputEmitsNoDecorations(t *testing.T) {
+	t.Parallel()
+
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.MarkdownCodeblock = true
+	cli.SystemVariables.Feature.EchoInput = true
+
+	var buf bytes.Buffer
+	// SELECT requires a database connection; the detached session rejects it
+	// before producing any output.
+	_, err := cli.executeStatement(context.Background(), &SelectStatement{Query: "SELECT 1"}, false, "SELECT 1", &buf)
+	if err == nil {
+		t.Fatal("executeStatement succeeded, want detached-mode rejection")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("failed statement wrote decorations: %q", buf.String())
+	}
+}
+
+// TestExecuteStatement_setMarkdownDecoratesOwnResult pins that decoration
+// flags are read at emission time, not before execution: SET
+// CLI_MARKDOWN_CODEBLOCK=TRUE fences its own result line, matching the
+// historical post-execution flag evaluation.
+func TestExecuteStatement_setMarkdownDecoratesOwnResult(t *testing.T) {
+	t.Parallel()
+
+	cli := newDecorationTestCli()
+	if cli.SystemVariables.Display.MarkdownCodeblock {
+		t.Fatal("precondition: CLI_MARKDOWN_CODEBLOCK must start disabled")
+	}
+
+	var buf bytes.Buffer
+	stmt := &SetStatement{VarName: "CLI_MARKDOWN_CODEBLOCK", Value: "TRUE"}
+	if _, err := cli.executeStatement(context.Background(), stmt, true, "SET CLI_MARKDOWN_CODEBLOCK = TRUE", &buf); err != nil {
+		t.Fatalf("executeStatement: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "```sql\n") {
+		t.Errorf("SET result must be fenced with the post-execution flag value, got %q", out)
+	}
+	if !strings.Contains(out, "Query OK") {
+		t.Errorf("interactive SET result line missing, got %q", out)
+	}
+	if !strings.HasSuffix(out, "```\n\n") {
+		t.Errorf("output must end with closing fence plus interactive newline, got %q", out)
+	}
+}
+
+// firstLines returns up to n leading lines of s for readable test failures.
+func firstLines(s string, n int) string {
+	lines := strings.SplitN(s, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// lastLines returns up to n trailing lines of s for readable test failures.
+func lastLines(s string, n int) string {
+	lines := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/mycli/screen_width_vty_test.go
+++ b/internal/mycli/screen_width_vty_test.go
@@ -173,8 +173,8 @@ func TestDisplayResultWithPty(t *testing.T) {
 				SystemVariables: sysVars,
 			}
 
-			// Call displayResult
-			err = cli.displayResult(tt.result, tt.interactive, tt.input, tty)
+			// Call displayResult with a per-statement sink, as executeStatement does
+			err = cli.displayResult(cli.newResultSink(tty, tt.input), tt.result, tt.interactive, tty)
 			if err != nil {
 				t.Fatalf("displayResult() failed: %v", err)
 			}


### PR DESCRIPTION
## Summary

Fixes the output-decoration ordering and pager coverage defects for streamed results (output-layer finding C2), building on the per-statement `outputContext` from #715:

1. The markdown ```` ```sql ```` fence (`CLI_MARKDOWN_CODEBLOCK`) and input echo (`CLI_ECHO_INPUT`) were emitted by `printResult` after execution, so for streamed results they appeared **after** the rows had already been written.
2. `CLI_USE_PAGER` started the pager only around `printResult`, so streamed rows bypassed the pager entirely; only the summary line was paged.

## Design

A new per-statement `resultSink` (`internal/mycli/result_sink.go`) is created in `Cli.executeStatement` and shared between streamed output (via `outputContext`) and buffered display (`printResult`). Whether a statement will stream is not knowable with certainty before execution (`shouldUseStreaming` is a heuristic probe; `Result.Streamed` is the truth only afterwards), so the sink does not predict: it binds **lazily on the first written byte**, starting the pager and emitting the pre-result decorations at that moment, wherever that byte comes from.

- Streamed: fence/echo precede the first row; rows, summary, and closing fence flow through one pager session.
- Buffered: the first byte arrives at display time, reproducing the historical post-execution output byte for byte — including `SET CLI_MARKDOWN_CODEBLOCK=TRUE` decorating its own result, because decoration flags are read at emission time, not at statement submission.
- Meta commands keep the undecorated, unpaged direct writer as before (they also skip `displayResult`).
- MCP mode is unaffected: the sink wraps the handler's capture buffer transparently (existing `output_context_test.go` regression tests still pass).

`printResult` now renders only the result body; `Cli.PrintResult` remains as a decorated entry point for direct callers holding a `Result`. The pager startup logic moved unchanged from `PrintResult` into `startPager`.

## Behavior changes

- Streamed results with `CLI_MARKDOWN_CODEBLOCK`/`CLI_ECHO_INPUT`: fence and echo now precede the rows; the closing fence follows them (previously both appeared after the rows).
- Streamed results with `CLI_USE_PAGER`: rows are now paged together with the summary (previously only the summary was paged).
- Error after rows already streamed: the open fence is now closed and the pager released (previously rows were left dangling with no fence at all). Errors before any output remain silent, as before.
- Buffered results render byte-identically to before (the exact-output expectations in `TestPrintResult`, including the markdown fence + echo case, are unchanged and pass).

## Validation

- New regression tests in `result_sink_test.go`, written first and verified failing against `main`:
  - `TestExecuteStatement_decorationsPrecedeStreamedRows` (defect 1)
  - `TestExecuteStatement_pagerCoversStreamedRows` (defect 2, pager = `sed` prefixer proving full coverage)
  - `TestExecuteStatement_errorBeforeOutputEmitsNoDecorations` and `TestExecuteStatement_setMarkdownDecoratesOwnResult` pin the lazy-binding semantics.
- `make check` passes (test + lint + fmt-check); `go test -short -race` passes.
- End-to-end against the embedded emulator: `--set CLI_FORMAT=CSV --set CLI_MARKDOWN_CODEBLOCK=TRUE --set CLI_ECHO_INPUT=TRUE --set CLI_USE_PAGER=TRUE` with `PAGER="sed s/^/PAGED:/"` produces fence, echo, rows, closing fence in order, every line paged; default table and CSV outputs are unchanged.

## Merge note

This PR should merge **after the v0.32.0 tag** is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dmtS3P1H7JzRdNJvd17GV
