### PR TITLE
refactor: introduce declarative varDef table for system variables

### DIFF
--- a/dev-docs/patterns/system-variables.md
+++ b/dev-docs/patterns/system-variables.md
@@ -32,8 +32,10 @@ struct must never be copied. USE/DETACH mutate it in place
    - User-settable -> the matching `*Vars` group + writable registration.
    - Produced by statement execution -> `LastResult` field + read-only
      registration (or a getter-only handler).
-3. **Register** in `registerAll` in `internal/mycli/var_registry.go`
-   (NOT system_variables_registry.go, which holds the set/get plumbing).
+3. **Add a `varDef` entry** to the `varDefs` table in
+   `internal/mycli/var_defs.go`. `registerAll`
+   (`internal/mycli/var_registry.go`) iterates the table to build the
+   registry; `system_variables_registry.go` holds the set/get plumbing.
 4. **Document**: the reference table in docs/system_variables.md is generated
    from the registry (via the hidden `--sysvars-help` flag); run
    `make docs-update` after registering, so the description doubles as user
@@ -42,32 +44,55 @@ struct must never be copied. USE/DETACH mutate it in place
    variable needs more than one line of explanation.
 5. **Test**: see Testing below.
 
-## Registration API (var_handler.go, var_enum_handlers.go, var_custom_handlers.go)
+## Registration API (var_defs.go + var_handler.go, var_enum_handlers.go, var_custom_handlers.go)
 
-Descriptions are constructor arguments; there is no `WithDescription`.
+Every variable is one `varDef` entry in the `varDefs` table (var_defs.go).
+Metadata (name, `desc`, `scope`/`readOnly`) lives in the def; the `bind`
+closure constructs the live handler bound to the process-wide
+`systemVariables`. Handlers implement only `Get`/`Set` — read-only enforcement
+is driven by the def's scope in `VarRegistry.Set`, not by the handler. `scope`
+values: `scopeSession` (SET-able), `scopeStartup` (StartupConfig-backed,
+read-only), `scopeConnection` (connection identity, read-only), `scopeResult`
+(LastResult output, read-only).
 
 ```go
-// In registerAll (internal/mycli/var_registry.go):
+// In the varDefs table (internal/mycli/var_defs.go):
 
 // Writable bool/string/int
-r.Register("CLI_VERBOSE", BoolVar(&sv.Display.Verbose, "Display verbose output."))
+{
+	name: "CLI_VERBOSE", desc: "Display verbose output.", scope: scopeSession,
+	bind: func(sv *systemVariables) Variable { return BoolVar(&sv.Display.Verbose) },
+},
 
-// Read-only (StartupConfig-backed): same constructors + AsReadOnly()
-r.Register("CLI_INSECURE", BoolVar(&sv.Config.Insecure,
-	"Skip TLS certificate verification (insecure).").AsReadOnly())
-
-// Nullable types display and accept the literal NULL
-r.Register("MAX_COMMIT_DELAY", NullableDurationVar(&sv.Transaction.MaxCommitDelay, "..."))
+// Read-only (StartupConfig-backed): a non-session scope makes it non-settable
+{
+	name: "CLI_INSECURE", desc: "Skip TLS certificate verification (insecure).",
+	scope: scopeStartup,
+	bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Config.Insecure) },
+},
 
 // Computed read-only value: getter is func() string (it cannot fail)
-r.Register("CLI_VERSION", NewReadOnlyVar(getVersion, "The version of spanner-mycli."))
+{
+	name: "CLI_VERSION", desc: "The version of spanner-mycli.", scope: scopeStartup,
+	bind: func(sv *systemVariables) Variable { return NewReadOnlyVar(getVersion) },
+},
 
 // Enums: enumer-generated types in enums/ with a small typed constructor
-r.Register("CLI_FORMAT", DisplayModeVar(&sv.Display.CLIFormat, "..."))
+{
+	name: "CLI_FORMAT", desc: "...", scope: scopeSession,
+	bind: func(sv *systemVariables) Variable { return DisplayModeVar(&sv.Display.CLIFormat) },
+},
 
 // Validation hook (duration bounds via WithValidator)
-r.Register("STATEMENT_TIMEOUT", NullableDurationVar(&sv.Query.StatementTimeout, "...").
-	WithValidator(durationValidator(durationPtr(0), nil)))
+{
+	name: "STATEMENT_TIMEOUT", desc: "...", scope: scopeSession,
+	bind: func(sv *systemVariables) Variable {
+		return NullableDurationVar(&sv.Query.StatementTimeout).
+			WithValidator(durationValidator(durationPtr(0), nil))
+	},
+},
+
+// ADD support: set bindAdd to construct the ADD handler (see CLI_PROTO_DESCRIPTOR_FILE)
 ```
 
 ### Session-init-only variables
@@ -76,7 +101,7 @@ Variables that control client initialization can be set via `--set` before the
 session exists but must reject later writes. The actual pattern is a
 `CustomVar` whose setter checks `sv.inTransaction` as a session-existence
 proxy (it is nil until the first session is created); see the
-`CLI_ENABLE_ADC_PLUS` registration in `registerAll` for the canonical example.
+`CLI_ENABLE_ADC_PLUS` entry in the `varDefs` table for the canonical example.
 
 ### Raw + parsed variables
 

