### PR TITLE
fix: degrade SHOW PLAN NODE gracefully on malformed cached plans

### DIFF
--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -142,11 +142,18 @@ func (s *ShowPlanNodeStatement) Execute(ctx context.Context, session *Session) (
 		return nil, err
 	}
 
-	queryPlan, err := spannerplan.New(planNodes)
-	if err != nil {
-		return nil, err
+	// Computing incoming parent links requires reconstructing the whole plan,
+	// which can fail on a malformed or unexpected cached plan shape. SHOW PLAN
+	// NODE is a debugging command whose primary value is dumping the raw node
+	// YAML (already marshaled above), so degrade gracefully here: keep showing
+	// the node content and replace the parent-links row with a short note
+	// instead of failing the whole statement.
+	var parentLinksInfo string
+	if queryPlan, err := spannerplan.New(planNodes); err != nil {
+		parentLinksInfo = fmt.Sprintf("parent links unavailable: %v", err)
+	} else {
+		parentLinksInfo = formatShowPlanNodeIncomingLinks(queryPlan.ParentLinks(int32(s.NodeID)))
 	}
-	parentLinksInfo := formatShowPlanNodeIncomingLinks(queryPlan.ParentLinks(int32(s.NodeID)))
 
 	return &Result{
 		TableHeader:  toTableHeader(fmt.Sprintf("Content of Node %v", s.NodeID)),

--- a/internal/mycli/statements_explain_describe_test.go
+++ b/internal/mycli/statements_explain_describe_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/plantree"
 	planref "github.com/apstndb/spannerplan/plantree/reference"
-	"github.com/apstndb/spannerplan/protoyaml"
 	"github.com/apstndb/spannerplan/stats"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -879,8 +878,13 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 		name           string
 		statement      *ShowPlanNodeStatement
 		lastQueryCache *LastQueryCache
-		wantIncoming   string
-		wantErr        bool
+		// wantContent is the literal expected YAML dump of the requested node.
+		// It is a golden string on purpose: deriving it by calling the same
+		// protoyaml.Marshal the production code uses would make the test
+		// tautological (it could never catch a marshaling regression).
+		wantContent  string
+		wantIncoming string
+		wantErr      bool
 	}{
 		{
 			"node with incoming parent link",
@@ -889,6 +893,17 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 				QueryPlan:  selectProfileResultSet.GetStats().GetQueryPlan(),
 				QueryStats: selectProfileResultSet.GetStats().GetQueryStats().AsMap(),
 			},
+			"index: 1\n" +
+				"kind: 1\n" +
+				"display_name: Unit Relation\n" +
+				"child_links:\n" +
+				"- {child_index: 2}\n" +
+				"metadata: {execution_method: Row}\n" +
+				"execution_stats:\n" +
+				"  cpu_time: {total: \"0\", unit: msecs}\n" +
+				"  execution_summary: {num_executions: \"1\"}\n" +
+				"  latency: {total: \"0\", unit: msecs}\n" +
+				"  rows: {total: \"1\", unit: rows}\n",
 			"Incoming Parent Links:\n  - Parent Node Index: 0\n    Parent Node Title: Serialize Result (execution_method: Row)\n    Child Link Type: (not set)",
 			false,
 		},
@@ -918,6 +933,7 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 					},
 				},
 			},
+			"index: 1\nkind: 1\ndisplay_name: Child\n",
 			"Incoming Parent Links:\n  - Parent Node Index: 0\n    Parent Node Title: Root\n    Child Link Type: Map\n    Variable: v",
 			false,
 		},
@@ -940,7 +956,40 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 					},
 				},
 			},
+			"kind: 1\ndisplay_name: Root\n",
 			"Incoming Parent Links:\n  - No incoming parent links",
