### PR TITLE
fix: surface operation ID and invalidate schema on canceled DDL wait

### DIFF
--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -109,7 +109,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	metadata, err := pollDdl()
 	if err != nil {
 		teardown()
-		return nil, err
+		return nil, handleDdlWaitError(session, op, err)
 	}
 
 	if metadata != nil && bars != nil {
@@ -133,13 +133,13 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 			// continue
 		case <-ctx.Done():
 			teardown()
-			return nil, ctx.Err()
+			return nil, handleDdlWaitError(session, op, ctx.Err())
 		}
 
 		metadata, err = pollDdl()
 		if err != nil {
 			teardown()
-			return nil, err
+			return nil, handleDdlWaitError(session, op, err)
 		}
 
 		if metadata != nil && bars != nil {
@@ -189,6 +189,35 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	}
 
 	return result, nil
+}
+
+// handleDdlWaitError post-processes an error that terminated the synchronous DDL wait loop.
+//
+// When the wait is aborted by context cancellation or deadline (typically Ctrl+C), the
+// UpdateDatabaseDdl long-running operation keeps running server-side and its schema changes
+// may still land. In that case we:
+//   - invalidate the schema cache (IncrementSchemaGeneration), because the schema may change
+//     regardless of whether we kept waiting; and
+//   - surface the still-running operation ID so the user can check progress later via
+//     SHOW OPERATION, instead of returning a bare context error with no handle.
+//
+// Non-cancellation errors (e.g. a DDL that actually failed server-side) are returned unchanged.
+func handleDdlWaitError(session *Session, op *adminapi.UpdateDatabaseDdlOperation, err error) error {
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	session.IncrementSchemaGeneration()
+	return ddlCancellationError(op.Name(), err)
+}
+
+// ddlCancellationError builds the user-facing error for a canceled DDL wait. It extracts the
+// operation ID from the full operation name (same formatting as the async DDL path) and points
+// the user at SHOW OPERATION so they can attach to the still-running operation later. The
+// underlying cause is wrapped so errors.Is(err, context.Canceled) still holds for callers.
+func ddlCancellationError(opName string, cause error) error {
+	operationID := lo.LastOrEmpty(strings.Split(opName, "/"))
+	return fmt.Errorf("stopped waiting for DDL to complete; the operation may still be running server-side, check it with: SHOW OPERATION '%s': %w", operationID, cause)
 }
 
 // formatAsyncDdlResult formats the async DDL operation result in the same format as SHOW OPERATION

--- a/internal/mycli/execute_ddl.go
+++ b/internal/mycli/execute_ddl.go
@@ -8,12 +8,15 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/apstndb/go-tabwrap"
 	"github.com/apstndb/spanner-mycli/internal/mycli/iterutil"
 	"github.com/samber/lo"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -161,7 +164,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	metadata, err = op.Metadata()
 	if err != nil {
 		teardown()
-		return nil, err
+		return nil, handleDdlWaitError(session, op, err)
 	}
 
 	if p != nil {
@@ -191,24 +194,55 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	return result, nil
 }
 
-// handleDdlWaitError post-processes an error that terminated the synchronous DDL wait loop.
+// handleDdlWaitError post-processes an error that terminated the synchronous DDL wait loop,
+// after the UpdateDatabaseDdl operation was already accepted by the server.
 //
-// When the wait is aborted by context cancellation or deadline (typically Ctrl+C), the
-// UpdateDatabaseDdl long-running operation keeps running server-side and its schema changes
-// may still land. In that case we:
-//   - invalidate the schema cache (IncrementSchemaGeneration), because the schema may change
-//     regardless of whether we kept waiting; and
-//   - surface the still-running operation ID so the user can check progress later via
-//     SHOW OPERATION, instead of returning a bare context error with no handle.
+// Two independent concerns are handled here, deliberately kept separate:
 //
