### PR TITLE
test(lint_plan): add unit tests for CLI_LINT_PLAN linter (0% -> 100% coverage)

### DIFF
--- a/internal/mycli/lint_plan_test.go
+++ b/internal/mycli/lint_plan_test.go
@@ -1,0 +1,145 @@
+package mycli
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestLintPlan exercises each heuristic implemented by lintPlan against a query
+// plan that triggers it. Expected messages are hardcoded (not produced by the
+// same formatting code under test) so the assertions verify the documented
+// linter behavior described in docs/query_plan.md. The output slice is a flat
+// list where each finding is a node-title header line followed by one or more
+// indented ("    ") message lines.
+func TestLintPlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// file is a plan fixture under testdata/plans. Existing fixtures are
+		// reused where they already trigger a rule; sort/minor_sort/
+		// hash_aggregate/no_findings are minimal fixtures added specifically
+		// for rules that no existing fixture exercised.
+		file string
+		// want is the complete expected lint output. nil means "no findings".
+		want []string
+	}{
+		{
+			// "Filter" display name -> Filter operator heuristic.
+			name: "filter_operator",
+			file: "testdata/plans/filter.input.json",
+			want: []string{
+				"1: Filter",
+				"    Potentially expensive operator Filter can't utilize index: Maybe better to modify to use Filter Scan with Seek Condition?",
+			},
+		},
+		{
+			// "Hash Join" display name -> Hash Join heuristic; the same plan
+			// also has "Full scan": "true" metadata on two scan nodes.
+			name: "hash_join_and_full_scan",
+			file: "testdata/plans/hash_join.input.json",
+			want: []string{
+				"2: Hash Join (join_type: INNER)",
+				"    Potentially expensive operator Hash Join: Maybe better to modify to use Cross Apply or Merge Join?",
+				"4: Table Scan (Full scan: true, Table: Albums)",
+				"    Full scan=true: Potentially expensive execution full scan: Do you really want full scan?",
+				"9: Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
+				"    Full scan=true: Potentially expensive execution full scan: Do you really want full scan?",
+			},
+		},
+		{
+			// "Residual Condition" child link type -> Residual Condition
+			// heuristic; the same plan also has a full-scan Table Scan.
+			name: "residual_condition_and_full_scan",
+			file: "testdata/plans/scalar_subquery_with_filter_scan.input.json",
+			want: []string{
+				"3: FilterScan",
+				"    Residual Condition: Potentially expensive Residual Condition: Maybe better to modify it to Scan Condition",
+				"4: Table Scan (Full scan: true, Table: Songs)",
+				"    Full scan=true: Potentially expensive execution full scan: Do you really want full scan?",
+			},
+		},
+		{
+			// Full scan heuristic in isolation (single triggering node).
+			name: "full_scan_only",
+			file: "testdata/plans/array_subqueries.input.json",
+			want: []string{
+				"3: Index Scan (Full scan: true, Index: AlbumsByAlbumTitle)",
+				"    Full scan=true: Potentially expensive execution full scan: Do you really want full scan?",
+			},
+		},
+		{
+			// "Sort" display name -> Sort heuristic, including the formatted
+			// key order pulled from the "Key" child link. The key description
+			// "$SingerId DESC" is resolved through the Scan node's "SingerId"
+			// variable definition, so it renders as "SingerId DESC".
+			name: "sort_operator",
+			file: "testdata/plans/sort.input.json",
+			want: []string{
+				"0: Sort",
+				"    Potentially expensive operator Sort: Maybe better to modify to use the same order with the index?, order: SingerId DESC",
+			},
+		},
+		{
+			// "Minor Sort" display name -> Minor Sort heuristic. This is
+			// matched before the plain "Sort" branch even though the name
+			// also contains "Sort"; the message reports major/minor keys.
+			name: "minor_sort_operator",
+			file: "testdata/plans/minor_sort.input.json",
+			want: []string{
+				"0: Minor Sort",
+				"    Potentially expensive operator Minor Sort is cheaper than Sort but it may be not optimal: Maybe better to modify to use the same order with the index?: major: $SingerId ASC, minor: $AlbumId DESC",
+			},
+		},
+		{
+			// iterator_type=Hash metadata -> Hash iterator heuristic. The node
+			// title is rendered as "Hash Aggregate" by spannerplan.
+			name: "hash_iterator",
+			file: "testdata/plans/hash_aggregate.input.json",
+			want: []string{
+				"0: Hash Aggregate",
+				"    iterator_type=Hash: Potentially expensive execution Hash Aggregate: Maybe better to modify to use Stream Aggregate?, keys: $SingerId",
+			},
+		},
+		{
+			// A plan with a plain (non-full) Table Scan under Serialize Result
+			// triggers no heuristic.
+			name: "no_findings",
+			file: "testdata/plans/no_findings.input.json",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			plan := loadTestPlan(t, tt.file)
+			got := lintPlan(plan)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("lintPlan(%s) mismatch (-want +got):\n%s", tt.file, diff)
+			}
+		})
+	}
+}
+
+// TestLintPlan_InvalidPlan verifies that lintPlan degrades gracefully: when
+// spannerplan.New rejects the plan (here, a PlanNode whose Index does not match
+// its slice position), the linter logs and returns no findings rather than
+// panicking or surfacing an error, because linting is only informative.
+func TestLintPlan_InvalidPlan(t *testing.T) {
+	t.Parallel()
+
+	// Index 5 at slice position 0 violates the Index-matches-position contract
+	// enforced by spannerplan.New.
+	plan := &sppb.QueryPlan{
+		PlanNodes: []*sppb.PlanNode{
+			{Index: 5, DisplayName: "Scan"},
+		},
+	}
+
+	if got := lintPlan(plan); got != nil {
+		t.Errorf("lintPlan(invalid plan) = %v, want nil", got)
+	}
+}

