### PR TITLE
fix: enforce client-swap lifecycle invariant via TransactionManager.SetClient

### DIFF
--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -446,38 +446,6 @@ func (s *Session) ValidateStatementExecution(stmt Statement) error {
 	return nil
 }
 
-func (s *Session) ConnectToDatabase(ctx context.Context, databaseId string) error {
-	if s.mode == DatabaseConnected && s.client != nil {
-		return errors.New("session is already connected to a database")
-	}
-
-	// Construct database path directly to avoid modifying state before success
-	dbPath := databasePath(s.systemVariables.Connection.Project, s.systemVariables.Connection.Instance, databaseId)
-
-	clientConfig := s.clientConfig
-
-	client, err := spanner.NewClientWithConfig(ctx, dbPath, clientConfig, s.clientOpts...)
-	if err != nil {
-		return err
-	}
-
-	// Close existing client if any
-	if s.client != nil {
-		s.client.Close()
-	}
-
-	// Update state only after successful client creation
-	s.systemVariables.Connection.Database = databaseId
-	s.client = client
-	s.txn.client = client
-	s.mode = DatabaseConnected
-
-	// Heartbeat is now managed per-transaction, not per-session
-	// so we don't need to start it here anymore
-
-	return nil
-}
-
 // --- Delegation methods to TransactionManager ---
 // These one-liner methods preserve the existing Session API so callers
 // (statement files, fuzzy finder, etc.) don't need to change.
@@ -911,9 +879,17 @@ func (s *Session) RecreateClient() error {
 	if err != nil {
 		return err
 	}
+	// Refuse the swap if a transaction context is still live: SetClient enforces
+	// the lifecycle invariant that the old client must not be closed while a
+	// transaction (and its heartbeat goroutine) could still use it. On refusal,
+	// close the NEW client and surface the error (it joins the Aborted error at
+	// the caller). Only on success close the OLD client and update Session.client.
+	if err := s.txn.SetClient(c); err != nil {
+		c.Close()
+		return err
+	}
 	s.client.Close()
 	s.client = c
-	s.txn.client = c
 	return nil
 }
 

--- a/internal/mycli/session_modes_test.go
+++ b/internal/mycli/session_modes_test.go
@@ -102,41 +102,6 @@ func TestSessionModes(t *testing.T) {
 			t.Error("Expected database-connected session when database is specified")
 		}
 	})
-
-	t.Run("ConnectToDatabase upgrades admin session", func(t *testing.T) {
-		sysVars := &systemVariables{
-			Connection: ConnectionVars{
-				Project:  "test-project",
-				Instance: "test-instance",
-				Database: "",
-			},
-		}
-
-		session, err := NewAdminSession(ctx, sysVars)
-		if err != nil {
-			t.Skip("Skipping test due to authentication requirements:", err)
-		}
-		defer session.Close()
-
-		// Verify it starts as detached
-		if !session.IsDetached() {
-			t.Error("Expected detached session initially")
-		}
-
-		// Try to connect to database
-		err = session.ConnectToDatabase(ctx, "test-database")
-		if err != nil {
-			t.Skip("Skipping database connection test:", err)
-		}
-
-		// Verify it's now database-connected
-		if session.IsDetached() {
-			t.Error("Expected database-connected session after ConnectToDatabase")
-		}
-		if session.client == nil {
-			t.Error("Expected non-nil client after ConnectToDatabase")
-		}
-	})
 }
 
 func TestDatabaseOperationValidation(t *testing.T) {

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -150,6 +150,22 @@ func NewTransactionManager(client *spanner.Client, sysVars *systemVariables, cli
 	}
 }
 
+// SetClient replaces the Spanner client under tm.mu. It refuses to replace
+// the client while any transaction context exists: the old client is closed
+// by the caller, so a live tc (and its heartbeat goroutine) would be left
+// using a closed client. All Aborted paths that trigger RecreateClient roll
+// back or clear the transaction first; this guard turns that ordering from
+// an emergent property into an enforced invariant.
+func (tm *TransactionManager) SetClient(client *spanner.Client) error {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if tm.tc != nil {
+		return fmt.Errorf("cannot replace client during %s transaction", tm.tc.attrs.mode)
+	}
+	tm.client = client
+	return nil
+}
+
 // withTransactionContextWithLock is the most generic base method for transaction context manipulation.
 // It acquires a write lock and provides direct access to the transaction context pointer,
 // allowing atomic read-modify-write operations.

--- a/internal/mycli/transaction_manager_test.go
+++ b/internal/mycli/transaction_manager_test.go
@@ -357,3 +357,63 @@ func TestTransactionValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestSetClient(t *testing.T) {
+	t.Parallel()
+
+	oldClient := &spanner.Client{}
+	newClient := &spanner.Client{}
+
+	tests := []struct {
+		name    string
+		tc      *transactionContext
+		wantErr bool
+	}{
+		{
+			name:    "idle swaps successfully",
+			tc:      nil,
+			wantErr: false,
+		},
+		{
+			name:    "refuses during active read-write transaction",
+			tc:      &transactionContext{attrs: transactionAttributes{mode: transactionModeReadWrite}},
+			wantErr: true,
+		},
+		{
+			name:    "refuses during active read-only transaction",
+			tc:      &transactionContext{attrs: transactionAttributes{mode: transactionModeReadOnly}},
+			wantErr: true,
+		},
+		{
+			name:    "refuses during pending transaction",
+			tc:      &transactionContext{attrs: transactionAttributes{mode: transactionModePending}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tm := &TransactionManager{
+				tc:     tt.tc,
+				client: oldClient,
+			}
+
+			err := tm.SetClient(newClient)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("SetClient() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				// On refusal the client must be left untouched so the caller can
+				// close the new client without orphaning the live transaction.
+				if tm.client != oldClient {
+					t.Errorf("SetClient() replaced client on refusal: got %p, want %p", tm.client, oldClient)
+				}
+			} else {
+				if tm.client != newClient {
+					t.Errorf("SetClient() did not swap client: got %p, want %p", tm.client, newClient)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Part of #739 (PR-1: A5, design section 1.3 / 5.1).

`TransactionManager.client` was mutated outside `tm.mu` by two write sites. This PR closes the unenforced client-swap lifecycle invariant.

- Add `TransactionManager.SetClient`: replaces the client under `tm.mu` and **refuses** the swap while any transaction context exists. The caller closes the old client, so a live `tc` (and its heartbeat goroutine) must never be left holding a closed client. All Aborted paths that trigger `RecreateClient` roll back / clear the transaction first; this guard turns that emergent ordering into an enforced invariant.
- Route `Session.RecreateClient` through `SetClient` with corrected ordering: create new client → `SetClient`; on refusal close the **new** client and return the error (it joins the Aborted error at `cli.go`); only on success close the **old** client and update `Session.client`.
- Delete the production-dead `Session.ConnectToDatabase` (the other unlocked write site) plus its credential-gated test.

No user-visible behavior change.

## Tests

- `TestSetClient`: refusal during active read-write, active read-only, and pending transaction contexts (asserts the client is left untouched on refusal); successful swap when idle.
- `make check` and `make check-race` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dmtS3P1H7JzRdNJvd17GV