--- a/internal/mycli/var_custom_handlers.go
+++ b/internal/mycli/var_custom_handlers.go
@@ -57,8 +57,7 @@ func formatTimestampBound(tb *spanner.TimestampBound) string {
 
 // TimestampBoundVar handles READ_ONLY_STALENESS variable
 type TimestampBoundVar struct {
-	ptr         **spanner.TimestampBound
-	description string
+	ptr **spanner.TimestampBound
 }
 
 func (t *TimestampBoundVar) Get() (string, error) {
@@ -82,19 +81,10 @@ func (t *TimestampBoundVar) Set(value string) error {
 	return nil
 }
 
-func (t *TimestampBoundVar) Description() string {
-	return t.description
-}
-
-func (t *TimestampBoundVar) IsReadOnly() bool {
-	return false
-}
-
 // ProtoDescriptorVar handles CLI_PROTO_DESCRIPTOR_FILE with ADD support
 type ProtoDescriptorVar struct {
 	filesPtr      *[]string
 	descriptorPtr **descriptorpb.FileDescriptorSet
-	description   string
 }
 
 func (p *ProtoDescriptorVar) Get() (string, error) {
@@ -143,22 +133,13 @@ func (p *ProtoDescriptorVar) Add(value string) error {
 	return nil
 }
 
-func (p *ProtoDescriptorVar) Description() string {
-	return p.description
-}
-
-func (p *ProtoDescriptorVar) IsReadOnly() bool {
-	return false
-}
-
 // EndpointVar handles CLI_ENDPOINT (host:port).
 // Read-only, like CLI_HOST and CLI_PORT which it is derived from: the
 // endpoint is part of the immutable StartupConfig, and changing it after
 // startup would not reconnect the live session.
 type EndpointVar struct {
-	hostPtr     *string
-	portPtr     *int
-	description string
+	hostPtr *string
+	portPtr *int
 }
 
 func (e *EndpointVar) Get() (string, error) {
@@ -170,14 +151,6 @@ func (e *EndpointVar) Get() (string, error) {
 
 func (e *EndpointVar) Set(value string) error {
 	return errSetterReadOnly
-}
-
-func (e *EndpointVar) Description() string {
-	return e.description
-}
-
-func (e *EndpointVar) IsReadOnly() bool {
-	return true
 }
 
 // parseOutputTemplate parses output template file
@@ -207,10 +180,9 @@ func parseInlineStats(value string) ([]inlineStatsDef, error) {
 
 // TemplateVar handles template variables like CLI_ANALYZE_COLUMNS
 type TemplateVar struct {
-	stringPtr   *string
-	parsedPtr   interface{} // Will be type-asserted based on usage
-	parseFunc   func(string) error
-	description string
+	stringPtr *string
+	parsedPtr interface{} // Will be type-asserted based on usage
+	parseFunc func(string) error
 }
 
 func (t *TemplateVar) Get() (string, error) {
@@ -227,27 +199,17 @@ func (t *TemplateVar) Set(value string) error {
 	return nil
 }
 
-func (t *TemplateVar) Description() string {
-	return t.description
-}
-
-func (t *TemplateVar) IsReadOnly() bool {
-	return false
-}
-
 // AutocommitDMLModeVar handles AUTOCOMMIT_DML_MODE using enumer-generated methods
-func AutocommitDMLModeVar(ptr *enums.AutocommitDMLMode, desc string) *EnumVar[enums.AutocommitDMLMode] {
+func AutocommitDMLModeVar(ptr *enums.AutocommitDMLMode) *EnumVar[enums.AutocommitDMLMode] {
 	return &EnumVar[enums.AutocommitDMLMode]{
-		ptr:         ptr,
-		values:      enumerValues(enums.AutocommitDMLModeValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.AutocommitDMLModeValues()),
 	}
 }
 
 // LogLevelVar handles CLI_LOG_LEVEL
 type LogLevelVar struct {
-	ptr         *slog.Level
-	description string
+	ptr *slog.Level
 }
 
 func (l *LogLevelVar) Get() (string, error) {
@@ -272,14 +234,6 @@ func (l *LogLevelVar) Set(value string) error {
 	return nil
 }
 
-func (l *LogLevelVar) Description() string {
-	return l.description
-}
-
-func (l *LogLevelVar) IsReadOnly() bool {
-	return false
-}
-
 // ValidValues returns the standard log level names as GoogleSQL string literals.
 func (l *LogLevelVar) ValidValues() []string {
 	return []string{"'DEBUG'", "'ERROR'", "'INFO'", "'WARN'", "'WARNING'"}
@@ -287,8 +241,7 @@ func (l *LogLevelVar) ValidValues() []string {
 
 // UnimplementedVar handles unimplemented variables
 type UnimplementedVar struct {
-	name        string
-	description string
+	name string
 }
 
 func (u *UnimplementedVar) Get() (string, error) {
@@ -299,18 +252,9 @@ func (u *UnimplementedVar) Set(value string) error {
 	return errSetterUnimplemented{u.name}
 }
 
-func (u *UnimplementedVar) Description() string {
-	return u.description
-}
-
-func (u *UnimplementedVar) IsReadOnly() bool {
-	return false
-}
-
 // TimestampVar handles timestamp formatting for read-only timestamp variables
 type TimestampVar struct {
-	ptr         *time.Time
-	description string
+	ptr *time.Time
 }
 
 func (t *TimestampVar) Get() (string, error) {
@@ -324,18 +268,9 @@ func (t *TimestampVar) Set(value string) error {
 	return errSetterReadOnly
 }
 
-func (t *TimestampVar) Description() string {
-	return t.description
-}
-
-func (t *TimestampVar) IsReadOnly() bool {
-	return true
-}
-
 // IntGetterVar handles integer variables with custom getters
 type IntGetterVar struct {
-	getter      func() int64
-	description string
+	getter func() int64
 }
 
 func (i *IntGetterVar) Get() (string, error) {
@@ -344,12 +279,4 @@ func (i *IntGetterVar) Get() (string, error) {
 
 func (i *IntGetterVar) Set(value string) error {
 	return errSetterReadOnly
-}
-
-func (i *IntGetterVar) Description() string {
-	return i.description
-}
-
-func (i *IntGetterVar) IsReadOnly() bool {
-	return true
 }

--- a/internal/mycli/var_defs.go
+++ b/internal/mycli/var_defs.go
@@ -1,0 +1,799 @@
+package mycli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanner-mycli/enums"
+)
+
+// varScope classifies where a system variable's value lives and, together with
+// readOnly, whether SET may change it.
+type varScope int
+
+const (
+	// scopeSession is the SET-able surface. (Later: participates in RESET ALL
+	// and SET LOCAL.)
+	scopeSession varScope = iota
+	// scopeStartup is StartupConfig-backed: read-only via SET, written only by
+	// config.go/app.go before session creation.
+	scopeStartup
+	// scopeConnection is connection identity: read-only via SET, mutated only by
+	// USE/DETACH.
+	scopeConnection
+	// scopeResult is last-statement output (LastResult): read-only via SET.
+	scopeResult
+)
+
+// varDef is the declarative metadata for one system variable. The varDefs
+// table is the single source of truth for a variable's name, description,
+// read-only/scope policy, and how to construct its live handler; registerAll
+// iterates it to populate the registry.
+type varDef struct {
+	name string
+	desc string
+
+	scope    varScope
+	readOnly bool // for scopeSession exceptions only; other scopes are implicitly read-only
+
+	// bind constructs the live handler bound to the given systemVariables.
+	bind func(sv *systemVariables) Variable
+	// bindAdd, when non-nil, constructs the variable's ADD handler.
+	bindAdd func(sv *systemVariables) func(string) error
+}
+
+// settable reports whether SET may change this variable. Non-session scopes are
+// implicitly read-only; scopeSession vars are settable unless readOnly is set.
+func (d *varDef) settable() bool { return d.scope == scopeSession && !d.readOnly }
+
+// varDefs is the declarative table of all system variables. Order is not
+// significant (listings sort by name); it mirrors the historical grouping for
+// readability.
+//
+// Note: COMMIT_RESPONSE and CLI_DIRECT_READ require special handling outside
+// the registry (see system_variables_registry.go).
+var varDefs = []varDef{
+	// === Simple boolean variables ===
+	{
+		name:  "READONLY",
+		desc:  "A boolean indicating whether or not the connection is in read-only mode",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: BoolVar(&sv.Transaction.ReadOnly),
+				customSetter: func(value string) error {
+					// Custom validation for READONLY
+					if sv.inTransaction != nil && sv.inTransaction() {
+						return errSetterInTransaction
+					}
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return err
+					}
+					sv.Transaction.ReadOnly = b
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "AUTO_PARTITION_MODE",
+		desc:  "A property of type BOOL indicating whether the connection automatically uses partitioned queries for all queries that are executed.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Query.AutoPartitionMode) },
+	},
+	{
+		name:  "DATA_BOOST_ENABLED",
+		desc:  "A property of type BOOL indicating whether this connection should use Data Boost for partitioned queries. The default is false.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Query.DataBoostEnabled) },
+	},
+	{
+		name:  "AUTO_BATCH_DML",
+		desc:  "A property of type BOOL indicating whether the DML is executed immediately or begins a batch DML. The default is false.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Transaction.AutoBatchDML) },
+	},
+	{
+		name:  "EXCLUDE_TXN_FROM_CHANGE_STREAMS",
+		desc:  "Controls whether to exclude recording modifications in current transaction from the allowed tracking change streams(with DDL option allow_txn_exclusion=true).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Transaction.ExcludeTxnFromChangeStreams) },
+	},
+	{
+		name:  "RETURN_COMMIT_STATS",
+		desc:  "A property of type BOOL indicating whether statistics should be returned for transactions on this connection.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Transaction.ReturnCommitStats) },
+	},
+	{
+		name:  "CLI_VERBOSE",
+		desc:  "Display verbose output.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.Verbose) },
+	},
+	{
+		name:  "CLI_PROFILE",
+		desc:  "Enable performance profiling (memory and timing metrics).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Query.Profile) },
+	},
+	{
+		name:  "CLI_LINT_PLAN",
+		desc:  "Enable query plan linting.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Query.LintPlan) },
+	},
+	{
+		name:  "CLI_USE_PAGER",
+		desc:  "Enable pager for output.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.UsePager) },
+	},
+	{
+		name:  "CLI_AUTOWRAP",
+		desc:  "Enable automatic line wrapping.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.AutoWrap) },
+	},
+	{
+		name:  "CLI_ENABLE_HIGHLIGHT",
+		desc:  "Enable syntax highlighting.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.EnableHighlight) },
+	},
+	{
+		name:  "CLI_PROTOTEXT_MULTILINE",
+		desc:  "Enable multiline prototext output.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.MultilineProtoText) },
+	},
+	{
+		name:  "CLI_MARKDOWN_CODEBLOCK",
+		desc:  "Enable markdown codeblock output.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.MarkdownCodeblock) },
+	},
+	{
+		name:  "CLI_TRY_PARTITION_QUERY",
+		desc:  "A boolean indicating whether to test query for partition compatibility instead of executing it.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Query.TryPartitionQuery) },
+	},
+	{
+		name:  "CLI_ECHO_EXECUTED_DDL",
+		desc:  "Echo executed DDL statements.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Feature.EchoExecutedDDL) },
+	},
+	{
+		name:  "CLI_ECHO_INPUT",
+		desc:  "Echo input statements.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Feature.EchoInput) },
+	},
+	{
+		name:  "CLI_AUTO_CONNECT_AFTER_CREATE",
+		desc:  "A boolean indicating whether to automatically connect to a database after CREATE DATABASE. The default is false.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Feature.AutoConnectAfterCreate) },
+	},
+	{
+		name:  "CLI_ENABLE_PROGRESS_BAR",
+		desc:  "A boolean indicating whether to display progress bars during operations. The default is false.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.EnableProgressBar) },
+	},
+	{
+		name:  "CLI_ASYNC_DDL",
+		desc:  "A boolean indicating whether DDL statements should be executed asynchronously. The default is false.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Feature.AsyncDDL) },
+	},
+	{
+		// Read-only: this is a security feature (--skip-system-command /
+		// --system-command=OFF); if it were settable, a user in a restricted
+		// environment could re-enable shell access with a single SET.
+		name:  "CLI_SKIP_SYSTEM_COMMAND",
+		desc:  "A read-only boolean indicating whether system commands are disabled. Set by --skip-system-command or --system-command=OFF.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Config.SkipSystemCommand) },
+	},
+	{
+		name:  "CLI_TAB_VISUALIZE",
+		desc:  "Visualize tab characters with arrow symbol in table output.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.TabVisualize) },
+	},
+	{
+		name:  "CLI_SKIP_COLUMN_NAMES",
+		desc:  "A boolean indicating whether to suppress column headers in output. The default is false.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.SkipColumnNames) },
+	},
+	{
+		name:  "CLI_EXPLAIN_HANGING_INDENT",
+		desc:  "Use hanging indent for wrapped query plan lines in EXPLAIN, EXPLAIN ANALYZE, and query profile rendering. Only affects output when CLI_EXPLAIN_WRAP_WIDTH or WIDTH is set.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.ExplainHangingIndent) },
+	},
+	{
+		name:  "CLI_FUZZY_FINDER_KEY",
+		desc:  "Key binding for fuzzy finder. Uses go-readline-ny key names (e.g., C_T, M_F, F1). Set to empty string to disable. The default is C_T (Ctrl+T).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Feature.FuzzyFinderKey) },
+	},
+	{
+		name:  "CLI_FUZZY_FINDER_OPTIONS",
+		desc:  "Additional fzf options passed to the fuzzy finder. Appended after built-in defaults, so user options take precedence. Example: --color=dark --no-select-1",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Feature.FuzzyFinderOptions) },
+	},
+	{
+		name:  "CLI_TABLE_STREAMING",
+		desc:  "Controls table streaming output mode: AUTO/FALSE buffer table output for layout quality, TRUE streams table output. Non-table formats always stream. Default is AUTO.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StreamingModeVar(&sv.Query.StreamingMode) },
+	},
+	{
+		name:  "CLI_STYLED_OUTPUT",
+		desc:  "Controls ANSI styling in table output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled). Default is AUTO.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StyledModeVar(&sv.Display.StyledOutput) },
+	},
+	{
+		name:  "CLI_WIDTH_STRATEGY",
+		desc:  "Controls column width allocation algorithm: GREEDY_FREQUENCY (default, frequency-based greedy), PROPORTIONAL (proportional to natural width), MARGINAL_COST (wrap-line minimization via max-heap).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return WidthStrategyVar(&sv.Display.WidthStrategy) },
+	},
+
+	// === String variables ===
+	{
+		name:  "OPTIMIZER_VERSION",
+		desc:  "A property of type STRING indicating the optimizer version. The version is either an integer string or LATEST.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Query.OptimizerVersion) },
+	},
+	{
+		name:  "OPTIMIZER_STATISTICS_PACKAGE",
+		desc:  "A property of type STRING indicating the current optimizer statistics package that is used by this connection.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Query.OptimizerStatisticsPackage) },
+	},
+	{
+		name:  "TRANSACTION_TAG",
+		desc:  "A property of type STRING that contains the transaction tag for the next transaction.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Transaction.TransactionTag) },
+	},
+	{
+		name:  "STATEMENT_TAG",
+		desc:  "A property of type STRING that contains the request tag for the next statement.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Transaction.RequestTag) },
+	},
+	{
+		name:  "CLI_PROJECT",
+		desc:  "GCP Project ID.",
+		scope: scopeConnection,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Connection.Project) },
+	},
+	{
+		name:  "CLI_INSTANCE",
+		desc:  "Cloud Spanner instance ID.",
+		scope: scopeConnection,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Connection.Instance) },
+	},
+	{
+		name:  "CLI_DATABASE",
+		desc:  "Cloud Spanner database ID.",
+		scope: scopeConnection,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Connection.Database) },
+	},
+	{
+		name:  "CLI_PROMPT",
+		desc:  "Custom prompt for spanner-mycli.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Display.Prompt) },
+	},
+	{
+		name:  "CLI_PROMPT2",
+		desc:  "Custom continuation prompt for spanner-mycli.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: StringVar(&sv.Display.Prompt2),
+				customSetter: func(value string) error {
+					if value == "" {
+						return fmt.Errorf("CLI_PROMPT2 cannot be empty")
+					}
+					sv.Display.Prompt2 = value
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_HISTORY_FILE",
+		desc:  "Path to the history file.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Display.HistoryFile) },
+	},
+	{
+		name:  "CLI_VERTEXAI_PROJECT",
+		desc:  "Vertex AI project for natural language features.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Feature.VertexAIProject) },
+	},
+	{
+		name:  "CLI_VERTEXAI_MODEL",
+		desc:  "Vertex AI model for natural language features.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Feature.VertexAIModel) },
+	},
+	{
+		name:  "CLI_VERTEXAI_LOCATION",
+		desc:  "Vertex AI location for natural language features.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Feature.VertexAILocation) },
+	},
+	{
+		name:  "CLI_ROLE",
+		desc:  "Cloud Spanner database role.",
+		scope: scopeConnection,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Connection.Role) },
+	},
+	{
+		name:  "CLI_HOST",
+		desc:  "Host on which Spanner server is located",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Config.Host) },
+	},
+	{
+		name:  "CLI_EMULATOR_PLATFORM",
+		desc:  "Container platform used by embedded emulator.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Config.EmulatorPlatform) },
+	},
+	{
+		name:  "CLI_IMPERSONATE_SERVICE_ACCOUNT",
+		desc:  "Service account to impersonate.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Config.ImpersonateServiceAccount) },
+	},
+
+	// === Integer variables ===
+	{
+		name:  "MAX_PARTITIONED_PARALLELISM",
+		desc:  "A property of type INT64 indicating the number of worker threads the spanner-mycli uses to execute partitions. This value is used for AUTO_PARTITION_MODE=TRUE and RUN PARTITIONED QUERY",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return IntVar(&sv.Query.MaxPartitionedParallelism) },
+	},
+	{
+		name:  "CLI_TAB_WIDTH",
+		desc:  "Tab width. It is used for expanding tabs.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return IntVar(&sv.Display.TabWidth) },
+	},
+	{
+		name:  "CLI_EXPLAIN_WRAP_WIDTH",
+		desc:  "Controls query plan wrap width. It effects only operators column contents",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return IntVar(&sv.Display.ExplainWrapWidth) },
+	},
+	{
+		name:  "CLI_TABLE_PREVIEW_ROWS",
+		desc:  "Number of rows to preview for table width calculation in streaming mode. 0 means use header widths only. Positive values use that many rows for preview (default: 50). -1 means collect all rows (non-streaming).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return IntVar(&sv.Query.TablePreviewRows) },
+	},
+	{
+		name:  "CLI_SQL_TABLE_NAME",
+		desc:  "Table name for generated SQL statements. Required for SQL export formats. Supports both simple names (e.g., 'Users') and schema-qualified names (e.g., 'myschema.Users').",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return StringVar(&sv.Display.SQLTableName) },
+	},
+	{
+		name:  "CLI_SQL_BATCH_SIZE",
+		desc:  "Number of VALUES per INSERT statement for SQL export. 0 (default): single-row INSERT statements. 2+: multi-row INSERT with up to N rows per statement.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return IntVar(&sv.Display.SQLBatchSize) },
+	},
+	{
+		name:  "CLI_SUPPRESS_RESULT_LINES",
+		desc:  "Suppress result lines like 'rows in set' for clean output. Useful for scripting and dump operations.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Display.SuppressResultLines) },
+	},
+	{
+		name:  "CLI_PORT",
+		desc:  "Port number for connections.",
+		scope: scopeStartup,
+		bind: func(sv *systemVariables) Variable {
+			return &IntGetterVar{getter: func() int64 { return int64(sv.Config.Port) }}
+		},
+	},
+
+	// === Nullable types ===
+	{
+		name:  "MAX_COMMIT_DELAY",
+		desc:  "The amount of latency this request is configured to incur in order to improve throughput. You can specify it as duration between 0 and 500ms.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return NullableDurationVar(&sv.Transaction.MaxCommitDelay).
+				WithValidator(durationValidator(durationPtr(0), durationPtr(500*time.Millisecond)))
+		},
+	},
+	{
+		name:  "STATEMENT_TIMEOUT",
+		desc:  "A property of type STRING indicating the current timeout value for statements (e.g., 10s, 5m, 1h). Default is 10m.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return NullableDurationVar(&sv.Query.StatementTimeout).
+				WithValidator(durationValidator(durationPtr(0), nil))
+		},
+	},
+	{
+		name:  "CLI_FIXED_WIDTH",
+		desc:  "If set, limits output width to the specified number of characters. NULL means automatic width detection.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return NullableIntVar(&sv.Display.FixedWidth) },
+	},
+
+	// === Proto Enum types ===
+	{
+		name:  "RPC_PRIORITY",
+		desc:  "A property of type STRING indicating the relative priority for Spanner requests. The priority acts as a hint to the Spanner scheduler and doesn't guarantee order of execution.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return RPCPriorityVar(&sv.Query.RPCPriority) },
+	},
+	{
+		name:  "DEFAULT_ISOLATION_LEVEL",
+		desc:  "The transaction isolation level that is used by default for read/write transactions.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return IsolationLevelVar(&sv.Transaction.DefaultIsolationLevel) },
+	},
+	{
+		name:  "READ_LOCK_MODE",
+		desc:  "The read lock mode for read/write transactions. OPTIMISTIC uses optimistic concurrency control; PESSIMISTIC uses pessimistic locking. Default is UNSPECIFIED (server default).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return ReadLockModeVar(&sv.Transaction.ReadLockMode) },
+	},
+	{
+		name:  "CLI_DATABASE_DIALECT",
+		desc:  "Database dialect for the session.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return DatabaseDialectVar(&sv.Feature.DatabaseDialect) },
+	},
+	{
+		name:  "CLI_QUERY_MODE",
+		desc:  "Query execution mode.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: QueryModeVar(func() *sppb.ExecuteSqlRequest_QueryMode {
+					// Use a zero-value pointer just for ValidValues() / description;
+					// actual get/set are handled by custom getter/setter below.
+					var mode sppb.ExecuteSqlRequest_QueryMode
+					return &mode
+				}()),
+				customGetter: func() (string, error) {
+					if sv.Query.QueryMode == nil {
+						return "NULL", nil
+					}
+					mode := *sv.Query.QueryMode
+					return QueryModeVar(&mode).Get()
+				},
+				customSetter: func(value string) error {
+					if strings.EqualFold(value, "NULL") {
+						sv.Query.QueryMode = nil
+						return nil
+					}
+					if sv.Query.QueryMode == nil {
+						sv.Query.QueryMode = new(sppb.ExecuteSqlRequest_QueryMode)
+					}
+					mode := *sv.Query.QueryMode
+					err := QueryModeVar(&mode).Set(value)
+					if err != nil {
+						return err
+					}
+					*sv.Query.QueryMode = mode
+					return nil
+				},
+			}
+		},
+	},
+
+	// === Custom enum types ===
+	{
+		name:  "AUTOCOMMIT_DML_MODE",
+		desc:  "A STRING property indicating the autocommit mode for Data Manipulation Language (DML) statements.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return AutocommitDMLModeVar(&sv.Transaction.AutocommitDMLMode) },
+	},
+	{
+		name:  "CLI_FORMAT",
+		desc:  "Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated, raw values), TSV (tab-separated with tab/newline/carriage-return/backslash escaping), HTML (HTML table), XML (XML format), CSV (comma-separated values).",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return DisplayModeVar(&sv.Display.CLIFormat) },
+	},
+	{
+		name:  "CLI_PARSE_MODE",
+		desc:  "Controls statement parsing mode: FALLBACK (default), NO_MEMEFISH, MEMEFISH_ONLY, or UNSPECIFIED",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return ParseModeVar(&sv.Query.BuildStatementMode) },
+	},
+	{
+		name:  "CLI_EXPLAIN_FORMAT",
+		desc:  "Controls query plan notation. CURRENT(default): new notation, TRADITIONAL: spanner-cli compatible notation, COMPACT: compact notation.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: ExplainFormatVar(&sv.Display.ExplainFormat),
+				customSetter: func(value string) error {
+					if value == "" {
+						sv.Display.ExplainFormat = enums.ExplainFormatUnspecified
+						return nil
+					}
+					return ExplainFormatVar(&sv.Display.ExplainFormat).Set(value)
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_EXPLAIN_PRINT_SECTIONS",
+		desc:  "Query plan appendix preset or comma-separated sections to print. Presets: basic, enhanced, full, none. Sections: predicates, ordering, aggregate, typed, full. Empty string suppresses appendices.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: StringVar(&sv.Display.ExplainPrintSections),
+				customSetter: func(value string) error {
+					sections, err := parseExplainPrintSections(value)
+					if err != nil {
+						return err
+					}
+					sv.Display.ExplainPrintSections = value
+					sv.Display.ParsedExplainPrintSections = sections
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_LOG_LEVEL",
+		desc:  "Log level for the CLI.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return &LogLevelVar{ptr: &sv.Feature.LogLevel} },
+	},
+
+	// === Computed/Read-only variables ===
+	{
+		name:  "CLI_VERSION",
+		desc:  "The version of spanner-mycli.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return NewReadOnlyVar(getVersion) },
+	},
+	{
+		name:  "CLI_CURRENT_WIDTH",
+		desc:  "Current terminal width. Returns NULL if not connected to a terminal.",
+		scope: scopeStartup,
+		bind: func(sv *systemVariables) Variable {
+			return NewReadOnlyVar(func() string {
+				if sv.StreamManager != nil {
+					return sv.StreamManager.GetTerminalWidthString()
+				}
+				return "NULL"
+			})
+		},
+	},
+	{
+		name:  "READ_TIMESTAMP",
+		desc:  "The read timestamp of the most recent read-only transaction.",
+		scope: scopeResult,
+		bind:  func(sv *systemVariables) Variable { return &TimestampVar{ptr: &sv.LastResult.ReadTimestamp} },
+	},
+	{
+		name:  "COMMIT_TIMESTAMP",
+		desc:  "The commit timestamp of the last read-write transaction that Spanner committed.",
+		scope: scopeResult,
+		bind:  func(sv *systemVariables) Variable { return &TimestampVar{ptr: &sv.LastResult.CommitTimestamp} },
+	},
+
+	// === Complex variables ===
+	{
+		name:  "READ_ONLY_STALENESS",
+		desc:  "A property of type STRING for read-only transactions with flexible staleness.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return &TimestampBoundVar{ptr: &sv.Query.ReadOnlyStaleness} },
+	},
+	{
+		name:  "CLI_PROTO_DESCRIPTOR_FILE",
+		desc:  "Comma-separated list of proto descriptor files. Supports ADD to append files.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &ProtoDescriptorVar{
+				filesPtr:      &sv.Internal.ProtoDescriptorFile,
+				descriptorPtr: &sv.Internal.ProtoDescriptor,
+			}
+		},
+		bindAdd: func(sv *systemVariables) func(string) error {
+			return (&ProtoDescriptorVar{
+				filesPtr:      &sv.Internal.ProtoDescriptorFile,
+				descriptorPtr: &sv.Internal.ProtoDescriptor,
+			}).Add
+		},
+	},
+	{
+		name: "CLI_TYPE_STYLES",
+		desc: "Type-based ANSI styling for query results. Format: colon-separated TYPE=STYLE pairs (e.g., 'STRING=green:INT64=bold:NULL=dim'). " +
+			"Supports named colors (red, green, yellow, blue, magenta, cyan, white, black), " +
+			"attributes (bold, dim, italic, underline, reverse, strikethrough), " +
+			"and raw SGR numbers (e.g., 38;5;214 for 256-color). " +
+			"NULL key overrides the default dim style for NULL values. Empty string disables type styling.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: StringVar(&sv.Display.TypeStylesRaw),
+				customGetter: func() (string, error) {
+					return sv.Display.TypeStylesRaw, nil
+				},
+				customSetter: func(value string) error {
+					if strings.EqualFold(value, "NULL") {
+						value = ""
+					}
+					config, err := parseTypeStyles(value)
+					if err != nil {
+						return err
+					}
+					sv.Display.TypeStylesRaw = value
+					sv.typeStyles = config.typeStyles
+					sv.nullStyle = config.nullStyle
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_ENDPOINT",
+		desc:  "Host and port for connections (host:port format).",
+		scope: scopeStartup,
+		bind: func(sv *systemVariables) Variable {
+			return &EndpointVar{
+				hostPtr: &sv.Config.Host,
+				portPtr: &sv.Config.Port,
+			}
+		},
+	},
+	{
+		name:  "CLI_OUTPUT_TEMPLATE_FILE",
+		desc:  "Go text/template for formatting the output of the CLI.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: StringVar(&sv.Display.OutputTemplateFile),
+				customGetter: func() (string, error) {
+					return sv.Display.OutputTemplateFile, nil
+				},
+				customSetter: func(value string) error {
+					// Parse and set template.
+					// An empty value (or NULL) restores the built-in default template
+					// (defaultOutputFormat), matching the startup default when no
+					// --output-template flag is given. This keeps SET and startup in
+					// sync so Get/Set round-trips (relied on by RESET ALL) hold.
+					if value == "" || strings.EqualFold(value, "NULL") {
+						sv.Display.OutputTemplateFile = ""
+						sv.Display.OutputTemplate = defaultOutputFormat
+						return nil
+					}
+
+					tmpl, err := parseOutputTemplate(value)
+					if err != nil {
+						return err
+					}
+					sv.Display.OutputTemplateFile = value
+					sv.Display.OutputTemplate = tmpl
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_ANALYZE_COLUMNS",
+		desc:  "Go template for analyzing column data.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &TemplateVar{
+				stringPtr: &sv.Display.AnalyzeColumns,
+				parsedPtr: &sv.Display.ParsedAnalyzeColumns,
+				parseFunc: func(value string) error {
+					parsed, err := parseAnalyzeColumns(value)
+					if err != nil {
+						return err
+					}
+					sv.Display.ParsedAnalyzeColumns = parsed
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_INLINE_STATS",
+		desc:  "<name>:<template>, ...",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &TemplateVar{
+				stringPtr: &sv.Display.InlineStats,
+				parsedPtr: &sv.Display.ParsedInlineStats,
+				parseFunc: func(value string) error {
+					parsed, err := parseInlineStats(value)
+					if err != nil {
+						return err
+					}
+					sv.Display.ParsedInlineStats = parsed
+					return nil
+				},
+			}
+		},
+	},
+	{
+		// CLI_ENABLE_ADC_PLUS is a session-init-only variable.
+		// Currently implemented using a custom setter that checks inTransaction != nil
+		// to detect whether a session has been created. Could use native support
+		// for session-init-only behavior if added to the varDef metadata.
+		name:  "CLI_ENABLE_ADC_PLUS",
+		desc:  "A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true.",
+		scope: scopeSession,
+		bind: func(sv *systemVariables) Variable {
+			return &CustomVar{
+				base: BoolVar(&sv.Config.EnableADCPlus),
+				customSetter: func(value string) error {
+					if sv.inTransaction != nil {
+						return fmt.Errorf("CLI_ENABLE_ADC_PLUS cannot be changed after session creation")
+					}
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return err
+					}
+					sv.Config.EnableADCPlus = b
+					return nil
+				},
+			}
+		},
+	},
+	{
+		name:  "CLI_MCP",
+		desc:  "A read-only boolean indicating whether the connection is running as an MCP server.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Config.MCP) },
+	},
+	{
+		name:  "CLI_INSECURE",
+		desc:  "Skip TLS certificate verification (insecure).",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Config.Insecure) },
+	},
+	{
+		name:  "CLI_LOG_GRPC",
+		desc:  "Enable gRPC logging.",
+		scope: scopeStartup,
+		bind:  func(sv *systemVariables) Variable { return BoolVar(&sv.Config.LogGrpc) },
+	},
+
+	// === Unimplemented variables ===
+	{
+		name:  "AUTOCOMMIT",
+		desc:  "A boolean indicating whether or not the connection is in autocommit mode. The default is true.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return &UnimplementedVar{name: "AUTOCOMMIT"} },
+	},
+	{
+		name:  "RETRY_ABORTS_INTERNALLY",
+		desc:  "A boolean indicating whether the connection automatically retries aborted transactions. The default is true.",
+		scope: scopeSession,
+		bind:  func(sv *systemVariables) Variable { return &UnimplementedVar{name: "RETRY_ABORTS_INTERNALLY"} },
+	},
+}

