### PR TITLE
ci: pin goreleaser version derivation to the pushed tag

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -32,3 +32,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pin the release version to the pushed tag. Without this, goreleaser
+          # derives the version via git describe, which is ambiguous when multiple
+          # tags point at the same commit: v0.32.0's first run released to
+          # v0.32.0-alpha.1 because both tags shared one commit.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Pin goreleaser's version derivation to the pushed tag by setting `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` on the goreleaser step.

## Background

During the v0.32.0 release, the tag workflow ran on the correct commit but goreleaser resolved its "current tag" via `git describe`, which is ambiguous when multiple tags point at the same commit. Because `v0.32.0-alpha.1` and `v0.32.0` both pointed at the same commit, the run for the `v0.32.0` tag resolved `current=v0.32.0-alpha.1`, built binaries stamped `0.32.0-alpha.1`, and published a duplicate `v0.32.0-alpha.1` prerelease draft instead of a `v0.32.0` release. Recovery required deleting the alpha tag and drafts and rerunning the workflow.

`GORELEASER_CURRENT_TAG` makes the version deterministic: the workflow only triggers on tag pushes, so `github.ref_name` is always the exact tag being released.

## Validation

- YAML parse-checked the workflow file.
- The variable is documented goreleaser behavior: https://goreleaser.com/cookbooks/set-a-custom-git-tag/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dmtS3P1H7JzRdNJvd17GV