-// Non-cancellation errors (e.g. a DDL that actually failed server-side) are returned unchanged.
+//   - Schema-cache invalidation is unconditional. Once the operation is accepted, ANY error exit
+//     may leave the schema changed server-side: a canceled wait whose operation later completes,
+//     or a multi-statement batch that fails at statement k after statements 1..k-1 already
+//     committed. Invalidation is cheap and always safe, and the schema-cache TTL bounds any
+//     residual staleness, so we always bump the generation rather than trying to prove the schema
+//     is unchanged.
+//   - Error-message classification is conditional. Only for cancellation/deadline errors do we
+//     replace the raw error with a hint that surfaces the still-running operation ID via
+//     SHOW OPERATION; genuine DDL failures are returned unchanged.
 func handleDdlWaitError(session *Session, op *adminapi.UpdateDatabaseDdlOperation, err error) error {
-	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+	session.IncrementSchemaGeneration()
+
+	if !isCancellationError(err) {
 		return err
 	}
-
-	session.IncrementSchemaGeneration()
 	return ddlCancellationError(op.Name(), err)
+}
+
+// isCancellationError reports whether err represents a canceled or deadline-exceeded wait.
+//
+// It checks both the standard-library sentinels via errors.Is (matched when the context error is
+// wrapped) AND the gRPC/Spanner status codes. The status-code check is necessary because when the
+// context is canceled while a GetOperation poll RPC is in flight, grpc-go returns a plain status
+// error (codes.Canceled / "context canceled") that does NOT wrap context.Canceled, so errors.Is
+// alone would miss it and the cancellation hint would silently not fire.
+//
+// Tradeoff: a DDL that genuinely fails server-side could in principle carry codes.Canceled or
+// codes.DeadlineExceeded and be misreported as a user cancellation. This is accepted because the
+// in-flight-cancellation window is only reachable through those status codes, so code-based
+// classification is the only way to catch it; misclassification only changes the error text (the
+// invalidation above happens regardless).
+func isCancellationError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return true
+	}
+	switch spanner.ErrCode(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return true
+	}
+	return false
 }
 
 // ddlCancellationError builds the user-facing error for a canceled DDL wait. It extracts the

--- a/internal/mycli/execute_ddl_test.go
+++ b/internal/mycli/execute_ddl_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestDdlCancellationError verifies that a canceled DDL wait produces an error that surfaces
+// the still-running operation ID, points the user at SHOW OPERATION, and preserves the
+// underlying context cause so errors.Is keeps working for callers.
+func TestDdlCancellationError(t *testing.T) {
+	tests := []struct {
+		name      string
+		opName    string
+		cause     error
+		wantOpID  string
+		wantIsErr error
+	}{
+		{
+			name:      "full operation name",
+			opName:    "projects/p/instances/i/databases/d/operations/1234567890",
+			cause:     context.Canceled,
+			wantOpID:  "1234567890",
+			wantIsErr: context.Canceled,
+		},
+		{
+			name:      "bare operation id",
+			opName:    "op-abc",
+			cause:     context.Canceled,
+			wantOpID:  "op-abc",
+			wantIsErr: context.Canceled,
+		},
+		{
+			name:      "deadline exceeded cause",
+			opName:    "projects/p/instances/i/databases/d/operations/op-xyz",
+			cause:     context.DeadlineExceeded,
+			wantOpID:  "op-xyz",
+			wantIsErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ddlCancellationError(tt.opName, tt.cause)
+			if err == nil {
+				t.Fatal("expected non-nil error")
+			}
+
+			if !errors.Is(err, tt.wantIsErr) {
+				t.Errorf("errors.Is(err, %v) = false, want true; err = %v", tt.wantIsErr, err)
+			}
+
+			msg := err.Error()
+			if !strings.Contains(msg, "SHOW OPERATION '"+tt.wantOpID+"'") {
+				t.Errorf("error message does not contain SHOW OPERATION hint for %q\n  got: %s", tt.wantOpID, msg)
+			}
+		})
+	}
+}

