### PR TITLE
refactor: type the partitioned buffered fan-in (TypedRows)

### DIFF
--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -52,7 +52,7 @@ func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Re
 		return result, nil
 	}
 
-	return bufferPartitionedQuery(ctx, batchROTx, partitions, parallelism, sysVars, fc, vfm)
+	return bufferPartitionedQuery(ctx, batchROTx, partitions, parallelism, vfm)
 }
 
 // streamPartitionedQuery streams merged partition rows through the same
@@ -99,27 +99,30 @@ func streamPartitionedQuery(
 	}, true, nil
 }
 
-// bufferPartitionedQuery collects all partition rows into memory for formats
-// that need the full result set (table width calculation) or have no
-// streaming writer.
+// bufferPartitionedQuery collects all partition rows into memory as a typed
+// buffered Result (Result.Typed) for formats that need the full result set
+// (table width calculation) or have no streaming writer. Rows are captured raw
+// via the identity transform; printTableData derives display cells (or replays
+// export formats through the single spanvalue emitters) lazily, exactly like
+// the buffered server query path (issue #738).
+//
+// Only table and processor-based formats reach this path: writer formats
+// (CSV/JSONL/SQL_INSERT*) stream via streamPartitionedQuery. vfm still feeds
+// TypedRows.SQLExportAllowed so the field mirrors the streaming path, though
+// SQL-literal modes never buffer here in practice.
 func bufferPartitionedQuery(
 	ctx context.Context,
 	batchROTx *spanner.BatchReadOnlyTransaction,
 	partitions []*spanner.Partition,
 	parallelism int,
-	sysVars *systemVariables,
-	fc *spanvalue.FormatConfig,
 	vfm format.ValueFormatMode,
 ) (*Result, error) {
-	transform := spannerRowToRow(fc, sysVars.typeStyles, sysVars.nullStyle)
-	if vfm == format.JSONValues {
-		transform = withRawJSONMarker(transform)
-	}
-
 	type partitionQueryResult struct {
 		Metadata *sppb.ResultSetMetadata
-		Rows     []Row
+		Rows     []*spanner.Row
 	}
+
+	identity := func(r *spanner.Row) (*spanner.Row, error) { return r, nil }
 
 	p := pool.NewWithResults[*partitionQueryResult]().
 		WithContext(ctx).
@@ -128,7 +131,7 @@ func bufferPartitionedQuery(
 	for _, partition := range partitions {
 		p.Go(func(ctx context.Context) (*partitionQueryResult, error) {
 			iter := batchROTx.Execute(ctx, partition)
-			rows, _, _, md, _, err := consumeRowIterCollect(iter, transform)
+			rows, _, _, md, _, err := consumeRowIterCollect(iter, identity)
 			if err != nil {
 				return nil, err
 			}
@@ -141,19 +144,23 @@ func bufferPartitionedQuery(
 		return nil, err
 	}
 
-	var allRows []Row
-	var rowType *sppb.StructType
+	var allRows []*spanner.Row
+	var metadata *sppb.ResultSetMetadata
 	for _, result := range results {
 		allRows = append(allRows, result.Rows...)
 
 		if len(result.Metadata.GetRowType().GetFields()) > 0 {
-			rowType = result.Metadata.GetRowType()
+			metadata = result.Metadata
 		}
 	}
 
 	return &Result{
-		Rows:           allRows,
-		TableHeader:    toTableHeader(rowType.GetFields()),
+		Typed: &TypedRows{
+			Metadata:         metadata,
+			Rows:             allRows,
+			SQLExportAllowed: vfm == format.SQLLiteralValues,
+		},
+		TableHeader:    toTableHeader(metadata.GetRowType().GetFields()),
 		AffectedRows:   len(allRows),
 		PartitionCount: len(partitions),
 	}, nil


### PR DESCRIPTION
## Summary

PR4 of the Result-type decomposition (issue #738). `bufferPartitionedQuery` now collects raw `*spanner.Row` per partition via the identity transform and merges them into a single `Result.Typed` (`*sppb.ResultSetMetadata` + `[]*spanner.Row`) instead of building display cells inline. `printTableData` derives display cells lazily (PR1), exactly like the buffered server query path.

The `fc`/`sysVars` params are dropped from `bufferPartitionedQuery` since formatting no longer happens at collection time; `vfm` is retained only to mirror `TypedRows.SQLExportAllowed` with the streaming path.

## Byte identity

Only table and processor-based formats reach this buffered path -- CSV/JSONL/SQL_INSERT* stream via `streamPartitionedQuery` -- so output is byte-identical. The existing partitioned integration test (`TestPartitionedStatements`, "mutation, pdml, partitioned query") exercises the new typed producer end-to-end: `normalizeResultForCompare` derives the same display `Rows` the inline transform produced before, and the assertion is unchanged.

## Test plan

- [x] `make check`

Part of #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dmtS3P1H7JzRdNJvd17GV