### PR TITLE
fix: block mutating CQL and ADD SPLIT POINTS in READONLY mode

### DIFF
--- a/internal/mycli/readonly_guard_test.go
+++ b/internal/mycli/readonly_guard_test.go
@@ -28,6 +28,7 @@ func TestReadOnlyGuardCoversBatchStatements(t *testing.T) {
 		{desc: "batch DML", stmt: &BatchDMLStatement{DMLs: []spanner.Statement{spanner.NewStatement("UPDATE t SET id = 1 WHERE TRUE")}}},
 		{desc: "CREATE DATABASE", stmt: &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d"}},
 		{desc: "SYNC PROTO BUNDLE", stmt: &SyncProtoStatement{UpsertPaths: []string{"examples.ProtoType"}}},
+		{desc: "ADD SPLIT POINTS", stmt: &AddSplitPointsStatement{}},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
@@ -67,5 +68,90 @@ func TestReadOnlyGuardPreservesActiveBatch(t *testing.T) {
 	}
 	if len(bulk.Ddls) != 1 {
 		t.Fatalf("batch DDLs = %d, want 1", len(bulk.Ddls))
+	}
+}
+
+// TestCQLStatementMutates exhaustively checks the fail-closed classification of
+// CQL statements: only SELECT is treated as read-only; every other verb
+// (mutations, DDL, permissions) and any unrecognized or empty keyword is
+// treated as mutating.
+func TestCQLStatementMutates(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		cql  string
+		want bool
+	}{
+		{cql: "SELECT * FROM t", want: false},
+		{cql: "select * from t", want: false},
+		{cql: "  SELECT * FROM t", want: false},
+		{cql: "INSERT INTO t (id) VALUES (1)", want: true},
+		{cql: "UPDATE t SET c = 1 WHERE id = 1", want: true},
+		{cql: "DELETE FROM t WHERE id = 1", want: true},
+		{cql: "BEGIN BATCH INSERT INTO t (id) VALUES (1) APPLY BATCH", want: true},
+		{cql: "TRUNCATE t", want: true},
+		{cql: "CREATE TABLE t (id int PRIMARY KEY)", want: true},
+		{cql: "DROP TABLE t", want: true},
+		{cql: "ALTER TABLE t ADD c int", want: true},
+		{cql: "GRANT SELECT ON t TO role", want: true},
+		{cql: "REVOKE SELECT ON t FROM role", want: true},
+		{cql: "BOGUS not a real verb", want: true}, // fail-closed on unknown keyword
+		{cql: "", want: true},                      // fail-closed on empty
+		{cql: "   ", want: true},                   // fail-closed on whitespace-only
+	} {
+		t.Run(tt.cql, func(t *testing.T) {
+			t.Parallel()
+			if got := cqlStatementMutates(tt.cql); got != tt.want {
+				t.Errorf("cqlStatementMutates(%q) = %v, want %v", tt.cql, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReadOnlyGuardBlocksMutatingCQL verifies that mutating CQL is rejected by
+// Session.ExecuteStatement in READONLY mode. These statements short-circuit at
+// the guard before CQLStatement.Execute, so no Cassandra adapter is needed.
+//
+// The complementary case (read-only SELECT is NOT blocked) is covered by
+// TestReadOnlyGuardAllowsReadOnlyCQL and TestCQLStatementMutates; it is not
+// exercised through ExecuteStatement here because a passing SELECT proceeds to
+// Execute, which would attempt a real Cassandra/Spanner connection.
+func TestReadOnlyGuardBlocksMutatingCQL(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		desc string
+		cql  string
+	}{
+		{desc: "DELETE blocked", cql: "DELETE FROM t WHERE id = 1"},
+		{desc: "INSERT blocked", cql: "INSERT INTO t (id) VALUES (1)"},
+		{desc: "unrecognized keyword blocked", cql: "FROBNICATE t"},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			session := newSessionForLocalVarTest(t)
+			session.systemVariables.Transaction.ReadOnly = true
+
+			_, err := session.ExecuteStatement(t.Context(), &CQLStatement{CQL: tt.cql})
+			if !errors.Is(err, errReadOnly) {
+				t.Errorf("%s in READONLY mode: got error %v, want errReadOnly", tt.desc, err)
+			}
+		})
+	}
+}
+
+// TestReadOnlyGuardAllowsReadOnlyCQL verifies that a read-only CQL statement is
+// not classified as mutating, so the READONLY guard lets it through. The guard
+// input is isConditionallyMutating; asserting it directly avoids running
+// CQLStatement.Execute, which would need a live Cassandra adapter.
+func TestReadOnlyGuardAllowsReadOnlyCQL(t *testing.T) {
+	t.Parallel()
+
+	stmt := &CQLStatement{CQL: "SELECT * FROM t"}
+	if _, isMutation := any(stmt).(MutationStatement); isMutation {
+		t.Fatal("CQLStatement must not be a static MutationStatement")
+	}
+	if stmt.isConditionallyMutating() {
+		t.Error("read-only SELECT CQL classified as mutating; READONLY guard would wrongly block it")
 	}
 }

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -803,6 +803,15 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 		return stmt.Execute(ctx, s)
 	}
 
+	// Conditionally mutating statements (e.g. mutating CQL) participate in the
+	// READONLY guard but do not determine a pending Spanner transaction, since
+	// they do not use the Spanner transaction machinery.
+	if cm, ok := stmt.(ConditionallyMutatingStatement); ok && cm.isConditionallyMutating() {
+		if err := s.failStatementIfReadOnly(); err != nil {
+			return &Result{}, err
+		}
+	}
+
 	return stmt.Execute(ctx, s)
 }
 

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -48,6 +48,19 @@ type MutationStatement interface {
 	isMutationStatement()
 }
 
+// ConditionallyMutatingStatement is a marker interface for statements whose
+// mutation-ness cannot be decided statically from their Go type but only from
+// their content (e.g. a CQL statement text). The READONLY guard in
+// Session.ExecuteStatement consults isConditionallyMutating at the same single
+// call site as the static MutationStatement marker.
+//
+// Unlike MutationStatement, implementing this interface does NOT determine a
+// pending Spanner transaction: it only participates in the READONLY guard,
+// because such statements (CQL) do not use the Spanner transaction machinery.
+type ConditionallyMutatingStatement interface {
+	isConditionallyMutating() bool
+}
+
 // Compile-time assertions for every MutationStatement implementation.
 // The marker method is unexported, so a typo (e.g. an exported
 // IsMutationStatement) silently drops the type out of the interface and
@@ -66,6 +79,14 @@ var (
 	_ MutationStatement = (*BulkDdlStatement)(nil)
 	_ MutationStatement = (*BatchDMLStatement)(nil)
 	_ MutationStatement = (*SyncProtoStatement)(nil)
+	_ MutationStatement = (*AddSplitPointsStatement)(nil)
+)
+
+// Compile-time assertions for every ConditionallyMutatingStatement
+// implementation. As with the marker above, the method is unexported so a typo
+// silently drops the type out of the interface and bypasses the READONLY guard.
+var (
+	_ ConditionallyMutatingStatement = (*CQLStatement)(nil)
 )
 
 // DetachedCompatible is a marker interface for statements that can run in Detached session mode (admin operation only mode).

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -665,6 +665,43 @@ type CQLStatement struct {
 	CQL string
 }
 
+// firstCQLKeyword returns the uppercased first whitespace-delimited token of a
+// CQL statement, or "" if there is none.
+func firstCQLKeyword(cql string) string {
+	fields := strings.Fields(cql)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToUpper(fields[0])
+}
+
+// cqlStatementMutates reports whether a CQL statement should be treated as
+// mutating for the purpose of the READONLY guard.
+//
+// It classifies by the statement's first keyword and is deliberately
+// fail-closed: only statements whose first keyword is a known read-only verb
+// are allowed under READONLY. Everything else - data mutations
+// (INSERT/UPDATE/DELETE), batches (BATCH), DDL (CREATE/DROP/ALTER/TRUNCATE),
+// permission changes (GRANT/REVOKE), and any unrecognized or empty keyword - is
+// treated as mutating so the guard blocks it. This avoids silently allowing an
+// unknown CQL verb to bypass READONLY.
+//
+// SELECT is the only clearly read-only data verb in the Spanner Cassandra
+// adapter's supported surface. Other Cassandra read verbs (e.g. LIST, DESCRIBE)
+// are not part of that surface, so they are intentionally not allow-listed.
+func cqlStatementMutates(cql string) bool {
+	switch firstCQLKeyword(cql) {
+	case "SELECT":
+		return false
+	default:
+		return true
+	}
+}
+
+func (cs *CQLStatement) isConditionallyMutating() bool {
+	return cqlStatementMutates(cs.CQL)
+}
+
 func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (result *Result, err error) {
 	// lazy initialize gocql.ClusterConfig
 	if session.cqlCluster == nil {

--- a/internal/mycli/statements_split_points.go
+++ b/internal/mycli/statements_split_points.go
@@ -22,6 +22,11 @@ type AddSplitPointsStatement struct {
 	SplitPoints []*databasepb.SplitPoints
 }
 
+// ADD SPLIT POINTS mutates the database split state via the admin API, so it is
+// blocked in READONLY mode. See the compile-time assertion in
+// statement_processing.go.
+func (AddSplitPointsStatement) isMutationStatement() {}
+
 func (s *AddSplitPointsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	_, err := session.adminClient.AddSplitPoints(ctx, &databasepb.AddSplitPointsRequest{
 		Database:    session.DatabasePath(),


### PR DESCRIPTION
## Summary

Closes two remaining gaps where a statement could mutate data while the session was in READONLY mode (`--readonly` / `SET READONLY=TRUE`). Both statements bypassed the single READONLY guard in `Session.ExecuteStatement` (`internal/mycli/session.go`), which only consulted the static `MutationStatement` marker.

## Gap 1: CQL statements bypassed the guard entirely

`CQLStatement` (`internal/mycli/statements.go`) does not implement `MutationStatement`, so the guard never saw it. As a result `CQL DELETE ...`, `CQL INSERT ...`, etc. executed and mutated data even under READONLY.

Unlike SQL statement types, CQL mutation-ness is not decidable from the Go type: it depends on the statement text. So a static marker is insufficient.

### Fix: fail-closed first-keyword classification + a per-statement guard marker

- New pure function `cqlStatementMutates(cql string) bool` classifies a CQL statement by its first whitespace-delimited keyword and is deliberately **fail-closed**: only `SELECT` is treated as read-only. Every other verb — `INSERT`/`UPDATE`/`DELETE`, `BATCH`, `TRUNCATE`, `CREATE`/`DROP`/`ALTER`, `GRANT`/`REVOKE` — and any unrecognized or empty keyword is treated as mutating so the guard blocks it. `SELECT` is the only clearly read-only data verb in the Spanner Cassandra adapter's supported surface; other Cassandra read verbs (e.g. `LIST`, `DESCRIBE`) are not part of that surface and are intentionally not allow-listed. Fail-closed means an unknown/future CQL verb can never silently bypass READONLY.
- New unexported marker interface `ConditionallyMutatingStatement { isConditionallyMutating() bool }` in `internal/mycli/statement_processing.go`, implemented by `CQLStatement`. It is consulted at the **same single guard call site** in `Session.ExecuteStatement`, preserving the central-guard property. Crucially, a conditionally-mutating statement participates only in the READONLY check and does **not** determine a pending Spanner transaction, because CQL does not use the Spanner transaction machinery.
- A compile-time assertion `var _ ConditionallyMutatingStatement = (*CQLStatement)(nil)` mirrors the `MutationStatement` assertion discipline from #695/#696: because the marker method is unexported, a typo would silently drop the type out of the interface and reopen the guard gap, and the assertion catches that at build time.

## Gap 2: ADD SPLIT POINTS executed unguarded

`AddSplitPointsStatement` (`internal/mycli/statements_split_points.go`) mutates database split state via the admin API but did not implement `MutationStatement`, so it ran unguarded under READONLY.

### Fix

Added `func (AddSplitPointsStatement) isMutationStatement() {}` plus the matching compile-time assertion in `statement_processing.go`, consistent with the other DDL-ish statements.

## Tests

Added to `internal/mycli/readonly_guard_test.go`:

- `TestCQLStatementMutates` — exhaustive table over the classifier: `SELECT` (incl. lowercase / leading whitespace) is read-only; `INSERT`/`UPDATE`/`DELETE`/`BEGIN BATCH`/`TRUNCATE`/`CREATE`/`DROP`/`ALTER`/`GRANT`/`REVOKE`, an unrecognized verb, empty, and whitespace-only are all mutating (fail-closed).
- `TestReadOnlyGuardBlocksMutatingCQL` — mutating CQL (`DELETE`, `INSERT`, unrecognized keyword) is rejected with `errReadOnly` at `Session.ExecuteStatement`. These short-circuit at the guard before `Execute`, so no Cassandra adapter is needed.
- `TestReadOnlyGuardAllowsReadOnlyCQL` — asserts `SELECT` CQL is not a static `MutationStatement` and `isConditionallyMutating()` returns false, so the guard lets it through. This checks the guard input directly rather than running `Execute` (a passing SELECT would attempt a real Cassandra/Spanner connection), keeping the test hermetic per the no-heavy-CQL-infra constraint.
- Extended `TestReadOnlyGuardCoversBatchStatements` with an `ADD SPLIT POINTS` case.

`make check` passes (test + lint + fmt-check).

## Release note

This is a behavior change worth a release-note entry: **READONLY mode now also blocks mutating CQL statements and `ADD SPLIT POINTS`** (previously allowed by omission). Read-only `CQL SELECT` remains allowed. No in-repo docs enumerate the set of statements READONLY blocks, so no README/docs update was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRx8J3m4aexPMYDSMNY1Zs