--- a/internal/mycli/execute_ddl_test.go
+++ b/internal/mycli/execute_ddl_test.go
@@ -17,8 +17,12 @@ package mycli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestDdlCancellationError verifies that a canceled DDL wait produces an error that surfaces
@@ -69,6 +73,37 @@ func TestDdlCancellationError(t *testing.T) {
 			msg := err.Error()
 			if !strings.Contains(msg, "SHOW OPERATION '"+tt.wantOpID+"'") {
 				t.Errorf("error message does not contain SHOW OPERATION hint for %q\n  got: %s", tt.wantOpID, msg)
+			}
+		})
+	}
+}
+
+// TestIsCancellationError verifies that the classification that drives the SHOW OPERATION hint
+// recognizes cancellation both from the standard-library context sentinels and from plain gRPC /
+// Spanner status errors. The status-error cases matter because a context cancelled while a
+// GetOperation poll RPC is in flight surfaces as a bare status error that does NOT wrap
+// context.Canceled, so errors.Is alone would miss it.
+func TestIsCancellationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "context canceled sentinel", err: context.Canceled, want: true},
+		{name: "context deadline exceeded sentinel", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped context canceled", err: fmt.Errorf("poll failed: %w", context.Canceled), want: true},
+		{name: "grpc status canceled (in-flight RPC)", err: status.Error(codes.Canceled, "context canceled"), want: true},
+		{name: "grpc status deadline exceeded", err: status.Error(codes.DeadlineExceeded, "context deadline exceeded"), want: true},
+		{name: "wrapped grpc status canceled", err: fmt.Errorf("poll failed: %w", status.Error(codes.Canceled, "context canceled")), want: true},
+		{name: "genuine DDL failure", err: status.Error(codes.InvalidArgument, "bad DDL"), want: false},
+		{name: "plain non-status error", err: errors.New("boom"), want: false},
+		{name: "nil error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCancellationError(tt.err); got != tt.want {
+				t.Errorf("isCancellationError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Improves the cancellation and error behavior of the synchronous DDL wait loop in `internal/mycli/execute_ddl.go`. When a user cancels a running DDL wait (Ctrl+C), the submitted `UpdateDatabaseDdl` long-running operation (LRO) keeps executing server-side. This change gives the user a handle to that operation and keeps the schema cache honest on every error exit.

## Motivation

The DDL polling loop is context-aware, but on cancellation it had two problems:

1. **No handle to the still-running operation.** The loop returned a bare context error, so the user had no way to find the operation that was still running server-side, even though the CLI already provides `SHOW OPERATION <id>` for exactly this purpose.
2. **Stale schema cache.** `IncrementSchemaGeneration()` (which signals that schema-dependent caches should be invalidated) was only called on the success path and the async path — never on cancellation or other error exits. Because the DDL was already submitted and may still complete server-side, cancelling left the session's schema cache stale.

## Current vs. new behavior

Both `DdlStatement` and `BulkDdlStatement` execute through `executeDdlStatements`, so both share this wait loop and both are covered.

Before — on Ctrl+C during the wait:

```
context canceled
```

(no operation handle; schema cache not invalidated)

After — on Ctrl+C during the wait:

```
stopped waiting for DDL to complete; the operation may still be running server-side, check it with: SHOW OPERATION '1234567890': context canceled
```

The user can then run `SHOW OPERATION '1234567890'` (or `SHOW OPERATION '<id>' SYNC`) to attach to and monitor the operation. The operation ID is extracted with the same formatting used by the async DDL result path (`lo.LastOrEmpty(strings.Split(op.Name(), "/"))`). The context cause is wrapped with `%w`, so `errors.Is(err, context.Canceled)` still holds for callers.

## Implementation

All error exits after the `UpdateDatabaseDdl` operation is accepted (initial poll error, `ctx.Done()`, in-loop poll error, and the final `op.Metadata()` fetch) now route through `handleDdlWaitError`, which keeps two concerns deliberately separate:

- **Schema-cache invalidation is unconditional.** Once the operation is accepted, any error exit may leave the schema changed server-side — a canceled wait whose operation later completes, or a multi-statement batch that fails at statement *k* after statements 1..*k*-1 already committed. `IncrementSchemaGeneration()` is cheap and always safe, and the schema-cache TTL bounds residual staleness, so it is always called rather than trying to prove the schema is unchanged.
- **Error-message classification is conditional.** Only cancellation/deadline errors get replaced with the operation-ID-bearing `SHOW OPERATION` hint. Genuine DDL failures are returned unchanged.

Cancellation classification lives in `isCancellationError`, which checks both:

- the standard-library context sentinels via `errors.Is` (matched when the context error is wrapped), and
- the gRPC / Spanner status codes (`status.Code`, `spanner.ErrCode`) for `codes.Canceled` / `codes.DeadlineExceeded`.

The status-code check is necessary because when the context is canceled while a `GetOperation` poll RPC is in flight, grpc-go returns a plain status error (`codes.Canceled`, "context canceled") that does **not** wrap `context.Canceled`; an `errors.Is`-only check would miss it and the hint would silently not fire. Tradeoff: a DDL that genuinely fails server-side could in principle carry those codes and be misreported as a cancellation. This is accepted because the in-flight-cancellation window is only reachable through those status codes, and misclassification only changes the error text — invalidation happens regardless.

### Scope notes

- The async DDL path (`Feature.AsyncDDL`) returns immediately without waiting and already calls `IncrementSchemaGeneration()`, so it needs no change.
- `SHOW OPERATION ... SYNC` (`ShowOperationStatement.executeSyncMode`) has its own separate polling loop that also returns a bare context error on cancel. It is a different statement family (monitoring an existing operation rather than submitting DDL) and was intentionally left out of this surgical change.

## Verification

- `make check` passes (test + lint + fmt-check), exit code 0.
- `TestDdlCancellationError` covers the error-formatting helper: operation-ID extraction from a full operation name and from a bare ID, the `SHOW OPERATION '<id>'` hint text, and `errors.Is` preservation for both `context.Canceled` and `context.DeadlineExceeded`.
- `TestIsCancellationError` covers the classification: context sentinels (bare and wrapped), plain and wrapped gRPC status errors for `codes.Canceled` / `codes.DeadlineExceeded` (the in-flight-RPC case), and negative cases (`codes.InvalidArgument`, plain error, nil).
- The concrete `*adminapi.UpdateDatabaseDdlOperation`-dependent wrapper (`handleDdlWaitError`) is not cheaply mockable without emulator choreography, so its wiring is verified by code inspection; the load-bearing classification and error text are unit-tested above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRx8J3m4aexPMYDSMNY1Zs
