### PR TITLE
build(deps): bump memebridge to v0.6.4 (supersedes #734)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,17 +16,17 @@ require (
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe
 	github.com/apstndb/go-tabwrap v0.1.3
 	github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0
-	github.com/apstndb/memebridge v0.6.0
+	github.com/apstndb/memebridge v0.6.4
 	github.com/apstndb/spancodec v0.1.1
 	github.com/apstndb/spanemuboost v0.4.6
 	github.com/apstndb/spaniter v0.3.1
 	github.com/apstndb/spanner-docs-embed v0.0.0-20260312161525-0136df2da2a6
 	github.com/apstndb/spannerplan v0.1.11
 	github.com/apstndb/spanstats v0.1.0
-	github.com/apstndb/spantype v0.3.11
-	github.com/apstndb/spanvalue v0.8.0
+	github.com/apstndb/spantype v0.3.13
+	github.com/apstndb/spanvalue v0.8.2
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/cloudspannerecosystem/memefish v0.6.2
+	github.com/cloudspannerecosystem/memefish v0.7.0
 	github.com/creack/pty v1.1.24
 	github.com/fatih/color v1.19.0
 	github.com/go-sprout/sprout v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -2494,8 +2494,8 @@ github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba h1:l9MMbSfCb
 github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba/go.mod h1:adI+0n+0AY1J+qhb7UbW3HjsUD15JCQPIih7FHLcrI4=
 github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0 h1:VySrhGRfqXUDCrUuAEz70DrDnPrvj/nXGnUHwJF3PG4=
 github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0/go.mod h1:VwhJDip+HamDWWt+Ol4ECFU0g0HiveA27DeNkt3U8S0=
-github.com/apstndb/memebridge v0.6.0 h1:45uu/RFF63u5vJ+d8HT4PvOfotm1cV4eEveWFwGvElI=
-github.com/apstndb/memebridge v0.6.0/go.mod h1:E/HVP4iaSgiPXMIQTPT1u1uKkjmRtRECkVKE2TrF3bc=
+github.com/apstndb/memebridge v0.6.4 h1:OoOXj+m5YtosbAPz0pLNVUwhhCohf1mC2o+Dy9WMsjQ=
+github.com/apstndb/memebridge v0.6.4/go.mod h1:gw6dfrUAsT+GvmuRGiG/fnGbrKfiVvnjBriQt6nLnys=
 github.com/apstndb/ptyhelp v0.2.1 h1:vGqYJiIBNS3opPA3JLCKsdKIZzomz2zFkO1PVuM+WLs=
 github.com/apstndb/ptyhelp v0.2.1/go.mod h1:qQr/aibVk0BK/dweEW7mcaT0jAH9NeRHP2in6MIgEcA=
 github.com/apstndb/spancodec v0.1.1 h1:26jll4gTzB18yUilmSSE1IfCF9Rht2j/+cc492hjixE=
@@ -2510,10 +2510,10 @@ github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spanstats v0.1.0 h1:wAPqtFn1AfQaIudB4HwTLiIPinwWJw/gQhgE7NQWVKo=
 github.com/apstndb/spanstats v0.1.0/go.mod h1:DFGYC9e7WE0BFQL0st6EQwrl1Pn2FuvDWSefwI9FTWc=
-github.com/apstndb/spantype v0.3.11 h1:wKue4WLYGT82MH3B3TRSFn8tWIbk1Geczs+5BAEtnK4=
-github.com/apstndb/spantype v0.3.11/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.8.0 h1:wLHl/0m5C6PvRwJOJoz1nRL4qSpS17eS1tW3Pjzcvo8=
-github.com/apstndb/spanvalue v0.8.0/go.mod h1:bqVJYydQf+D0Tux1LtyRlREPVwrVYNG+1usZJ489GTA=
+github.com/apstndb/spantype v0.3.13 h1:FTP3zUpVXMfPlZ3P+1RK6SYHND+96YVht0I+ZHGIzMc=
+github.com/apstndb/spantype v0.3.13/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
+github.com/apstndb/spanvalue v0.8.2 h1:CMTJUmpSGtVrlKazMC6fmsi/PrOojhDNkmdLb0q1iPY=
+github.com/apstndb/spanvalue v0.8.2/go.mod h1:krLMj3J9sKS/IBLIUkEUlFufcxeLkIGJon+ypSPgrl0=
 github.com/apstndb/structfields v0.1.0 h1:TQbi8EpzLyDr1GOsLWJfMQrtw+cq7BQhNCHhqZTCtEg=
 github.com/apstndb/structfields v0.1.0/go.mod h1:iZuSnr5cvgVvMaEhm0ceB+auA+MeNmA1mtnBA05m9Qw=
 github.com/apstndb/structfields/spannertag v0.1.0 h1:faXv5yYgKHV4DA3V0UpL4D9cTgMM87yacNbno0p3ulM=
@@ -2551,8 +2551,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/cloudspannerecosystem/memefish v0.6.2 h1:0R6C8KdJLLbL3aYk/rzWrwvE+bPRMqj/2MNlNvAzIPo=
-github.com/cloudspannerecosystem/memefish v0.6.2/go.mod h1:mVw0xBxy0yOgm990BuR0+nqP8J+yBAAf7N/2uL69rBU=
+github.com/cloudspannerecosystem/memefish v0.7.0 h1:VkKZzVIIJ2Yj3D++NdTJFgyrr/fCgRCqcjTiia8R10U=
+github.com/cloudspannerecosystem/memefish v0.7.0/go.mod h1:tfdaTgJaxw38uEiY2tUPQ5Bk1c+6nLjIBJXSxD+bkFI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/mycli/sample_databases_test.go
+++ b/internal/mycli/sample_databases_test.go
@@ -331,13 +331,14 @@ CREATE TABLE test (id INT64);
    comment */
 INSERT INTO test VALUES (1);`,
 			filename: "mixed.sql",
-			// memefish.SplitRawStatements returns:
-			// - First statement includes the leading line comment
-			// - Second statement does not include the block comment that appears before it
-			// TODO: This behavior may change when https://github.com/cloudspannerecosystem/memefish/pull/322 is merged
+			// memefish.SplitRawStatements preserves all comments as of memefish v0.7.0
+			// (https://github.com/cloudspannerecosystem/memefish/pull/322), so each
+			// statement includes the comment(s) that immediately precede it. These
+			// leading comments are harmless when the statements are executed against
+			// Spanner.
 			want: []string{
 				"-- This is a comment\nCREATE TABLE test (id INT64)",
-				"INSERT INTO test VALUES (1)",
+				"/* Multi-line\n   comment */\nINSERT INTO test VALUES (1)",
 			},
 		},
 		{


### PR DESCRIPTION
Supersedes Dependabot PR #734 (memebridge 0.6.0 -> 0.6.2) by bumping directly to **v0.6.4**, the current latest tag.

## Why not just merge #734?

memebridge v0.6.2+ raises transitive requirements: memefish v0.7.x, spanvalue v0.8.x, spantype v0.3.13. Merging #734 unchanged left CI red on both `test` and `race`:

```
sample_databases_test.go:366: ParseStatements()[1] =
  "/* Multi-line\n   comment */\nINSERT INTO test VALUES (1)",
  want "INSERT INTO test VALUES (1)"
```

## Root cause

memefish v0.7.0 includes cloudspannerecosystem/memefish#322 ("Preserve all comments in `SplitRawStatements`"). `SplitRawStatements` now attaches a leading block comment to the statement that follows it. `ParseStatements` (`internal/mycli/sample_databases.go`) surfaces `rawStmt.Statement` verbatim, so the `TestParseStatements/Statements_with_comments` expectation for the second statement changed.

This is an **intentional upstream change**, not a bug — and the test's own TODO already anticipated it (`// TODO: This behavior may change when .../memefish/pull/322 is merged`). Leading comments are harmless when the statements execute against Spanner (the first statement already retained its leading line comment before this change).

## Change

- Bump memebridge to v0.6.4 (pulls memefish v0.7.0, spanvalue v0.8.2, spantype v0.3.13).
- Update the `TestParseStatements/Statements_with_comments` expectation and its explanatory comment to match memefish v0.7.0's comment-preserving behavior.

No production code changes were required; `go build ./...` is clean against the new APIs.

## Validation

`make check` passes locally (test + lint + fmt-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dmtS3P1H7JzRdNJvd17GV
