### PR TITLE
fix: harden file-input safety for credentials, stdin, and SafeReadFile

### DIFF
--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -696,13 +696,36 @@ func spannerConnectionEnvResolver() kong.Resolver {
 	})
 }
 
+// credentialFileMaxSize caps the credential JSON read. Service-account key
+// files are a few KiB; 4 MiB is a generous ceiling that still routes the read
+// through the filesafety layer (size/type limits) used for other file inputs.
+const credentialFileMaxSize = 4 * 1024 * 1024 // 4 MiB
+
 func readCredentialFile(filepath string) ([]byte, error) {
-	f, err := os.Open(filepath)
+	data, err := filesafety.SafeReadFile(filepath, &filesafety.FileSafetyOptions{MaxSize: credentialFileMaxSize})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read credential file %q failed: %w", filepath, err)
 	}
-	defer f.Close()
-	return io.ReadAll(f)
+	return data, nil
+}
+
+// stdinMaxSize caps batch input read from stdin. Batch/stdin input is otherwise
+// unbounded, so this mirrors the limit the CLI already enforces on SQL files
+// read from disk and prevents a hostile or accidental stream from exhausting
+// memory.
+const stdinMaxSize = int64(filesafety.DefaultMaxFileSize)
+
+// readStdinCapped reads from stdin but refuses input larger than maxSize,
+// returning a clear error that names the limit instead of silently truncating.
+func readStdinCapped(stdin io.Reader, maxSize int64) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(stdin, maxSize+1))
+	if err != nil {
+		return "", fmt.Errorf("read from stdin failed: %w", err)
+	}
+	if int64(len(data)) > maxSize {
+		return "", fmt.Errorf("stdin input too large: exceeded %d bytes", maxSize)
+	}
+	return string(data), nil
 }
 
 // determineInputAndMode decides whether to run in interactive or batch mode
@@ -732,11 +755,11 @@ func determineInputAndMode(opts *spannerOptions, stdin io.Reader) (input string,
 	case opts.SQL != "":
 		return opts.SQL, false, nil
 	case fileToRead == "-":
-		b, err := io.ReadAll(stdin)
+		s, err := readStdinCapped(stdin, stdinMaxSize)
 		if err != nil {
-			return "", false, fmt.Errorf("read from stdin failed: %w", err)
+			return "", false, err
 		}
-		return string(b), false, nil
+		return s, false, nil
 	case fileToRead != "":
 		// AllowNonRegular keeps process substitution (--file <(...)) working;
 		// SafeReadFile still bounds the read for pipe-like inputs.
@@ -754,11 +777,11 @@ func determineInputAndMode(opts *spannerOptions, stdin io.Reader) (input string,
 		}
 
 		// No terminal - read from stdin for batch mode
-		b, err := io.ReadAll(stdin)
+		s, err := readStdinCapped(stdin, stdinMaxSize)
 		if err != nil {
-			return "", false, fmt.Errorf("read from stdin failed: %w", err)
+			return "", false, err
 		}
-		return string(b), false, nil
+		return s, false, nil
 	}
 }
 

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -89,32 +89,51 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 	return nil
 }
 
-// SafeReadFile reads a file after performing safety checks. For regular files
-// the size limit is enforced up front from Stat. Non-regular inputs (only
-// reachable with AllowNonRegular, e.g. process substitution FIFOs) report a
-// meaningless Stat size, so the read itself is capped at the size limit and
-// exceeding it is an error rather than a truncation.
+// SafeReadFile reads a file after performing safety checks, validating the same
+// file descriptor it reads from to avoid a stat-then-reopen TOCTOU.
+//
+// The flow mirrors streamio.openOutputFile's open-then-fstat pattern:
+//  1. A pre-open Stat rejects unsafe targets (e.g. non-regular files when
+//     AllowNonRegular is unset, or directories) before we open them. This
+//     matters because opening a FIFO O_RDONLY blocks until a writer appears, so
+//     we must not open one we are only going to reject.
+//  2. After os.Open, f.Stat() re-validates against the descriptor actually
+//     opened. If the path was swapped between the two stats (e.g. a regular
+//     file replaced by a device or FIFO), this catches it and we never read
+//     from an unexpected target.
+//
+// The read itself is always capped via io.LimitReader for BOTH regular and
+// allowed non-regular inputs. Stat sizes are meaningless for pipes and can be
+// stale for regular files, so the limit is enforced at read time rather than
+// only from the FileInfo size.
 func SafeReadFile(path string, opts *FileSafetyOptions) ([]byte, error) {
+	maxSize := maxFileSize(opts)
+
+	// Pre-open validation: reject unsafe targets before opening so we never
+	// block opening (e.g. a FIFO) a file we would only reject anyway.
 	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat file %s: %w", path, err)
 	}
