### PR TITLE
refactor: make COMMIT_RESPONSE registry-native and add the alias mechanism

### DIFF
--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -127,7 +127,11 @@ func TestSetLocalRejectsUnsupportedVariables(t *testing.T) {
 	}{
 		{desc: "read-only variable", varName: "CLI_VERSION", value: "'v1'", wantErr: "does not support SET LOCAL"},
 		{desc: "unknown variable", varName: "NO_SUCH_VARIABLE", value: "1", wantErr: "unknown variable name"},
-		{desc: "virtual variable", varName: "COMMIT_RESPONSE", value: "1", wantErr: "unimplemented setter"},
+		// COMMIT_RESPONSE is now a read-only registry def (scopeResult), so SET
+		// LOCAL rejects it via localAllowed() rather than the old name check.
+		{desc: "multi-valued read-only variable", varName: "COMMIT_RESPONSE", value: "1", wantErr: "does not support SET LOCAL"},
+		// CLI_DIRECT_READ still lives outside the registry with no setter.
+		{desc: "unregistered special variable", varName: "CLI_DIRECT_READ", value: "1", wantErr: "unimplemented setter"},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -45,14 +44,12 @@ type ShowVariablesStatement struct{}
 func (s *ShowVariablesStatement) isDetachedCompatible() {}
 
 func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	// Get all variables from the registry
+	// Get all single-valued variables from the registry.
 	merged := session.systemVariables.ListVariables()
 
-	// Special handling for COMMIT_RESPONSE
-	if session.systemVariables.LastResult.CommitResponse != nil {
-		merged["COMMIT_TIMESTAMP"] = formatTimestamp(session.systemVariables.LastResult.CommitTimestamp, "NULL")
-		merged["MUTATION_COUNT"] = strconv.FormatInt(session.systemVariables.LastResult.CommitResponse.GetCommitStats().GetMutationCount(), 10)
-	}
+	// Merge multi-valued variables (COMMIT_RESPONSE -> COMMIT_TIMESTAMP,
+	// MUTATION_COUNT). These intentionally override the plain rows.
+	maps.Copy(merged, session.systemVariables.Registry.ListMultiValues())
 
 	// Special handling for CLI_DIRECT_READ
 	if session.systemVariables.Query.DirectedRead != nil {
@@ -113,8 +110,10 @@ func (s *SetLocalStatement) Execute(ctx context.Context, session *Session) (*Res
 	sysVars.ensureRegistry()
 	upperName := strings.ToUpper(s.VarName)
 
-	// Mirror the SET special cases for variables living outside the registry.
-	if upperName == "COMMIT_RESPONSE" || upperName == "CLI_DIRECT_READ" {
+	// CLI_DIRECT_READ still lives outside the registry and has no setter; mirror
+	// the SET special case. COMMIT_RESPONSE is now a registry def, so the
+	// localAllowed() check below rejects it (read-only) with no special case.
+	if upperName == "CLI_DIRECT_READ" {
 		return nil, errSetterUnimplemented{s.VarName}
 	}
 
@@ -178,9 +177,9 @@ type HelpVariablesStatement struct{}
 func (s *HelpVariablesStatement) isDetachedCompatible() {}
 
 // helpVariableRows returns sorted rows describing every system variable known
-// to the registry, plus the special variables handled outside the registry
-// (COMMIT_RESPONSE, CLI_DIRECT_READ). It is shared by HELP VARIABLES and the
-// documentation generator behind the hidden --sysvars-help flag.
+// to the registry, plus CLI_DIRECT_READ, which is still handled outside the
+// registry. It is shared by HELP VARIABLES and the documentation generator
+// behind the hidden --sysvars-help flag.
 func helpVariableRows(sysVars *systemVariables) []helpVariableRow {
 	varInfo := sysVars.ListVariableInfo()
 
@@ -208,15 +207,11 @@ func helpVariableRows(sysVars *systemVariables) []helpVariableRow {
 		})
 	}
 
-	// Add special variables not in registry
-	// COMMIT_RESPONSE - virtual variable
-	merged = append(merged, helpVariableRow{
-		Name:        "COMMIT_RESPONSE",
-		Operations:  "read",
-		Description: "The most recent response for a read-write transaction. This is a virtual variable: it can be used in SHOW COMMIT_RESPONSE and SHOW COMMIT_RESPONSE.COMMIT_TIMESTAMP and SHOW COMMIT_RESPONSE.MUTATION_COUNT, but attempting to read its value directly will give an error. Instead use the sub-fields COMMIT_TIMESTAMP and MUTATION_COUNT.",
-	})
-
-	// CLI_DIRECT_READ - complex proto type
+	// Add special variables not in the registry.
+	// COMMIT_RESPONSE is now a registry def (multi-valued), so it is described
+	// from varInfo above and no longer hand-appended here.
+	//
+	// CLI_DIRECT_READ - complex proto type (still outside the registry)
 	merged = append(merged, helpVariableRow{
 		Name:        "CLI_DIRECT_READ",
 		Operations:  "read",

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -409,7 +409,7 @@ var (
 // are parsed as GoogleSQL expressions (e.g., TRUE, 'string value').
 func (sv *systemVariables) SetFromGoogleSQL(name string, value string) error {
 	sv.ensureRegistry()
-	return sv.setFromGoogleSQL(name, value)
+	return sv.setFrom(name, value, true)
 }
 
 // SetFromSimple sets a system variable using Simple parsing mode.
@@ -417,17 +417,17 @@ func (sv *systemVariables) SetFromGoogleSQL(name string, value string) error {
 // don't follow GoogleSQL syntax rules.
 func (sv *systemVariables) SetFromSimple(name string, value string) error {
 	sv.ensureRegistry()
-	return sv.setFromSimple(name, value)
+	return sv.setFrom(name, value, false)
 }
 
 func (sv *systemVariables) AddFromGoogleSQL(name string, value string) error {
 	sv.ensureRegistry()
-	return sv.addFromGoogleSQL(name, value)
+	return sv.addFrom(name, value, true)
 }
 
 func (sv *systemVariables) AddFromSimple(name string, value string) error {
 	sv.ensureRegistry()
-	return sv.addFromSimple(name, value)
+	return sv.addFrom(name, value, false)
 }
 
 func (sv *systemVariables) Get(name string) (map[string]string, error) {

--- a/internal/mycli/system_variables_registry.go
+++ b/internal/mycli/system_variables_registry.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"strconv"
 	"strings"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -23,108 +22,50 @@ func (sv *systemVariables) ensureRegistry() {
 	}
 }
 
-// setFromGoogleSQL implements setting variables from GoogleSQL mode
-func (sv *systemVariables) setFromGoogleSQL(name string, value string) error {
+// setFrom sets a variable through the registry, translating registry error
+// types into the legacy messages callers and tests expect. isGoogleSQL selects
+// GoogleSQL vs simple value parsing.
+func (sv *systemVariables) setFrom(name string, value string, isGoogleSQL bool) error {
 	upperName := strings.ToUpper(name)
 
-	// Special case for COMMIT_RESPONSE (unimplemented setter)
-	if upperName == "COMMIT_RESPONSE" {
-		return errSetterUnimplemented{name}
-	}
-
-	// Special case for CLI_DIRECT_READ (unimplemented setter)
+	// CLI_DIRECT_READ lives outside the registry (complex proto type; see get);
+	// its setter is not yet implemented. COMMIT_RESPONSE is now a read-only
+	// registry def, so it no longer needs a special case here (Registry.Set
+	// rejects it with errSetterReadOnly).
 	if upperName == "CLI_DIRECT_READ" {
 		return errSetterUnimplemented{name}
 	}
 
-	slog.Debug("setFromGoogleSQL calling Registry.Set", "upperName", upperName, "value", value)
-	err := sv.Registry.Set(upperName, value, true)
-	slog.Debug("setFromGoogleSQL after Registry.Set", "err", err)
-	// Convert to legacy error types for compatibility
-	if err != nil {
-		if errors.Is(err, errSetterReadOnly) {
-			return errSetterReadOnly
-		}
-		var unknownErr *ErrUnknownVariable
-		if errors.As(err, &unknownErr) {
-			return fmt.Errorf("unknown variable name: %v", name)
-		}
-		var unimplementedErr *errSetterUnimplemented
-		if errors.As(err, &unimplementedErr) {
-			return errSetterUnimplemented{name}
-		}
+	slog.Debug("setFrom calling Registry.Set", "upperName", upperName, "value", value, "isGoogleSQL", isGoogleSQL)
+	err := sv.Registry.Set(upperName, value, isGoogleSQL)
+	slog.Debug("setFrom after Registry.Set", "err", err)
+	// ErrUnknownVariable carries a different message ("unknown variable: X");
+	// translate it to the legacy "unknown variable name: X" form. Other registry
+	// errors (read-only, unimplemented setter, parse errors) already carry the
+	// message callers expect, so they pass through unchanged.
+	var unknownErr *ErrUnknownVariable
+	if errors.As(err, &unknownErr) {
+		return fmt.Errorf("unknown variable name: %v", name)
 	}
 
 	return err
 }
 
-// setFromSimple implements setting variables from simple mode
-func (sv *systemVariables) setFromSimple(name string, value string) error {
-	upperName := strings.ToUpper(name)
-
-	// Special case for COMMIT_RESPONSE (unimplemented setter)
-	if upperName == "COMMIT_RESPONSE" {
-		return errSetterUnimplemented{name}
+// addFrom performs ADD through the registry, translating registry error types
+// into the legacy messages. isGoogleSQL selects GoogleSQL value parsing.
+func (sv *systemVariables) addFrom(name string, value string, isGoogleSQL bool) error {
+	if isGoogleSQL {
+		value = parseGoogleSQLValue(value)
 	}
-
-	// Special case for CLI_DIRECT_READ (unimplemented setter)
-	if upperName == "CLI_DIRECT_READ" {
-		return errSetterUnimplemented{name}
-	}
-
-	err := sv.Registry.Set(upperName, value, false)
-	// Convert to legacy error types for compatibility
-	if err != nil {
-		if errors.Is(err, errSetterReadOnly) {
-			return errSetterReadOnly
-		}
-		var unknownErr *ErrUnknownVariable
-		if errors.As(err, &unknownErr) {
-			return fmt.Errorf("unknown variable name: %v", name)
-		}
-		var unimplementedErr *errSetterUnimplemented
-		if errors.As(err, &unimplementedErr) {
-			return errSetterUnimplemented{name}
-		}
-	}
-
-	return err
-}
-
-// addFromGoogleSQL implements ADD from GoogleSQL mode
-func (sv *systemVariables) addFromGoogleSQL(name string, value string) error {
-	// Parse GoogleSQL value
-	value = parseGoogleSQLValue(value)
 
 	err := sv.Registry.Add(name, value)
-	// Convert to legacy error types for compatibility
-	if err != nil {
-		var addErr *ErrAddNotSupported
-		if errors.As(err, &addErr) {
-			return fmt.Errorf("%s does not support ADD operation", name)
-		}
-		var unknownErr *ErrUnknownVariable
-		if errors.As(err, &unknownErr) {
-			return fmt.Errorf("unknown variable name: %v", name)
-		}
+	var addErr *ErrAddNotSupported
+	if errors.As(err, &addErr) {
+		return fmt.Errorf("%s does not support ADD operation", name)
 	}
-
-	return err
-}
-
-// addFromSimple implements ADD from simple mode
-func (sv *systemVariables) addFromSimple(name string, value string) error {
-	err := sv.Registry.Add(name, value)
-	// Convert to legacy error types for compatibility
-	if err != nil {
-		var addErr *ErrAddNotSupported
-		if errors.As(err, &addErr) {
-			return fmt.Errorf("%s does not support ADD operation", name)
-		}
-		var unknownErr *ErrUnknownVariable
-		if errors.As(err, &unknownErr) {
-			return fmt.Errorf("unknown variable name: %v", name)
-		}
+	var unknownErr *ErrUnknownVariable
+	if errors.As(err, &unknownErr) {
+		return fmt.Errorf("unknown variable name: %v", name)
 	}
 
 	return err
@@ -134,19 +75,12 @@ func (sv *systemVariables) addFromSimple(name string, value string) error {
 func (sv *systemVariables) get(name string) (map[string]string, error) {
 	upperName := strings.ToUpper(name)
 
-	// Special case for COMMIT_RESPONSE
-	// This variable returns multiple key-value pairs (COMMIT_TIMESTAMP and MUTATION_COUNT)
-	// which doesn't fit the single-string return type of the Variable interface.
-	// This behavior is maintained for java-spanner compatibility where SHOW VARIABLE
-	// COMMIT_RESPONSE returns both values as a result set.
-	if upperName == "COMMIT_RESPONSE" {
-		if sv.LastResult.CommitResponse == nil {
-			return nil, errIgnored
-		}
-		return map[string]string{
-			"COMMIT_TIMESTAMP": formatTimestamp(sv.LastResult.CommitTimestamp, "NULL"),
-			"MUTATION_COUNT":   strconv.FormatInt(sv.LastResult.CommitResponse.GetCommitStats().GetMutationCount(), 10),
-		}, nil
+	// Multi-valued variables (COMMIT_RESPONSE) return several columns, which
+	// don't fit the single-string Variable.Get; SHOW VARIABLE reads them via the
+	// MultiValueVar capability. GetVariable resolves aliases and returns nil for
+	// unknown names (the nil type assertion below simply falls through).
+	if mv, ok := sv.Registry.GetVariable(upperName).(MultiValueVar); ok {
+		return mv.GetMulti()
 	}
 
 	// Special case for CLI_DIRECT_READ (complex proto type not in registry)

--- a/internal/mycli/var_custom_handlers.go
+++ b/internal/mycli/var_custom_handlers.go
@@ -252,6 +252,40 @@ func (u *UnimplementedVar) Set(value string) error {
 	return errSetterUnimplemented{u.name}
 }
 
+// commitResponseVar is the registry handler for COMMIT_RESPONSE, the one
+// genuinely multi-valued system variable. It reports the last read-write
+// transaction's commit result as two columns (COMMIT_TIMESTAMP, MUTATION_COUNT)
+// via GetMulti; a plain Get is unavailable, mirroring java-spanner where
+// COMMIT_RESPONSE cannot be read as a single value.
+type commitResponseVar struct {
+	sv *systemVariables
+}
+
+// Get always reports the value as unavailable so COMMIT_RESPONSE stays out of
+// the flat ListVariables()/SHOW VARIABLES rows; its columns are merged in
+// separately from GetMulti. errIgnored is the established "skip me" sentinel.
+func (c *commitResponseVar) Get() (string, error) {
+	return "", errIgnored
+}
+
+// Set is never reached through Registry.Set (scopeResult is read-only, rejected
+// centrally before the handler), but is implemented for completeness.
+func (c *commitResponseVar) Set(string) error {
+	return errSetterReadOnly
+}
+
+// GetMulti returns COMMIT_TIMESTAMP and MUTATION_COUNT from the last commit, or
+// errIgnored when no read-write transaction has committed yet.
+func (c *commitResponseVar) GetMulti() (map[string]string, error) {
+	if c.sv.LastResult.CommitResponse == nil {
+		return nil, errIgnored
+	}
+	return map[string]string{
+		"COMMIT_TIMESTAMP": formatTimestamp(c.sv.LastResult.CommitTimestamp, "NULL"),
+		"MUTATION_COUNT":   strconv.FormatInt(c.sv.LastResult.CommitResponse.GetCommitStats().GetMutationCount(), 10),
+	}, nil
+}
+
 // TimestampVar handles timestamp formatting for read-only timestamp variables
 type TimestampVar struct {
 	ptr *time.Time

--- a/internal/mycli/var_defs.go
+++ b/internal/mycli/var_defs.go
@@ -42,6 +42,11 @@ type varDef struct {
 	noLocal  bool // opt-out of SET LOCAL for otherwise-eligible vars
 	noReset  bool // opt-out of RESET ALL for otherwise-eligible vars
 
+	// aliases are additional (typically deprecated) names accepted by
+	// SET/SHOW/ADD. They resolve to the same handler as name but are excluded
+	// from listings and completion. Used for one-release renames.
+	aliases []string
+
 	// bind constructs the live handler bound to the given systemVariables.
 	bind func(sv *systemVariables) Variable
 	// bindAdd, when non-nil, constructs the variable's ADD handler.
@@ -625,6 +630,15 @@ var varDefs = []varDef{
 		desc:  "The commit timestamp of the last read-write transaction that Spanner committed.",
 		scope: scopeResult,
 		bind:  func(sv *systemVariables) Variable { return &TimestampVar{ptr: &sv.LastResult.CommitTimestamp} },
+	},
+	{
+		// COMMIT_RESPONSE is multi-valued: SHOW VARIABLE / SHOW VARIABLES expose
+		// its COMMIT_TIMESTAMP and MUTATION_COUNT columns via the MultiValueVar
+		// capability (commitResponseVar.GetMulti). It is read-only (scopeResult).
+		name:  "COMMIT_RESPONSE",
+		desc:  "The most recent response for a read-write transaction. This is a virtual variable: it can be used in SHOW COMMIT_RESPONSE and SHOW COMMIT_RESPONSE.COMMIT_TIMESTAMP and SHOW COMMIT_RESPONSE.MUTATION_COUNT, but attempting to read its value directly will give an error. Instead use the sub-fields COMMIT_TIMESTAMP and MUTATION_COUNT.",
+		scope: scopeResult,
+		bind:  func(sv *systemVariables) Variable { return &commitResponseVar{sv: sv} },
 	},
 
 	// === Complex variables ===

--- a/internal/mycli/var_handler.go
+++ b/internal/mycli/var_handler.go
@@ -16,6 +16,16 @@ type Variable interface {
 	Set(string) error
 }
 
+// MultiValueVar is an optional capability for a Variable whose SHOW VARIABLE
+// result has multiple columns (e.g. COMMIT_RESPONSE, which surfaces
+// COMMIT_TIMESTAMP and MUTATION_COUNT). Such a variable's plain Get returns an
+// error (the value cannot be rendered as a single string); SHOW VARIABLE and
+// SHOW VARIABLES consult GetMulti instead. Returning errIgnored signals that
+// the value is currently unavailable and should be omitted.
+type MultiValueVar interface {
+	GetMulti() (map[string]string, error)
+}
+
 // ValidValuesEnumerator is implemented by variables that have a constrained set of valid values.
 // Used by fuzzy completion to offer value candidates for SET <name> = <Ctrl+T>.
 // Values must be returned as valid GoogleSQL literals (e.g., 'TABLE' for strings, TRUE for booleans).

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -48,6 +48,12 @@ func (r *VarRegistry) registerAll() {
 			rv.add = def.bindAdd(sv)
 		}
 		r.vars[strings.ToUpper(def.name)] = rv
+		// Aliases are extra keys pointing at the same registeredVar so lookups
+		// (Get/Set/Add) resolve them, but listings iterate varDefs by canonical
+		// name and therefore never surface aliases.
+		for _, alias := range def.aliases {
+			r.vars[strings.ToUpper(alias)] = rv
+		}
 	}
 }
 
@@ -154,14 +160,38 @@ func (r *VarRegistry) IsReadOnly(name string) (bool, error) {
 	return !rv.def.settable(), nil
 }
 
-// ListVariables returns a map of all variables with their current values
+// ListVariables returns a map of all variables with their current values.
+// It iterates varDefs by canonical name so aliases are excluded, and skips
+// variables whose Get reports the value as unavailable (e.g. multi-valued
+// COMMIT_RESPONSE, whose columns are merged in separately via ListMultiValues).
 func (r *VarRegistry) ListVariables() map[string]string {
 	result := make(map[string]string)
-	for name, rv := range r.vars {
-		value, err := rv.v.Get()
+	for i := range varDefs {
+		name := strings.ToUpper(varDefs[i].name)
+		value, err := r.vars[name].v.Get()
 		if err == nil {
 			result[name] = value
 		}
+	}
+	return result
+}
+
+// ListMultiValues returns the merged GetMulti() output of every registered
+// MultiValueVar whose value is currently available. Keys may intentionally
+// collide with single-valued variables (COMMIT_RESPONSE's COMMIT_TIMESTAMP
+// overrides the plain COMMIT_TIMESTAMP row in SHOW VARIABLES).
+func (r *VarRegistry) ListMultiValues() map[string]string {
+	result := make(map[string]string)
+	for i := range varDefs {
+		mv, ok := r.vars[strings.ToUpper(varDefs[i].name)].v.(MultiValueVar)
+		if !ok {
+			continue
+		}
+		values, err := mv.GetMulti()
+		if err != nil {
+			continue
+		}
+		maps.Copy(result, values)
 	}
 	return result
 }
@@ -178,7 +208,10 @@ func (r *VarRegistry) ListVariableInfo() map[string]struct {
 		CanAdd      bool
 	})
 
-	for name, rv := range r.vars {
+	// Iterate varDefs by canonical name so aliases are excluded from the listing.
+	for i := range varDefs {
+		name := strings.ToUpper(varDefs[i].name)
+		rv := r.vars[name]
 		result[name] = struct {
 			Description string
 			ReadOnly    bool


### PR DESCRIPTION
Part of #725 (PR3 of the varDef migration plan).

## What

Turns the multi-valued `COMMIT_RESPONSE` special variable into an ordinary `varDef` and collapses the duplicated registry plumbing.

- New optional `MultiValueVar { GetMulti() (map[string]string, error) }` capability plus a `commitResponseVar` handler. `Get` reports the value as unavailable (kept out of the flat listing); `GetMulti` returns `COMMIT_TIMESTAMP` / `MUTATION_COUNT`. `COMMIT_RESPONSE` is registered as a `scopeResult` def with its existing description, so generated docs are byte-identical.
- `SHOW VARIABLE` / `SHOW VARIABLES` / `ListVariables` handle multi-valued vars generically via `registry.ListMultiValues`. The `COMMIT_RESPONSE` special cases in `sv.get`, `setFrom*`, `ShowVariablesStatement`, `helpVariableRows`, and the `SetLocalStatement` name check are removed.
- `setFromGoogleSQL`/`setFromSimple` collapse into one `setFrom`, `addFrom*` into one `addFrom`. The dead `errors.Is(readOnly)` / `errors.As(unimplemented setter)` legacy conversions are deleted (the raw registry errors already carry the expected messages); only the load-bearing `ErrUnknownVariable` / `ErrAddNotSupported` translations remain.
- Adds the `varDef.aliases` mechanism: aliases are extra registry keys resolving to the same handler, while listings/completion iterate `varDefs` by canonical name so aliases never surface. No aliases are declared yet.

## Deviation from the #725 PR3 sketch

`CLI_DIRECT_READ` intentionally **stays** special-cased (its `sv.get` case, `ShowVariablesStatement` injection, `helpVariableRows` hand-appended row, `setFrom` unimplemented-setter case, and `SetLocalStatement` name check). The design folds `CLI_DIRECT_READ` into the registry as part of #486 (PR3b), which is explicitly out of scope for this PR. Its generated-docs row is therefore unchanged.

`make check` passes; `make docs-update` produced no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dmtS3P1H7JzRdNJvd17GV