+			false,
+		},
+		{
+			// Malformed cached plan: node 0 references a non-existent child
+			// index, so spannerplan.New fails. The node YAML must still be
+			// shown, with the parent-links row replaced by a note. This guards
+			// the graceful-degradation path: before it, the whole statement
+			// failed on such plans (regression introduced when incoming
+			// parent-link display was added).
+			"malformed plan degrades to note",
+			&ShowPlanNodeStatement{NodeID: 0},
+			&LastQueryCache{
+				QueryPlan: &sppb.QueryPlan{
+					PlanNodes: []*sppb.PlanNode{
+						{
+							Index:       0,
+							DisplayName: "Root",
+							Kind:        sppb.PlanNode_RELATIONAL,
+							ChildLinks: []*sppb.PlanNode_ChildLink{
+								{ChildIndex: 99},
+							},
+						},
+						{
+							Index:       1,
+							DisplayName: "Child",
+							Kind:        sppb.PlanNode_RELATIONAL,
+						},
+					},
+				},
+			},
+			"kind: 1\ndisplay_name: Root\nchild_links:\n- {child_index: 99}\n",
+			"parent links unavailable: spannerplan: childLink childIndex out of range: parent node 0 childLinks[0] has childIndex 99, len(planNodes)=2",
 			false,
 		},
 	}
@@ -961,14 +1010,8 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 				return
 			}
 
-			planNode := tt.lastQueryCache.QueryPlan.GetPlanNodes()[tt.statement.NodeID]
-			y, err := protoyaml.Marshal(planNode, getGlobalOpts()...)
-			if err != nil {
-				t.Fatalf("yaml.Marshal(planNode, getGlobalOpts()) error = %v", err)
-			}
-
 			want := &Result{
-				Rows:         sliceOf(toRow(string(y)), toRow(tt.wantIncoming)),
+				Rows:         sliceOf(toRow(tt.wantContent), toRow(tt.wantIncoming)),
 				AffectedRows: 2,
 				TableHeader:  toTableHeader(fmt.Sprintf("Content of Node %v", tt.statement.NodeID)),
 			}


### PR DESCRIPTION
## What and why

`SHOW PLAN NODE <id>` dumps the raw YAML of a cached plan node — a debugging aid whose whole point is inspecting whatever the last query left in the cache, however malformed.

Commit `77dd9a2` ("Show incoming parent links for plan nodes") added an incoming parent-link row to the output. To compute those links it calls `spannerplan.New(planNodes)` on the entire cached plan. That call can return an error on a malformed or unexpected plan shape (e.g. a child link whose `childIndex` is out of range, a `PlanNode.Index` that does not match its slice position, or a nil node). In the current Execute path the node YAML is already marshaled successfully *before* that call, but a `spannerplan.New` error now fails the **whole** statement.

That is a robustness regression: before `77dd9a2`, the raw YAML dump always succeeded regardless of overall plan integrity.

## The fix

When `spannerplan.New` (and therefore parent-link computation) fails, still return the node YAML and replace the parent-links row with a short note instead of failing:

```
parent links unavailable: spannerplan: childLink childIndex out of range: parent node 0 childLinks[0] has childIndex 99, len(planNodes)=2
```

The result still has two rows (node content + note) and `AffectedRows: 2`. The happy path is byte-identical: when the plan is well-formed, the parent-links row is produced exactly as before.

## Test changes

The existing `TestShowPlanNodeStatement_Execute` computed its expected node-content row by calling the **same** `protoyaml.Marshal(planNode, getGlobalOpts()...)` the production code uses. That expectation is tautological — it mirrors whatever the production marshaler emits, so it can never catch a marshaling regression.

- Replaced the computed expectation with literal golden YAML strings (a new `wantContent` field per case).
- Added a degraded-path case: a plan whose node 0 references a non-existent child index makes `spannerplan.New` fail; the test asserts the node YAML is still shown and the parent-links row is replaced by the `parent links unavailable: ...` note.

## Validation

`make check` passes (tests + `golangci-lint` clean + formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRx8J3m4aexPMYDSMNY1Zs