-
 	if err := ValidateFileSafety(fi, path, opts); err != nil {
 		return nil, err
 	}
-
-	if fi.Mode().IsRegular() {
-		return os.ReadFile(path)
-	}
-
-	maxSize := maxFileSize(opts)
 
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", path, err)
 	}
 	defer f.Close()
+
+	// Re-validate against the opened descriptor to close the stat-then-reopen
+	// TOCTOU: the file we read from is exactly the one we validated here.
+	fi, err = f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat opened file %s: %w", path, err)
+	}
+	if err := ValidateFileSafety(fi, path, opts); err != nil {
+		return nil, err
+	}
 
 	data, err := io.ReadAll(io.LimitReader(f, maxSize+1))
 	if err != nil {

--- a/internal/mycli/filesafety/file_safety.go
+++ b/internal/mycli/filesafety/file_safety.go
@@ -90,7 +90,7 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 }
 
 // SafeReadFile reads a file after performing safety checks, validating the same
-// file descriptor it reads from to avoid a stat-then-reopen TOCTOU.
+// file descriptor it reads from so it never reads from an unexpected target.
 //
 // The flow mirrors streamio.openOutputFile's open-then-fstat pattern:
 //  1. A pre-open Stat rejects unsafe targets (e.g. non-regular files when
@@ -99,8 +99,15 @@ func ValidateFileSafety(fi os.FileInfo, path string, opts *FileSafetyOptions) er
 //     we must not open one we are only going to reject.
 //  2. After os.Open, f.Stat() re-validates against the descriptor actually
 //     opened. If the path was swapped between the two stats (e.g. a regular
-//     file replaced by a device or FIFO), this catches it and we never read
-//     from an unexpected target.
+//     file replaced by a device or FIFO), this catches it before we read.
+//
+// Scope of the guarantee: the fd re-validation ensures we never READ from a
+// swapped or unexpected file type. It does NOT eliminate an open-time block: a
+// hostile swap of a regular file to a FIFO in the window between the pre-open
+// Stat and os.Open can still block the blocking os.Open until a writer appears,
+// on platforms where opening a FIFO read-only blocks. This is an accepted
+// limitation for a local CLI. O_NONBLOCK open is deliberately not used so that
+// process-substitution FIFOs (--file <(...)) keep working with blocking reads.
 //
 // The read itself is always capped via io.LimitReader for BOTH regular and
 // allowed non-regular inputs. Stat sizes are meaningless for pipes and can be

--- a/internal/mycli/filesafety/file_safety_test.go
+++ b/internal/mycli/filesafety/file_safety_test.go
@@ -295,3 +295,41 @@ func TestSafeReadFile_directoryRejectedEvenWithAllowNonRegular(t *testing.T) {
 		t.Fatalf("error = %v, want cannot-read-directory error", err)
 	}
 }
+
+// TestSafeReadFile_openOnceRegularReadCap exercises the open-once path for
+// regular files: the size limit is enforced against the descriptor that is
+// actually read. A file at the limit is returned in full and a file over the
+// limit is rejected.
+func TestSafeReadFile_openOnceRegularReadCap(t *testing.T) {
+	t.Parallel()
+
+	const maxSize = 1024
+
+	t.Run("at limit", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "at_limit.txt")
+		content := strings.Repeat("a", maxSize)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got, err := SafeReadFile(path, &FileSafetyOptions{MaxSize: maxSize})
+		if err != nil {
+			t.Fatalf("SafeReadFile: %v", err)
+		}
+		if string(got) != content {
+			t.Errorf("got %d bytes, want %d", len(got), len(content))
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "over_limit.txt")
+		if err := os.WriteFile(path, []byte(strings.Repeat("a", maxSize+1)), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_, err := SafeReadFile(path, &FileSafetyOptions{MaxSize: maxSize})
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("error = %v, want too-large error", err)
+		}
+	})
+}

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -1792,6 +1792,63 @@ func TestReadCredentialFile(t *testing.T) {
 	}
 }
 
