### PR TITLE
fix: unify output-template loaders so empty value restores default

### DIFF
--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -477,12 +477,12 @@ func applyOptionMappings(sysVars *systemVariables, mappings []optionMapping) err
 }
 
 func applyOutputTemplate(sysVars *systemVariables, opts *spannerOptions) error {
-	if opts.OutputTemplate == "" {
-		setDefaultOutputTemplate(sysVars)
-	} else {
-		if err := setOutputTemplateFile(sysVars, opts.OutputTemplate); err != nil {
-			return fmt.Errorf("parse error of output template: %w", err)
-		}
+	// Route startup through the single registry-side loader so that startup and
+	// SET CLI_OUTPUT_TEMPLATE_FILE share identical semantics (an empty value
+	// restores the built-in default template). This is the sole output-template
+	// loader; setDefaultOutputTemplate/setOutputTemplateFile were removed.
+	if err := sysVars.SetFromSimple("CLI_OUTPUT_TEMPLATE_FILE", opts.OutputTemplate); err != nil {
+		return fmt.Errorf("parse error of output template: %w", err)
 	}
 	return nil
 }

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -468,27 +467,6 @@ func parseTimeString(s string) (time.Time, error) {
 }
 
 var defaultOutputFormat = template.Must(template.New("").Funcs(sproutFuncMap()).Parse(outputTemplateStr))
-
-func setDefaultOutputTemplate(sysVars *systemVariables) {
-	sysVars.Display.OutputTemplateFile = ""
-	sysVars.Display.OutputTemplate = defaultOutputFormat
-}
-
-func setOutputTemplateFile(sysVars *systemVariables, filename string) error {
-	b, err := os.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-
-	tmpl, err := template.New("").Funcs(sproutFuncMap()).Parse(string(b))
-	if err != nil {
-		return err
-	}
-
-	sysVars.Display.OutputTemplateFile = filename
-	sysVars.Display.OutputTemplate = tmpl
-	return nil
-}
 
 func mergeFDS(left, right *descriptorpb.FileDescriptorSet) *descriptorpb.FileDescriptorSet {
 	result := slices.Clone(left.GetFile())

--- a/internal/mycli/system_variables_test.go
+++ b/internal/mycli/system_variables_test.go
@@ -1173,3 +1173,68 @@ func TestRenderSystemVariablesHelp(t *testing.T) {
 		t.Error("renderSystemVariablesHelp() must escape angle brackets in descriptions")
 	}
 }
+
+// TestOutputTemplateFileEmptyRestoresDefault is a regression test for the
+// unified output-template loader (issue #725, PR0). Setting
+// CLI_OUTPUT_TEMPLATE_FILE to an empty string (or NULL) must restore the
+// built-in default template (defaultOutputFormat), not nil, and it must match
+// the startup state produced when no --output-template flag is given. This
+// Get/Set round-trip is what RESET ALL relies on.
+func TestOutputTemplateFileEmptyRestoresDefault(t *testing.T) {
+	t.Parallel()
+
+	// Startup with no --output-template flag: applyOutputTemplate receives an
+	// empty opts.OutputTemplate and must leave the default template in place.
+	startup := newSystemVariablesWithDefaultsForTest()
+	if err := applyOutputTemplate(startup, &spannerOptions{OutputTemplate: ""}); err != nil {
+		t.Fatalf("applyOutputTemplate with empty flag: %v", err)
+	}
+	if startup.Display.OutputTemplate != defaultOutputFormat {
+		t.Errorf("startup OutputTemplate = %p, want defaultOutputFormat %p", startup.Display.OutputTemplate, defaultOutputFormat)
+	}
+	if startup.Display.OutputTemplateFile != "" {
+		t.Errorf("startup OutputTemplateFile = %q, want empty", startup.Display.OutputTemplateFile)
+	}
+
+	for _, empty := range []string{"", "NULL", "null"} {
+		t.Run("set_"+empty, func(t *testing.T) {
+			t.Parallel()
+			sv := newSystemVariablesWithDefaultsForTest()
+			// First point it at a real template file so the empty-set has
+			// something to override.
+			if err := sv.SetFromSimple("CLI_OUTPUT_TEMPLATE_FILE", "output_default.tmpl"); err != nil {
+				t.Fatalf("SET to file: %v", err)
+			}
+			if sv.Display.OutputTemplate == defaultOutputFormat {
+				t.Fatal("precondition failed: template still default after setting a file")
+			}
+
+			// SET CLI_OUTPUT_TEMPLATE_FILE = '' must restore the default template.
+			if err := sv.SetFromSimple("CLI_OUTPUT_TEMPLATE_FILE", empty); err != nil {
+				t.Fatalf("SET to %q: %v", empty, err)
+			}
+			if sv.Display.OutputTemplate == nil {
+				t.Fatalf("after SET %q, OutputTemplate is nil; want default template", empty)
+			}
+			if sv.Display.OutputTemplate != defaultOutputFormat {
+				t.Errorf("after SET %q, OutputTemplate = %p, want defaultOutputFormat %p", empty, sv.Display.OutputTemplate, defaultOutputFormat)
+			}
+
+			// Startup-with-no-flag and SET-empty must be byte-identical states.
+			if sv.Display.OutputTemplateFile != startup.Display.OutputTemplateFile {
+				t.Errorf("OutputTemplateFile mismatch: SET-empty %q vs startup %q", sv.Display.OutputTemplateFile, startup.Display.OutputTemplateFile)
+			}
+			if sv.Display.OutputTemplate != startup.Display.OutputTemplate {
+				t.Errorf("OutputTemplate mismatch between SET-empty and startup")
+			}
+
+			got, err := sv.get("CLI_OUTPUT_TEMPLATE_FILE")
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if diff := cmp.Diff(singletonMap("CLI_OUTPUT_TEMPLATE_FILE", ""), got); diff != "" {
+				t.Errorf("get mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -434,10 +434,14 @@ func (r *VarRegistry) registerAll() {
 			return sv.Display.OutputTemplateFile, nil
 		},
 		customSetter: func(value string) error {
-			// Parse and set template
+			// Parse and set template.
+			// An empty value (or NULL) restores the built-in default template
+			// (defaultOutputFormat), matching the startup default when no
+			// --output-template flag is given. This keeps SET and startup in
+			// sync so Get/Set round-trips (relied on by RESET ALL) hold.
 			if value == "" || strings.EqualFold(value, "NULL") {
 				sv.Display.OutputTemplateFile = ""
-				sv.Display.OutputTemplate = nil
+				sv.Display.OutputTemplate = defaultOutputFormat
 				return nil
 			}
 


### PR DESCRIPTION
## Summary

Fixes a divergence between the two output-template loaders, a precondition for the RESET ALL / round-trip semantics in the `varDef` refactor (#725, section 6 "PR0").

Today the registry setter for `CLI_OUTPUT_TEMPLATE_FILE` maps an empty string (or `NULL`) to `OutputTemplate = nil`, while startup maps an empty `--output-template` flag to the built-in default template (`defaultOutputFormat`). So `SET CLI_OUTPUT_TEMPLATE_FILE = ''` and the flag default produce different states, breaking any Get/Set round-trip.

## Changes

- Registry setter: empty/`NULL` now restores `defaultOutputFormat` (not `nil`), matching startup.
- `applyOutputTemplate` routes through `SetFromSimple("CLI_OUTPUT_TEMPLATE_FILE", ...)` — the single loader.
- Deleted the duplicated `setDefaultOutputTemplate` / `setOutputTemplateFile` helpers.
- Added a regression test asserting SET-empty yields the default template (not nil) and matches the startup no-flag state exactly (Get/Set round-trip), covering `""`, `NULL`, and `null`.

## Validation

- `make check` passes (test + lint + fmt-check).

Part of #725.