--- a/internal/mycli/var_enum_handlers.go
+++ b/internal/mycli/var_enum_handlers.go
@@ -14,9 +14,8 @@ import (
 
 // EnumVar handles enum-like variables
 type EnumVar[T comparable] struct {
-	ptr         *T
-	values      map[string]T
-	description string
+	ptr    *T
+	values map[string]T
 }
 
 func (e *EnumVar[T]) Get() (string, error) {
@@ -47,14 +46,6 @@ func (e *EnumVar[T]) Set(value string) error {
 	return nil
 }
 
-func (e *EnumVar[T]) Description() string {
-	return e.description
-}
-
-func (e *EnumVar[T]) IsReadOnly() bool {
-	return false
-}
-
 // ValidValues returns sorted valid values as GoogleSQL string literals.
 func (e *EnumVar[T]) ValidValues() []string {
 	keys := slices.Sorted(maps.Keys(e.values))
@@ -66,11 +57,10 @@ func (e *EnumVar[T]) ValidValues() []string {
 
 // ProtoEnumVar handles Protocol Buffer enum variables
 type ProtoEnumVar[T ~int32] struct {
-	ptr         *T
-	values      map[string]int32
-	prefix      string
-	aliases     map[string]string // Additional aliases for enum values
-	description string
+	ptr     *T
+	values  map[string]int32
+	prefix  string
+	aliases map[string]string // Additional aliases for enum values
 }
 
 func (p *ProtoEnumVar[T]) Get() (string, error) {
@@ -142,14 +132,6 @@ func (p *ProtoEnumVar[T]) Set(value string) error {
 	return fmt.Errorf("invalid value \"%s\", must be one of: %s", value, strings.Join(validValues, ", "))
 }
 
-func (p *ProtoEnumVar[T]) Description() string {
-	return p.description
-}
-
-func (p *ProtoEnumVar[T]) IsReadOnly() bool {
-	return false
-}
-
 // ValidValues returns sorted prefix-stripped valid values as GoogleSQL string literals.
 func (p *ProtoEnumVar[T]) ValidValues() []string {
 	values := make([]string, 0, len(p.values))
@@ -166,16 +148,15 @@ func (p *ProtoEnumVar[T]) ValidValues() []string {
 
 // Helper functions to create proto enum handlers for common types
 
-func RPCPriorityVar(ptr *sppb.RequestOptions_Priority, desc string) *ProtoEnumVar[sppb.RequestOptions_Priority] {
+func RPCPriorityVar(ptr *sppb.RequestOptions_Priority) *ProtoEnumVar[sppb.RequestOptions_Priority] {
 	return &ProtoEnumVar[sppb.RequestOptions_Priority]{
-		ptr:         ptr,
-		values:      sppb.RequestOptions_Priority_value,
-		prefix:      "PRIORITY_",
-		description: desc,
+		ptr:    ptr,
+		values: sppb.RequestOptions_Priority_value,
+		prefix: "PRIORITY_",
 	}
 }
 
-func IsolationLevelVar(ptr *sppb.TransactionOptions_IsolationLevel, desc string) *ProtoEnumVar[sppb.TransactionOptions_IsolationLevel] {
+func IsolationLevelVar(ptr *sppb.TransactionOptions_IsolationLevel) *ProtoEnumVar[sppb.TransactionOptions_IsolationLevel] {
 	return &ProtoEnumVar[sppb.TransactionOptions_IsolationLevel]{
 		ptr:    ptr,
 		values: sppb.TransactionOptions_IsolationLevel_value,
@@ -183,26 +164,23 @@ func IsolationLevelVar(ptr *sppb.TransactionOptions_IsolationLevel, desc string)
 		aliases: map[string]string{
 			"UNSPECIFIED": "ISOLATION_LEVEL_UNSPECIFIED",
 		},
-		description: desc,
 	}
 }
 
-func DatabaseDialectVar(ptr *databasepb.DatabaseDialect, desc string) *ProtoEnumVar[databasepb.DatabaseDialect] {
+func DatabaseDialectVar(ptr *databasepb.DatabaseDialect) *ProtoEnumVar[databasepb.DatabaseDialect] {
 	return &ProtoEnumVar[databasepb.DatabaseDialect]{
 		ptr:    ptr,
 		values: databasepb.DatabaseDialect_value,
 		aliases: map[string]string{
 			"": "DATABASE_DIALECT_UNSPECIFIED",
 		},
-		description: desc,
 	}
 }
 
-func QueryModeVar(ptr *sppb.ExecuteSqlRequest_QueryMode, desc string) *ProtoEnumVar[sppb.ExecuteSqlRequest_QueryMode] {
+func QueryModeVar(ptr *sppb.ExecuteSqlRequest_QueryMode) *ProtoEnumVar[sppb.ExecuteSqlRequest_QueryMode] {
 	return &ProtoEnumVar[sppb.ExecuteSqlRequest_QueryMode]{
-		ptr:         ptr,
-		values:      sppb.ExecuteSqlRequest_QueryMode_value,
-		description: desc,
+		ptr:    ptr,
+		values: sppb.ExecuteSqlRequest_QueryMode_value,
 	}
 }
 
@@ -214,64 +192,57 @@ func enumerValues[T fmt.Stringer](values []T) map[string]T {
 }
 
 // DisplayModeVar creates an enum handler for DisplayMode
-func DisplayModeVar(ptr *enums.DisplayMode, desc string) *EnumVar[enums.DisplayMode] {
+func DisplayModeVar(ptr *enums.DisplayMode) *EnumVar[enums.DisplayMode] {
 	return &EnumVar[enums.DisplayMode]{
-		ptr:         ptr,
-		values:      enumerValues(enums.DisplayModeValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.DisplayModeValues()),
 	}
 }
 
 // ParseModeVar creates an enum handler for ParseMode
-func ParseModeVar(ptr *enums.ParseMode, desc string) *EnumVar[enums.ParseMode] {
+func ParseModeVar(ptr *enums.ParseMode) *EnumVar[enums.ParseMode] {
 	return &EnumVar[enums.ParseMode]{
-		ptr:         ptr,
-		values:      enumerValues(enums.ParseModeValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.ParseModeValues()),
 	}
 }
 
 // ExplainFormatVar creates an enum handler for ExplainFormat
-func ExplainFormatVar(ptr *enums.ExplainFormat, desc string) *EnumVar[enums.ExplainFormat] {
+func ExplainFormatVar(ptr *enums.ExplainFormat) *EnumVar[enums.ExplainFormat] {
 	return &EnumVar[enums.ExplainFormat]{
-		ptr:         ptr,
-		values:      enumerValues(enums.ExplainFormatValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.ExplainFormatValues()),
 	}
 }
 
 // ReadLockModeVar creates an enum handler for ReadLockMode
-func ReadLockModeVar(ptr *sppb.TransactionOptions_ReadWrite_ReadLockMode, desc string) *ProtoEnumVar[sppb.TransactionOptions_ReadWrite_ReadLockMode] {
+func ReadLockModeVar(ptr *sppb.TransactionOptions_ReadWrite_ReadLockMode) *ProtoEnumVar[sppb.TransactionOptions_ReadWrite_ReadLockMode] {
 	return &ProtoEnumVar[sppb.TransactionOptions_ReadWrite_ReadLockMode]{
-		ptr:         ptr,
-		values:      sppb.TransactionOptions_ReadWrite_ReadLockMode_value,
-		prefix:      "READ_LOCK_MODE_",
-		description: desc,
+		ptr:    ptr,
+		values: sppb.TransactionOptions_ReadWrite_ReadLockMode_value,
+		prefix: "READ_LOCK_MODE_",
 	}
 }
 
 // StreamingModeVar creates an enum handler for StreamingMode
-func StreamingModeVar(ptr *enums.StreamingMode, desc string) *EnumVar[enums.StreamingMode] {
+func StreamingModeVar(ptr *enums.StreamingMode) *EnumVar[enums.StreamingMode] {
 	return &EnumVar[enums.StreamingMode]{
-		ptr:         ptr,
-		values:      enumerValues(enums.StreamingModeValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.StreamingModeValues()),
 	}
 }
 
-func StyledModeVar(ptr *enums.StyledMode, desc string) *EnumVar[enums.StyledMode] {
+func StyledModeVar(ptr *enums.StyledMode) *EnumVar[enums.StyledMode] {
 	return &EnumVar[enums.StyledMode]{
-		ptr:         ptr,
-		values:      enumerValues(enums.StyledModeValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.StyledModeValues()),
 	}
 }
 
 // WidthStrategyVar creates an enum handler for WidthStrategy
-func WidthStrategyVar(ptr *enums.WidthStrategy, desc string) *EnumVar[enums.WidthStrategy] {
+func WidthStrategyVar(ptr *enums.WidthStrategy) *EnumVar[enums.WidthStrategy] {
 	return &EnumVar[enums.WidthStrategy]{
-		ptr:         ptr,
-		values:      enumerValues(enums.WidthStrategyValues()),
-		description: desc,
+		ptr:    ptr,
+		values: enumerValues(enums.WidthStrategyValues()),
 	}
 }

--- a/internal/mycli/var_handler.go
+++ b/internal/mycli/var_handler.go
@@ -8,12 +8,12 @@ import (
 	"time"
 )
 
-// Variable interface that all handlers implement
+// Variable is the minimal get/set surface every handler implements.
+// Metadata (description, read-only/scope) lives in the varDef table
+// (see var_defs.go); the registry enforces policy from the def, not the handler.
 type Variable interface {
 	Get() (string, error)
 	Set(string) error
-	Description() string
-	IsReadOnly() bool
 }
 
 // ValidValuesEnumerator is implemented by variables that have a constrained set of valid values.
@@ -28,23 +28,17 @@ func formatBool(b bool) string {
 	return strings.ToUpper(strconv.FormatBool(b))
 }
 
-// VarHandler handles get/set operations for a variable
+// VarHandler handles get/set operations for a variable.
 //
-// TODO: Consider adding native support for session-init-only variables.
-// Currently, variables like CLI_ENABLE_ADC_PLUS use custom setters to check
-// if a session has been created, but this could be better supported as a first-class
-// feature. Potential implementation:
-//   - Add a sessionInitOnly bool field to VarHandler
-//   - Move the session-existence check logic into the Set method
-//   - This would centralize the behavior and make it declarative rather than imperative
+// Read-only enforcement no longer lives here: the varDef's scope/readOnly
+// metadata drives it in VarRegistry.Set, so a handler only needs to know how
+// to format, parse, and validate its value.
 type VarHandler[T any] struct {
-	ptr         *T
-	format      func(T) string
-	parse       func(string) (T, error)
-	validate    func(T) error
-	readOnly    bool
-	description string
-	enumValues  []string // optional: constrained valid values for fuzzy completion
+	ptr        *T
+	format     func(T) string
+	parse      func(string) (T, error)
+	validate   func(T) error
+	enumValues []string // optional: constrained valid values for fuzzy completion
 }
 
 // Get returns the formatted value
@@ -57,10 +51,6 @@ func (h *VarHandler[T]) Get() (string, error) {
 
 // Set parses and sets the value
 func (h *VarHandler[T]) Set(value string) error {
-	if h.readOnly {
-		return errSetterReadOnly
-	}
-
 	parsed, err := h.parse(value)
 	if err != nil {
 		return err
@@ -81,22 +71,6 @@ func (h *VarHandler[T]) Set(value string) error {
 	return nil
 }
 
-// Description returns the variable description
-func (h *VarHandler[T]) Description() string {
-	return h.description
-}
-
-// IsReadOnly returns whether the variable is read-only
-func (h *VarHandler[T]) IsReadOnly() bool {
-	return h.readOnly
-}
-
-// AsReadOnly makes the handler read-only
-func (h *VarHandler[T]) AsReadOnly() *VarHandler[T] {
-	h.readOnly = true
-	return h
-}
-
 // ValidValues returns the constrained valid values, if any.
 // Implements ValidValuesEnumerator for VarHandler instances with enumValues set.
 func (h *VarHandler[T]) ValidValues() []string {
@@ -110,41 +84,37 @@ func (h *VarHandler[T]) WithValidator(validate func(T) error) *VarHandler[T] {
 }
 
 // BoolVar creates a handler for bool variables
-func BoolVar(ptr *bool, desc string) *VarHandler[bool] {
+func BoolVar(ptr *bool) *VarHandler[bool] {
 	return &VarHandler[bool]{
-		ptr:         ptr,
-		description: desc,
-		format:      formatBool,
-		parse:       strconv.ParseBool,
-		enumValues:  []string{"TRUE", "FALSE"},
+		ptr:        ptr,
+		format:     formatBool,
+		parse:      strconv.ParseBool,
+		enumValues: []string{"TRUE", "FALSE"},
 	}
 }
 
 // StringVar creates a handler for string variables
-func StringVar(ptr *string, desc string) *VarHandler[string] {
+func StringVar(ptr *string) *VarHandler[string] {
 	return &VarHandler[string]{
-		ptr:         ptr,
-		description: desc,
-		format:      func(s string) string { return s },
-		parse:       func(s string) (string, error) { return s, nil },
+		ptr:    ptr,
+		format: func(s string) string { return s },
+		parse:  func(s string) (string, error) { return s, nil },
 	}
 }
 
 // IntVar creates a handler for int64 variables
-func IntVar(ptr *int64, desc string) *VarHandler[int64] {
+func IntVar(ptr *int64) *VarHandler[int64] {
 	return &VarHandler[int64]{
-		ptr:         ptr,
-		description: desc,
-		format:      func(i int64) string { return strconv.FormatInt(i, 10) },
-		parse:       func(s string) (int64, error) { return strconv.ParseInt(s, 10, 64) },
+		ptr:    ptr,
+		format: func(i int64) string { return strconv.FormatInt(i, 10) },
+		parse:  func(s string) (int64, error) { return strconv.ParseInt(s, 10, 64) },
 	}
 }
 
 // NullableDurationVar creates a handler for nullable duration variables
-func NullableDurationVar(ptr **time.Duration, desc string) *VarHandler[*time.Duration] {
+func NullableDurationVar(ptr **time.Duration) *VarHandler[*time.Duration] {
 	return &VarHandler[*time.Duration]{
-		ptr:         ptr,
-		description: desc,
+		ptr: ptr,
 		format: func(d *time.Duration) string {
 			if d == nil {
 				return "NULL"
@@ -165,10 +135,9 @@ func NullableDurationVar(ptr **time.Duration, desc string) *VarHandler[*time.Dur
 }
 
 // NullableIntVar creates a handler for nullable int64 variables
-func NullableIntVar(ptr **int64, desc string) *VarHandler[*int64] {
+func NullableIntVar(ptr **int64) *VarHandler[*int64] {
 	return &VarHandler[*int64]{
-		ptr:         ptr,
-		description: desc,
+		ptr: ptr,
 		format: func(i *int64) string {
 			if i == nil {
 				return "NULL"
@@ -190,8 +159,7 @@ func NullableIntVar(ptr **int64, desc string) *VarHandler[*int64] {
 
 // ReadOnlyVar creates a read-only variable with custom getter
 type ReadOnlyVar struct {
-	getter      func() string
-	description string
+	getter func() string
 }
 
 func (r *ReadOnlyVar) Get() (string, error) {
@@ -202,19 +170,10 @@ func (r *ReadOnlyVar) Set(value string) error {
 	return errSetterReadOnly
 }
 
-func (r *ReadOnlyVar) Description() string {
-	return r.description
-}
-
-func (r *ReadOnlyVar) IsReadOnly() bool {
-	return true
-}
-
 // NewReadOnlyVar creates a new read-only variable
-func NewReadOnlyVar(getter func() string, desc string) *ReadOnlyVar {
+func NewReadOnlyVar(getter func() string) *ReadOnlyVar {
 	return &ReadOnlyVar{
-		getter:      getter,
-		description: desc,
+		getter: getter,
 	}
 }
 
@@ -237,14 +196,6 @@ func (c *CustomVar) Set(value string) error {
 		return c.customSetter(value)
 	}
 	return c.base.Set(value)
-}
-
-func (c *CustomVar) Description() string {
-	return c.base.Description()
-}
-
-func (c *CustomVar) IsReadOnly() bool {
-	return c.base.IsReadOnly()
 }
 
 // Helper function for duration validation

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -1,60 +1,72 @@
 package mycli
 
 import (
-	"fmt"
 	"log/slog"
 	"maps"
 	"strconv"
 	"strings"
-	"time"
 
-	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 )
 
+// registeredVar pairs a variable's declarative metadata (def) with its live
+// handler (v) and optional ADD handler. Policy (read-only/scope) is enforced
+// from def, so the handler only implements Get/Set.
+type registeredVar struct {
+	def *varDef
+	v   Variable
+	add func(string) error
+}
+
 // VarRegistry is a registry for system variables
 type VarRegistry struct {
-	vars        map[string]Variable
-	addHandlers map[string]func(string) error // For ADD operations
-	sv          *systemVariables
+	vars map[string]*registeredVar
+	sv   *systemVariables
 }
 
 // NewVarRegistry creates a new variable registry
 func NewVarRegistry(sv *systemVariables) *VarRegistry {
 	r := &VarRegistry{
-		vars:        make(map[string]Variable),
-		addHandlers: make(map[string]func(string) error),
-		sv:          sv,
+		vars: make(map[string]*registeredVar),
+		sv:   sv,
 	}
 	r.registerAll()
 	return r
 }
 
-// Register adds a variable to the registry
-func (r *VarRegistry) Register(name string, v Variable) {
-	r.vars[strings.ToUpper(name)] = v
-}
-
-// RegisterWithAdd adds a variable with ADD support
-func (r *VarRegistry) RegisterWithAdd(name string, v Variable, addFunc func(string) error) {
-	r.Register(name, v)
-	r.addHandlers[strings.ToUpper(name)] = addFunc
+// registerAll builds the live registry from the declarative varDefs table.
+func (r *VarRegistry) registerAll() {
+	sv := r.sv
+	for i := range varDefs {
+		def := &varDefs[i]
+		rv := &registeredVar{
+			def: def,
+			v:   def.bind(sv),
+		}
+		if def.bindAdd != nil {
+			rv.add = def.bindAdd(sv)
+		}
+		r.vars[strings.ToUpper(def.name)] = rv
+	}
 }
 
 // GetVariable retrieves the Variable handler by name, or nil if not found.
 func (r *VarRegistry) GetVariable(name string) Variable {
-	return r.vars[strings.ToUpper(name)]
+	rv, ok := r.vars[strings.ToUpper(name)]
+	if !ok {
+		return nil
+	}
+	return rv.v
 }
 
 // Get retrieves a variable value
 func (r *VarRegistry) Get(name string) (string, error) {
-	v, ok := r.vars[strings.ToUpper(name)]
+	rv, ok := r.vars[strings.ToUpper(name)]
 	if !ok {
 		return "", &ErrUnknownVariable{Name: name}
 	}
-	value, err := v.Get()
+	value, err := rv.v.Get()
 	if err != nil {
 		return "", err
 	}
@@ -64,10 +76,16 @@ func (r *VarRegistry) Get(name string) (string, error) {
 // Set sets a variable value
 func (r *VarRegistry) Set(name, value string, isGoogleSQL bool) error {
 	upperName := strings.ToUpper(name)
-	v, ok := r.vars[upperName]
+	rv, ok := r.vars[upperName]
 	if !ok {
 		slog.Debug("Variable not found in registry", "name", upperName, "availableVars", maps.Keys(r.vars))
 		return &ErrUnknownVariable{Name: name}
+	}
+
+	// Read-only enforcement lives here, driven by the def's scope/readOnly
+	// metadata, rather than inside each handler's Set.
+	if !rv.def.settable() {
+		return errSetterReadOnly
 	}
 
 	// Parse GoogleSQL value if needed
@@ -78,7 +96,7 @@ func (r *VarRegistry) Set(name, value string, isGoogleSQL bool) error {
 
 	slog.Debug("Registry.Set", "name", upperName, "originalValue", originalValue, "parsedValue", value, "isGoogleSQL", isGoogleSQL)
 
-	err := v.Set(value)
+	err := rv.v.Set(value)
 	slog.Debug("Registry.Set result", "name", upperName, "err", err)
 	return err
 }
@@ -88,41 +106,41 @@ func (r *VarRegistry) Add(name, value string) error {
 	upperName := strings.ToUpper(name)
 
 	// First check if the variable exists
-	if _, ok := r.vars[upperName]; !ok {
+	rv, ok := r.vars[upperName]
+	if !ok {
 		return &ErrUnknownVariable{Name: name}
 	}
 
 	// Then check if it supports ADD
-	addFunc, ok := r.addHandlers[upperName]
-	if !ok {
+	if rv.add == nil {
 		return &ErrAddNotSupported{Name: name}
 	}
-	return addFunc(value)
+	return rv.add(value)
 }
 
 // GetDescription returns variable description
 func (r *VarRegistry) GetDescription(name string) (string, error) {
-	v, ok := r.vars[strings.ToUpper(name)]
+	rv, ok := r.vars[strings.ToUpper(name)]
 	if !ok {
 		return "", &ErrUnknownVariable{Name: name}
 	}
-	return v.Description(), nil
+	return rv.def.desc, nil
 }
 
 // IsReadOnly checks if a variable is read-only
 func (r *VarRegistry) IsReadOnly(name string) (bool, error) {
-	v, ok := r.vars[strings.ToUpper(name)]
+	rv, ok := r.vars[strings.ToUpper(name)]
 	if !ok {
 		return false, &ErrUnknownVariable{Name: name}
 	}
-	return v.IsReadOnly(), nil
+	return !rv.def.settable(), nil
 }
 
 // ListVariables returns a map of all variables with their current values
 func (r *VarRegistry) ListVariables() map[string]string {
 	result := make(map[string]string)
-	for name, v := range r.vars {
-		value, err := v.Get()
+	for name, rv := range r.vars {
+		value, err := rv.v.Get()
 		if err == nil {
 			result[name] = value
 		}
@@ -142,381 +160,19 @@ func (r *VarRegistry) ListVariableInfo() map[string]struct {
 		CanAdd      bool
 	})
 
-	for name, v := range r.vars {
-		_, hasAdd := r.addHandlers[name]
+	for name, rv := range r.vars {
 		result[name] = struct {
 			Description string
 			ReadOnly    bool
 			CanAdd      bool
 		}{
-			Description: v.Description(),
-			ReadOnly:    v.IsReadOnly(),
-			CanAdd:      hasAdd,
+			Description: rv.def.desc,
+			ReadOnly:    !rv.def.settable(),
+			CanAdd:      rv.add != nil,
 		}
 	}
 
 	return result
-}
-
-// registerAll registers all system variables
-func (r *VarRegistry) registerAll() {
-	sv := r.sv
-
-	// === Simple boolean variables (30+) ===
-	r.Register("READONLY", &CustomVar{
-		base: BoolVar(&sv.Transaction.ReadOnly, "A boolean indicating whether or not the connection is in read-only mode"),
-		customSetter: func(value string) error {
-			// Custom validation for READONLY
-			if sv.inTransaction != nil && sv.inTransaction() {
-				return errSetterInTransaction
-			}
-			b, err := strconv.ParseBool(value)
-			if err != nil {
-				return err
-			}
-			sv.Transaction.ReadOnly = b
-			return nil
-		},
-	})
-
-	r.Register("AUTO_PARTITION_MODE", BoolVar(&sv.Query.AutoPartitionMode,
-		"A property of type BOOL indicating whether the connection automatically uses partitioned queries for all queries that are executed."))
-	r.Register("DATA_BOOST_ENABLED", BoolVar(&sv.Query.DataBoostEnabled,
-		"A property of type BOOL indicating whether this connection should use Data Boost for partitioned queries. The default is false."))
-	r.Register("AUTO_BATCH_DML", BoolVar(&sv.Transaction.AutoBatchDML,
-		"A property of type BOOL indicating whether the DML is executed immediately or begins a batch DML. The default is false."))
-	r.Register("EXCLUDE_TXN_FROM_CHANGE_STREAMS", BoolVar(&sv.Transaction.ExcludeTxnFromChangeStreams,
-		"Controls whether to exclude recording modifications in current transaction from the allowed tracking change streams(with DDL option allow_txn_exclusion=true)."))
-	r.Register("RETURN_COMMIT_STATS", BoolVar(&sv.Transaction.ReturnCommitStats,
-		"A property of type BOOL indicating whether statistics should be returned for transactions on this connection."))
-	r.Register("CLI_VERBOSE", BoolVar(&sv.Display.Verbose, "Display verbose output."))
-	r.Register("CLI_PROFILE", BoolVar(&sv.Query.Profile, "Enable performance profiling (memory and timing metrics)."))
-	r.Register("CLI_LINT_PLAN", BoolVar(&sv.Query.LintPlan, "Enable query plan linting."))
-	r.Register("CLI_USE_PAGER", BoolVar(&sv.Display.UsePager, "Enable pager for output."))
-	r.Register("CLI_AUTOWRAP", BoolVar(&sv.Display.AutoWrap, "Enable automatic line wrapping."))
-	r.Register("CLI_ENABLE_HIGHLIGHT", BoolVar(&sv.Display.EnableHighlight, "Enable syntax highlighting."))
-	r.Register("CLI_PROTOTEXT_MULTILINE", BoolVar(&sv.Display.MultilineProtoText, "Enable multiline prototext output."))
-	r.Register("CLI_MARKDOWN_CODEBLOCK", BoolVar(&sv.Display.MarkdownCodeblock, "Enable markdown codeblock output."))
-	r.Register("CLI_TRY_PARTITION_QUERY", BoolVar(&sv.Query.TryPartitionQuery,
-		"A boolean indicating whether to test query for partition compatibility instead of executing it."))
-	r.Register("CLI_ECHO_EXECUTED_DDL", BoolVar(&sv.Feature.EchoExecutedDDL, "Echo executed DDL statements."))
-	r.Register("CLI_ECHO_INPUT", BoolVar(&sv.Feature.EchoInput, "Echo input statements."))
-	r.Register("CLI_AUTO_CONNECT_AFTER_CREATE", BoolVar(&sv.Feature.AutoConnectAfterCreate,
-		"A boolean indicating whether to automatically connect to a database after CREATE DATABASE. The default is false."))
-	r.Register("CLI_ENABLE_PROGRESS_BAR", BoolVar(&sv.Display.EnableProgressBar,
-		"A boolean indicating whether to display progress bars during operations. The default is false."))
-	r.Register("CLI_ASYNC_DDL", BoolVar(&sv.Feature.AsyncDDL,
-		"A boolean indicating whether DDL statements should be executed asynchronously. The default is false."))
-	// Read-only: this is a security feature (--skip-system-command /
-	// --system-command=OFF); if it were settable, a user in a restricted
-	// environment could re-enable shell access with a single SET.
-	r.Register("CLI_SKIP_SYSTEM_COMMAND", BoolVar(&sv.Config.SkipSystemCommand,
-		"A read-only boolean indicating whether system commands are disabled. Set by --skip-system-command or --system-command=OFF.").AsReadOnly())
-	r.Register("CLI_TAB_VISUALIZE", BoolVar(&sv.Display.TabVisualize, "Visualize tab characters with arrow symbol in table output."))
-	r.Register("CLI_SKIP_COLUMN_NAMES", BoolVar(&sv.Display.SkipColumnNames,
-		"A boolean indicating whether to suppress column headers in output. The default is false."))
-	r.Register("CLI_EXPLAIN_HANGING_INDENT", BoolVar(&sv.Display.ExplainHangingIndent,
-		"Use hanging indent for wrapped query plan lines in EXPLAIN, EXPLAIN ANALYZE, and query profile rendering. Only affects output when CLI_EXPLAIN_WRAP_WIDTH or WIDTH is set."))
-	r.Register("CLI_FUZZY_FINDER_KEY", StringVar(&sv.Feature.FuzzyFinderKey,
-		"Key binding for fuzzy finder. Uses go-readline-ny key names (e.g., C_T, M_F, F1). Set to empty string to disable. The default is C_T (Ctrl+T)."))
-	r.Register("CLI_FUZZY_FINDER_OPTIONS", StringVar(&sv.Feature.FuzzyFinderOptions,
-		"Additional fzf options passed to the fuzzy finder. Appended after built-in defaults, so user options take precedence. Example: --color=dark --no-select-1"))
-	r.Register("CLI_TABLE_STREAMING", StreamingModeVar(&sv.Query.StreamingMode,
-		"Controls table streaming output mode: AUTO/FALSE buffer table output for layout quality, TRUE streams table output. Non-table formats always stream. Default is AUTO."))
-	r.Register("CLI_STYLED_OUTPUT", StyledModeVar(&sv.Display.StyledOutput,
-		"Controls ANSI styling in table output: AUTO (styled if TTY), TRUE (always styled), FALSE (never styled). Default is AUTO."))
-	r.Register("CLI_WIDTH_STRATEGY", WidthStrategyVar(&sv.Display.WidthStrategy,
-		"Controls column width allocation algorithm: GREEDY_FREQUENCY (default, frequency-based greedy), PROPORTIONAL (proportional to natural width), MARGINAL_COST (wrap-line minimization via max-heap)."))
-
-	// === String variables (15+) ===
-	r.Register("OPTIMIZER_VERSION", StringVar(&sv.Query.OptimizerVersion,
-		"A property of type STRING indicating the optimizer version. The version is either an integer string or LATEST."))
-	r.Register("OPTIMIZER_STATISTICS_PACKAGE", StringVar(&sv.Query.OptimizerStatisticsPackage,
-		"A property of type STRING indicating the current optimizer statistics package that is used by this connection."))
-	r.Register("TRANSACTION_TAG", StringVar(&sv.Transaction.TransactionTag,
-		"A property of type STRING that contains the transaction tag for the next transaction."))
-	r.Register("STATEMENT_TAG", StringVar(&sv.Transaction.RequestTag,
-		"A property of type STRING that contains the request tag for the next statement."))
-	r.Register("CLI_PROJECT", StringVar(&sv.Connection.Project, "GCP Project ID.").AsReadOnly())
-	r.Register("CLI_INSTANCE", StringVar(&sv.Connection.Instance, "Cloud Spanner instance ID.").AsReadOnly())
-	r.Register("CLI_DATABASE", StringVar(&sv.Connection.Database, "Cloud Spanner database ID.").AsReadOnly())
-	r.Register("CLI_PROMPT", StringVar(&sv.Display.Prompt, "Custom prompt for spanner-mycli."))
-	r.Register("CLI_PROMPT2", &CustomVar{
-		base: StringVar(&sv.Display.Prompt2, "Custom continuation prompt for spanner-mycli."),
-		customSetter: func(value string) error {
-			if value == "" {
-				return fmt.Errorf("CLI_PROMPT2 cannot be empty")
-			}
-			sv.Display.Prompt2 = value
-			return nil
-		},
-	})
-	r.Register("CLI_HISTORY_FILE", StringVar(&sv.Display.HistoryFile, "Path to the history file.").AsReadOnly())
-	r.Register("CLI_VERTEXAI_PROJECT", StringVar(&sv.Feature.VertexAIProject, "Vertex AI project for natural language features."))
-	r.Register("CLI_VERTEXAI_MODEL", StringVar(&sv.Feature.VertexAIModel, "Vertex AI model for natural language features."))
-	r.Register("CLI_VERTEXAI_LOCATION", StringVar(&sv.Feature.VertexAILocation, "Vertex AI location for natural language features."))
-	r.Register("CLI_ROLE", StringVar(&sv.Connection.Role, "Cloud Spanner database role.").AsReadOnly())
-	r.Register("CLI_HOST", StringVar(&sv.Config.Host, "Host on which Spanner server is located").AsReadOnly())
-	r.Register("CLI_EMULATOR_PLATFORM", StringVar(&sv.Config.EmulatorPlatform, "Container platform used by embedded emulator.").AsReadOnly())
-	r.Register("CLI_IMPERSONATE_SERVICE_ACCOUNT", StringVar(&sv.Config.ImpersonateServiceAccount, "Service account to impersonate.").AsReadOnly())
-
-	// === Integer variables (10+) ===
-	r.Register("MAX_PARTITIONED_PARALLELISM", IntVar(&sv.Query.MaxPartitionedParallelism,
-		"A property of type INT64 indicating the number of worker threads the spanner-mycli uses to execute partitions. This value is used for AUTO_PARTITION_MODE=TRUE and RUN PARTITIONED QUERY"))
-	r.Register("CLI_TAB_WIDTH", IntVar(&sv.Display.TabWidth, "Tab width. It is used for expanding tabs."))
-	r.Register("CLI_EXPLAIN_WRAP_WIDTH", IntVar(&sv.Display.ExplainWrapWidth,
-		"Controls query plan wrap width. It effects only operators column contents"))
-	r.Register("CLI_TABLE_PREVIEW_ROWS", IntVar(&sv.Query.TablePreviewRows,
-		"Number of rows to preview for table width calculation in streaming mode. 0 means use header widths only. Positive values use that many rows for preview (default: 50). -1 means collect all rows (non-streaming)."))
-	r.Register("CLI_SQL_TABLE_NAME", StringVar(&sv.Display.SQLTableName,
-		"Table name for generated SQL statements. Required for SQL export formats. Supports both simple names (e.g., 'Users') and schema-qualified names (e.g., 'myschema.Users')."))
-	r.Register("CLI_SQL_BATCH_SIZE", IntVar(&sv.Display.SQLBatchSize,
-		"Number of VALUES per INSERT statement for SQL export. 0 (default): single-row INSERT statements. 2+: multi-row INSERT with up to N rows per statement."))
-	r.Register("CLI_SUPPRESS_RESULT_LINES", BoolVar(&sv.Display.SuppressResultLines,
-		"Suppress result lines like 'rows in set' for clean output. Useful for scripting and dump operations."))
-	r.Register("CLI_PORT", &IntGetterVar{
-		getter:      func() int64 { return int64(sv.Config.Port) },
-		description: "Port number for connections.",
-	})
-
-	// === Nullable types (5+) ===
-	r.Register("MAX_COMMIT_DELAY", NullableDurationVar(&sv.Transaction.MaxCommitDelay,
-		"The amount of latency this request is configured to incur in order to improve throughput. You can specify it as duration between 0 and 500ms.").
-		WithValidator(durationValidator(durationPtr(0), durationPtr(500*time.Millisecond))))
-	r.Register("STATEMENT_TIMEOUT", NullableDurationVar(&sv.Query.StatementTimeout,
-		"A property of type STRING indicating the current timeout value for statements (e.g., 10s, 5m, 1h). Default is 10m.").
-		WithValidator(durationValidator(durationPtr(0), nil)))
-	r.Register("CLI_FIXED_WIDTH", NullableIntVar(&sv.Display.FixedWidth,
-		"If set, limits output width to the specified number of characters. NULL means automatic width detection."))
-
-	// === Proto Enum types (5) ===
-	r.Register("RPC_PRIORITY", RPCPriorityVar(&sv.Query.RPCPriority,
-		"A property of type STRING indicating the relative priority for Spanner requests. The priority acts as a hint to the Spanner scheduler and doesn't guarantee order of execution."))
-	r.Register("DEFAULT_ISOLATION_LEVEL", IsolationLevelVar(&sv.Transaction.DefaultIsolationLevel,
-		"The transaction isolation level that is used by default for read/write transactions."))
-	r.Register("READ_LOCK_MODE", ReadLockModeVar(&sv.Transaction.ReadLockMode,
-		"The read lock mode for read/write transactions. OPTIMISTIC uses optimistic concurrency control; PESSIMISTIC uses pessimistic locking. Default is UNSPECIFIED (server default)."))
-
-	r.Register("CLI_DATABASE_DIALECT", DatabaseDialectVar(&sv.Feature.DatabaseDialect,
-		"Database dialect for the session."))
-	r.Register("CLI_QUERY_MODE", &CustomVar{
-		base: QueryModeVar(func() *sppb.ExecuteSqlRequest_QueryMode {
-			// Use a zero-value pointer just for ValidValues() / description;
-			// actual get/set are handled by custom getter/setter below.
-			var mode sppb.ExecuteSqlRequest_QueryMode
-			return &mode
-		}(), "Query execution mode."),
-		customGetter: func() (string, error) {
-			if sv.Query.QueryMode == nil {
-				return "NULL", nil
-			}
-			mode := *sv.Query.QueryMode
-			return QueryModeVar(&mode, "").Get()
-		},
-		customSetter: func(value string) error {
-			if strings.EqualFold(value, "NULL") {
-				sv.Query.QueryMode = nil
-				return nil
-			}
-			if sv.Query.QueryMode == nil {
-				sv.Query.QueryMode = new(sppb.ExecuteSqlRequest_QueryMode)
-			}
-			mode := *sv.Query.QueryMode
-			err := QueryModeVar(&mode, "").Set(value)
-			if err != nil {
-				return err
-			}
-			*sv.Query.QueryMode = mode
-			return nil
-		},
-	})
-
-	// === Custom enum types (4+) ===
-	r.Register("AUTOCOMMIT_DML_MODE", AutocommitDMLModeVar(&sv.Transaction.AutocommitDMLMode,
-		"A STRING property indicating the autocommit mode for Data Manipulation Language (DML) statements."))
-	r.Register("CLI_FORMAT", DisplayModeVar(&sv.Display.CLIFormat,
-		"Controls output format for query results. Valid values: TABLE (ASCII table), TABLE_COMMENT (table in comments), TABLE_DETAIL_COMMENT, VERTICAL (column:value pairs), TAB (tab-separated, raw values), TSV (tab-separated with tab/newline/carriage-return/backslash escaping), HTML (HTML table), XML (XML format), CSV (comma-separated values)."))
-	r.Register("CLI_PARSE_MODE", ParseModeVar(&sv.Query.BuildStatementMode,
-		"Controls statement parsing mode: FALLBACK (default), NO_MEMEFISH, MEMEFISH_ONLY, or UNSPECIFIED"))
-	r.Register("CLI_EXPLAIN_FORMAT", &CustomVar{
-		base: ExplainFormatVar(&sv.Display.ExplainFormat,
-			"Controls query plan notation. CURRENT(default): new notation, TRADITIONAL: spanner-cli compatible notation, COMPACT: compact notation."),
-		customSetter: func(value string) error {
-			if value == "" {
-				sv.Display.ExplainFormat = enums.ExplainFormatUnspecified
-				return nil
-			}
-			return ExplainFormatVar(&sv.Display.ExplainFormat, "").Set(value)
-		},
-	})
-	r.Register("CLI_EXPLAIN_PRINT_SECTIONS", &CustomVar{
-		base: StringVar(&sv.Display.ExplainPrintSections,
-			"Query plan appendix preset or comma-separated sections to print. Presets: basic, enhanced, full, none. Sections: predicates, ordering, aggregate, typed, full. Empty string suppresses appendices."),
-		customSetter: func(value string) error {
-			sections, err := parseExplainPrintSections(value)
-			if err != nil {
-				return err
-			}
-			sv.Display.ExplainPrintSections = value
-			sv.Display.ParsedExplainPrintSections = sections
-			return nil
-		},
-	})
-	r.Register("CLI_LOG_LEVEL", &LogLevelVar{
-		ptr:         &sv.Feature.LogLevel,
-		description: "Log level for the CLI.",
-	})
-
-	// === Computed/Read-only variables (3+) ===
-	r.Register("CLI_VERSION", NewReadOnlyVar(getVersion, "The version of spanner-mycli."))
-	r.Register("CLI_CURRENT_WIDTH", NewReadOnlyVar(func() string {
-		if sv.StreamManager != nil {
-			return sv.StreamManager.GetTerminalWidthString()
-		}
-		return "NULL"
-	}, "Current terminal width. Returns NULL if not connected to a terminal."))
-	r.Register("READ_TIMESTAMP", &TimestampVar{
-		ptr:         &sv.LastResult.ReadTimestamp,
-		description: "The read timestamp of the most recent read-only transaction.",
-	})
-	r.Register("COMMIT_TIMESTAMP", &TimestampVar{
-		ptr:         &sv.LastResult.CommitTimestamp,
-		description: "The commit timestamp of the last read-write transaction that Spanner committed.",
-	})
-
-	// === Complex variables (10+) ===
-	r.Register("READ_ONLY_STALENESS", &TimestampBoundVar{
-		ptr:         &sv.Query.ReadOnlyStaleness,
-		description: "A property of type STRING for read-only transactions with flexible staleness.",
-	})
-
-	protoDescVar := &ProtoDescriptorVar{
-		filesPtr:      &sv.Internal.ProtoDescriptorFile,
-		descriptorPtr: &sv.Internal.ProtoDescriptor,
-		description:   "Comma-separated list of proto descriptor files. Supports ADD to append files.",
-	}
-	r.RegisterWithAdd("CLI_PROTO_DESCRIPTOR_FILE", protoDescVar, protoDescVar.Add)
-
-	r.Register("CLI_TYPE_STYLES", &CustomVar{
-		base: StringVar(&sv.Display.TypeStylesRaw,
-			"Type-based ANSI styling for query results. Format: colon-separated TYPE=STYLE pairs (e.g., 'STRING=green:INT64=bold:NULL=dim'). "+
-				"Supports named colors (red, green, yellow, blue, magenta, cyan, white, black), "+
-				"attributes (bold, dim, italic, underline, reverse, strikethrough), "+
-				"and raw SGR numbers (e.g., 38;5;214 for 256-color). "+
-				"NULL key overrides the default dim style for NULL values. Empty string disables type styling."),
-		customGetter: func() (string, error) {
-			return sv.Display.TypeStylesRaw, nil
-		},
-		customSetter: func(value string) error {
-			if strings.EqualFold(value, "NULL") {
-				value = ""
-			}
-			config, err := parseTypeStyles(value)
-			if err != nil {
-				return err
-			}
-			sv.Display.TypeStylesRaw = value
-			sv.typeStyles = config.typeStyles
-			sv.nullStyle = config.nullStyle
-			return nil
-		},
-	})
-
-	r.Register("CLI_ENDPOINT", &EndpointVar{
-		hostPtr:     &sv.Config.Host,
-		portPtr:     &sv.Config.Port,
-		description: "Host and port for connections (host:port format).",
-	})
-
-	r.Register("CLI_OUTPUT_TEMPLATE_FILE", &CustomVar{
-		base: StringVar(&sv.Display.OutputTemplateFile, "Go text/template for formatting the output of the CLI."),
-		customGetter: func() (string, error) {
-			return sv.Display.OutputTemplateFile, nil
-		},
-		customSetter: func(value string) error {
-			// Parse and set template.
-			// An empty value (or NULL) restores the built-in default template
-			// (defaultOutputFormat), matching the startup default when no
-			// --output-template flag is given. This keeps SET and startup in
-			// sync so Get/Set round-trips (relied on by RESET ALL) hold.
-			if value == "" || strings.EqualFold(value, "NULL") {
-				sv.Display.OutputTemplateFile = ""
-				sv.Display.OutputTemplate = defaultOutputFormat
-				return nil
-			}
-
-			tmpl, err := parseOutputTemplate(value)
-			if err != nil {
-				return err
-			}
-			sv.Display.OutputTemplateFile = value
-			sv.Display.OutputTemplate = tmpl
-			return nil
-		},
-	})
-
-	r.Register("CLI_ANALYZE_COLUMNS", &TemplateVar{
-		stringPtr: &sv.Display.AnalyzeColumns,
-		parsedPtr: &sv.Display.ParsedAnalyzeColumns,
-		parseFunc: func(value string) error {
-			parsed, err := parseAnalyzeColumns(value)
-			if err != nil {
-				return err
-			}
-			sv.Display.ParsedAnalyzeColumns = parsed
-			return nil
-		},
-		description: "Go template for analyzing column data.",
-	})
-
-	r.Register("CLI_INLINE_STATS", &TemplateVar{
-		stringPtr: &sv.Display.InlineStats,
-		parsedPtr: &sv.Display.ParsedInlineStats,
-		parseFunc: func(value string) error {
-			parsed, err := parseInlineStats(value)
-			if err != nil {
-				return err
-			}
-			sv.Display.ParsedInlineStats = parsed
-			return nil
-		},
-		description: "<name>:<template>, ...",
-	})
-
-	// CLI_ENABLE_ADC_PLUS is a session-init-only variable.
-	// Currently implemented using a custom setter that checks inTransaction != nil
-	// to detect whether a session has been created. Could use native support
-	// for session-init-only behavior if added to VarHandler (see TODO in var_handler.go).
-	r.Register("CLI_ENABLE_ADC_PLUS", &CustomVar{
-		base: BoolVar(&sv.Config.EnableADCPlus, "A boolean indicating whether to enable enhanced Application Default Credentials. Must be set before session creation. The default is true."),
-		customSetter: func(value string) error {
-			if sv.inTransaction != nil {
-				return fmt.Errorf("CLI_ENABLE_ADC_PLUS cannot be changed after session creation")
-			}
-			b, err := strconv.ParseBool(value)
-			if err != nil {
-				return err
-			}
-			sv.Config.EnableADCPlus = b
-			return nil
-		},
-	})
-
-	r.Register("CLI_MCP", BoolVar(&sv.Config.MCP, "A read-only boolean indicating whether the connection is running as an MCP server.").AsReadOnly())
-	r.Register("CLI_INSECURE", BoolVar(&sv.Config.Insecure, "Skip TLS certificate verification (insecure).").AsReadOnly())
-	r.Register("CLI_LOG_GRPC", BoolVar(&sv.Config.LogGrpc, "Enable gRPC logging.").AsReadOnly())
-
-	// === Unimplemented variables ===
-	r.Register("AUTOCOMMIT", &UnimplementedVar{
-		name:        "AUTOCOMMIT",
-		description: "A boolean indicating whether or not the connection is in autocommit mode. The default is true.",
-	})
-	r.Register("RETRY_ABORTS_INTERNALLY", &UnimplementedVar{
-		name:        "RETRY_ABORTS_INTERNALLY",
-		description: "A boolean indicating whether the connection automatically retries aborted transactions. The default is true.",
-	})
-
-	// Note: COMMIT_RESPONSE and CLI_DIRECT_READ require special handling outside the registry
 }
 
 // parseGoogleSQLValue parses GoogleSQL-style values using memefish


### PR DESCRIPTION
## Summary

The mechanical core of the system-variable schema-metadata model (#725, section 6 "PR1"). Converts the imperative `registerAll` (~84 `r.Register` calls) into a declarative `varDefs` table in `internal/mycli/var_defs.go`, with per-variable `bind` closures constructing today's handlers.

Each `varDef` carries the variable's `name`, `desc`, and `scope`/`readOnly` policy. `registerAll` now iterates the table.

## Changes

- `Variable` interface shrinks to `{Get() (string, error); Set(string) error}`. `Description()`/`IsReadOnly()` methods, the `description`/`readOnly` fields, and `AsReadOnly` are deleted from all handler types.
- Read-only enforcement moves to `VarRegistry.Set`, driven by the def (`settable()` = `scope == scopeSession && !readOnly`).
- The registry stores `registeredVar{def, v, add}`; `GetDescription`, `IsReadOnly`, and `ListVariableInfo` serve from the def.
- `scope` values: `scopeSession` (SET-able), `scopeStartup`, `scopeConnection`, `scopeResult` (last three implicitly read-only).
- Updates `dev-docs/patterns/system-variables.md`.

Explicitly **not** in scope (later PRs): no `initOnly`/`txnGuard` enforcement (READONLY and CLI_ENABLE_ADC_PLUS keep their `CustomVar` wrappers), no aliases, no `MultiValueVar`, no `fromOpts`, no RESET.

## Zero behavior change / review gate

- Descriptions are byte-identical. `make docs-update` regenerates `docs/system_variables.md` and the README with an **empty diff** (`git diff --stat` shows no doc changes).
- `make check` passes unchanged (test + lint + fmt-check; golangci-lint reports 0 issues).

## Deviation from the design

`varDef.typ` (a docs-only field listed in the section 6 PR1 struct) is **not** included in this PR. It has no consumer until the docs Type column lands (PR6, which also populates `typ`), and the `unused` linter rejects a struct field that is written nowhere and read nowhere. Deferring it to its population PR keeps PR1 lint-clean with zero behavior change. The field is trivial to add alongside its first consumer.

Part of #725.