+// TestReadCredentialFile_sizeCap verifies that credential files exceeding the
+// filesafety size cap are rejected instead of being read unbounded.
+func TestReadCredentialFile_sizeCap(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	credFile := filepath.Join(tempDir, "big-cred.json")
+	// One byte over the cap is enough to trigger rejection.
+	oversized := make([]byte, credentialFileMaxSize+1)
+	if err := os.WriteFile(credFile, oversized, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readCredentialFile(credFile)
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("readCredentialFile() error = %v, want too-large error", err)
+	}
+}
+
+// TestReadStdinCapped verifies the stdin size cap: input at the limit is
+// returned in full and input over the limit is rejected with a clear error.
+func TestReadStdinCapped(t *testing.T) {
+	t.Parallel()
+
+	const maxSize = int64(16)
+
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		got, err := readStdinCapped(strings.NewReader("SELECT 1;"), maxSize)
+		if err != nil {
+			t.Fatalf("readStdinCapped() error = %v", err)
+		}
+		if got != "SELECT 1;" {
+			t.Errorf("got %q, want %q", got, "SELECT 1;")
+		}
+	})
+
+	t.Run("at limit", func(t *testing.T) {
+		t.Parallel()
+		content := strings.Repeat("x", int(maxSize))
+		got, err := readStdinCapped(strings.NewReader(content), maxSize)
+		if err != nil {
+			t.Fatalf("readStdinCapped() error = %v", err)
+		}
+		if got != content {
+			t.Errorf("got %d bytes, want %d", len(got), len(content))
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		t.Parallel()
+		content := strings.Repeat("x", int(maxSize)+1)
+		_, err := readStdinCapped(strings.NewReader(content), maxSize)
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("readStdinCapped() error = %v, want too-large error", err)
+		}
+	})
+}
+
 func TestBatchModeTableFormatLogic(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

The CLI already applies the `filesafety` contract (size caps and file-type
checks) to SQL files (`config.go`, `cli.go`) and sample-database files
(`sample_databases.go`), but two file-like inputs bypassed it and one
`filesafety` helper had a stat-then-reopen race. This PR closes all three gaps so
size/type limits are enforced consistently across every file-like input, and
tightens `SafeReadFile` to validate the exact descriptor it reads from.

## Gaps addressed

### 1. Credential file read was unbounded and bypassed filesafety

`readCredentialFile` (`internal/mycli/config.go:699-706`) opened the
`--credential` file with `os.Open` and read it with an unbounded `io.ReadAll`,
skipping the size/type checks used for other file inputs. It now routes through
`filesafety.SafeReadFile` with a 4 MiB cap (`FileSafetyOptions.MaxSize`).
Service-account key files are a few KiB, so 4 MiB is a generous ceiling that
still bounds the read and rejects directories/special files with clear errors.

### 2. stdin batch input was unbounded

`determineInputAndMode` (`internal/mycli/config.go:735` and `:757`) read
`--file=-` and non-TTY stdin with unbounded `io.ReadAll`, so a hostile or
accidental stream could exhaust memory. Both sites now use a shared
`readStdinCapped` helper that wraps stdin in `io.LimitReader` at the
`filesafety.DefaultMaxFileSize` limit and returns a clear error naming the limit
when exceeded, instead of silently truncating. Interactive mode is untouched.

### 3. SafeReadFile stat-then-reopen TOCTOU

`filesafety.SafeReadFile` (`internal/mycli/filesafety/file_safety.go:97-122`)
stat-ed the path, validated the resulting `FileInfo`, then re-opened the path
(`os.ReadFile` for regular files) — a time-of-check/time-of-use gap where the
path could be swapped between the stat and the read. It is now restructured to
validate the descriptor it actually reads from, mirroring
`streamio.openOutputFile`'s open-then-fstat pattern:

1. A pre-open `os.Stat` rejects unsafe targets before opening. This is kept
   because opening a FIFO `O_RDONLY` blocks until a writer appears, so we must
   not open one we are only going to reject.
2. After `os.Open`, `f.Stat()` re-validates against the opened descriptor; a
   path swapped after the initial stat (e.g. regular file replaced by a device
   or FIFO) is caught here, and the read comes from exactly the validated
   descriptor.
3. The read is capped via `io.LimitReader(f, max+1)` for BOTH regular and
   allowed non-regular inputs. Stat sizes are meaningless for pipes and can be
   stale for regular files, so the limit is enforced at read time as well.

`ValidateFileSafety` remains exported (used directly by tests) and existing
error-message semantics are preserved.

## Why consistency matters

The CLI treats untrusted file paths uniformly for SQL and sample data by routing
them through `filesafety`. Credentials and stdin were the two remaining
file-like inputs that skipped those guarantees; aligning them removes
inconsistent, unbounded reads from the codebase.

## Tests

- `filesafety`: added open-once read-cap coverage for regular files (at limit
  and over limit); existing FIFO (within/exceeds limit) and directory cases
  continue to cover non-regular and TOCTOU-adjacent behavior.
- `mycli`: added a credential-cap test (oversized file rejected with a
  too-large error) and unit tests for the stdin cap (within/at/over limit) via
  the testable `readStdinCapped` helper.

## Validation

`make check` (test + lint + fmt-check) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRx8J3m4aexPMYDSMNY1Zs