--- a/internal/mycli/testdata/plans/hash_aggregate.input.json
+++ b/internal/mycli/testdata/plans/hash_aggregate.input.json
@@ -1,0 +1,37 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 2,
+          "type": "Key"
+        }
+      ],
+      "displayName": "Aggregate",
+      "kind": "RELATIONAL",
+      "metadata": {
+        "iterator_type": "Hash"
+      }
+    },
+    {
+      "displayName": "Scan",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "Singers",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 2,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    }
+  ]
+}

--- a/internal/mycli/testdata/plans/minor_sort.input.json
+++ b/internal/mycli/testdata/plans/minor_sort.input.json
@@ -1,0 +1,46 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 2,
+          "type": "MajorKey"
+        },
+        {
+          "childIndex": 3,
+          "type": "MinorKey"
+        }
+      ],
+      "displayName": "Minor Sort",
+      "kind": "RELATIONAL"
+    },
+    {
+      "displayName": "Scan",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "Singers",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 2,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId ASC"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 3,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId DESC"
+      }
+    }
+  ]
+}

--- a/internal/mycli/testdata/plans/no_findings.input.json
+++ b/internal/mycli/testdata/plans/no_findings.input.json
@@ -1,0 +1,22 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        }
+      ],
+      "displayName": "Serialize Result",
+      "kind": "RELATIONAL"
+    },
+    {
+      "displayName": "Scan",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "Singers",
+        "scan_type": "TableScan"
+      }
+    }
+  ]
+}

--- a/internal/mycli/testdata/plans/sort.input.json
+++ b/internal/mycli/testdata/plans/sort.input.json
@@ -1,0 +1,48 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 2,
+          "type": "Key"
+        }
+      ],
+      "displayName": "Sort",
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 3,
+          "variable": "SingerId"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "Singers",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 2,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId DESC"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 3,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

`internal/mycli/lint_plan.go` implements the `CLI_LINT_PLAN` heuristic query
plan linter — a documented feature (see `docs/query_plan.md`, "Query plan linter
(EARLY EXPERIMENTAL)"). Despite being user-facing, it had **0% test coverage**
and zero test references, so every heuristic and the graceful-degradation path
were unverified.

This PR adds table-driven unit tests that map each heuristic to at least one
plan that triggers it, and asserts on the exact lint message content. Expected
messages are hardcoded rather than produced by the formatting code under test,
so the assertions genuinely pin the documented behavior instead of being
tautological. Tests are unit-only (`go test -short`): the linter operates purely
on plan JSON, no emulator required.

## What each test covers

`TestLintPlan` (table-driven) — one case per heuristic in `lintPlan`:

- **Filter operator** (`filter.input.json`) — `"Filter"` display name.
- **Hash Join** + **Full scan** (`hash_join.input.json`) — `"Hash Join"` display
  name plus two nodes with `"Full scan": "true"` metadata.
- **Residual Condition** + **Full scan** (`scalar_subquery_with_filter_scan.input.json`)
  — `Residual Condition` child-link type plus a full-scan Table Scan.
- **Full scan in isolation** (`array_subqueries.input.json`) — single triggering
  node, exercising the full-scan rule on its own.
- **Sort** (`sort.input.json`, new) — `"Sort"` display name, including the key
  order rendered from the `Key` child link. The key `$SingerId` is resolved
  through the Scan node's variable definition, exercising the variable-lookup
  recursion in `lookupVar`.
- **Minor Sort** (`minor_sort.input.json`, new) — `"Minor Sort"` display name,
  matched before the plain `Sort` branch, reporting major/minor keys.
- **Hash iterator** (`hash_aggregate.input.json`, new) — `iterator_type=Hash`
  metadata on an Aggregate node.
- **No findings** (`no_findings.input.json`, new) — a plain (non-full) Table Scan
  under Serialize Result triggers nothing; asserts empty output.

`TestLintPlan_InvalidPlan` — a `PlanNode` whose `Index` does not match its slice
position makes `spannerplan.New` fail; verifies the linter logs and returns no
findings (linting is only informative) rather than erroring or panicking.

### Fixtures

Existing `testdata/plans/*.input.json` fixtures are reused wherever they already
trigger a rule. Four minimal fixtures were added only for rules no existing
fixture exercised: `sort`, `minor_sort`, `hash_aggregate`, and `no_findings`.
Each is kept as small as possible while still triggering (or, for
`no_findings`, deliberately not triggering) the heuristic.

## Coverage (lint_plan.go)

Measured with
`go test -short -coverprofile=... ./internal/mycli/ && go tool cover -func | grep lint_plan.go`:

| Function | Before | After |
|---|---|---|
| `lookupVar` | 0.0% | 100.0% |
| `descToKeyElem` | 0.0% | 100.0% |
| `buildVariableToNodeMap` | 0.0% | 100.0% |
| `LinkTypePred` | 0.0% | 100.0% |
| `formatKeyElem` | 0.0% | 100.0% |
| `lintPlan` | 0.0% | 100.0% |
| `formatKeyElemForLinkType` | 0.0% | 100.0% |

The whole file goes from 0% to 100% function coverage.

## Docs observation (no behavior change)

`docs/query_plan.md` illustrates the linter with a single example output that
demonstrates only the **Residual Condition** and **Full scan** heuristics. The
linter additionally implements **Filter**, **Hash Join**, **Sort**, **Minor
Sort**, and **Hash-iterator** heuristics that the docs do not spell out. This is
under-documentation, not a docs/code contradiction, so no behavior was changed;
noting it here for visibility.

## Verification

- `make check` passes (test + lint + fmt-check), exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRx8J3m4aexPMYDSMNY1Zs
