### PR TITLE
refactor: extract CQL into feature/cql (part of #778)

### DIFF
--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -1191,10 +1191,11 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 			return &ExitStatement{}, nil
 		},
 	},
-	// The optional statement families (GEMINI/CQL) sit at the end of the table.
-	// BIGQUERY was extracted into internal/mycli/feature/bigquery (#778); the
-	// remaining families follow in PR2/PR3. Feature-contributed defs are appended
-	// after this core table in feature/all.All() order (llm, cql, bigquery).
+	// The optional statement family GEMINI/LLM sits at the end of the table.
+	// BIGQUERY (#778) and CQL (#778) were extracted into internal/mycli/feature/
+	// {bigquery,cql}; GEMINI/LLM follows in PR3. Feature-contributed defs are
+	// appended after this core table in feature/all.All() order (llm, cql,
+	// bigquery).
 	// LLM
 	{
 		Descriptions: []clientSideStatementDescription{
@@ -1207,20 +1208,6 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		Pattern: regexp.MustCompile(`(?is)^GEMINI\s+(?P<text>.*)$`),
 		HandleGroups: func(groups map[string]string) (Statement, error) {
 			return &GeminiStatement{Text: unquoteString(groups["text"])}, nil
-		},
-	},
-	// Cassandra interface
-	{
-		Descriptions: []clientSideStatementDescription{
-			{
-				Usage:  `Execute CQL`,
-				Syntax: `CQL ...`,
-				Note:   "EARLY EXPERIMENTAL",
-			},
-		},
-		Pattern: regexp.MustCompile(`(?is)^CQL\s+(?P<cql>.+)$`),
-		HandleGroups: func(groups map[string]string) (Statement, error) {
-			return &CQLStatement{CQL: groups["cql"]}, nil
 		},
 	},
 }

--- a/internal/mycli/cql_readonly_guard_test.go
+++ b/internal/mycli/cql_readonly_guard_test.go
@@ -64,23 +64,39 @@ func TestReadOnlyGuardBlocksMutatingCQL(t *testing.T) {
 }
 
 // TestReadOnlyGuardAllowsReadOnlyCQL verifies, at the dispatch level, that a
-// read-only CQL SELECT is not classified as a static MutationStatement, so the
-// READONLY guard does not statically block it.
+// read-only CQL SELECT is not classified as a static MutationStatement and that
+// the DISPATCH-BUILT statement's conditional classifier reports non-mutating,
+// so the READONLY guard lets it through. Asserting the classification on the
+// statement produced by the real def table (not one built via the constructor)
+// catches a HandleGroups regression that returns a zero-value CQLStatement:
+// with the fail-closed nil-Classify default, that regression would silently
+// block CQL SELECT in READONLY mode (#782 review nit).
 //
 // Unlike the BigQuery counterpart, this does NOT run the SELECT through
 // Session.ExecuteStatement: a passing SELECT proceeds to CQLStatement.Execute,
 // which builds the Cassandra adapter via spancql.NewCluster. That call panics
 // when the adapter client cannot be constructed (no live Spanner backend in
 // tests), so it cannot "fail later for a non-READONLY reason" the way BigQuery's
-// project-not-configured guard does. The complementary proof that a wired SELECT
-// classifier reports non-mutating (so the conditional guard lets it through)
-// lives in feature/cql (TestCQLStatementConditionalMutation), which asserts the
-// classification directly without touching the adapter.
+// project-not-configured guard does.
 func TestReadOnlyGuardAllowsReadOnlyCQL(t *testing.T) {
 	t.Parallel()
 
 	stmt := buildCQL(t, "SELECT * FROM t")
 	if _, isMutation := stmt.(mycli.MutationStatement); isMutation {
 		t.Fatal("CQLStatement must not be a static MutationStatement")
+	}
+	conditional, mutating := mycli.ClassifyForTest(stmt)
+	if !conditional {
+		t.Fatal("dispatch-built CQLStatement must be a ConditionallyMutatingStatement")
+	}
+	if mutating {
+		t.Fatal("dispatch-built CQL SELECT classifies as mutating; READONLY mode would wrongly block it (HandleGroups regression?)")
+	}
+
+	// The mutating counterpart, classified on the dispatch-built statement.
+	del := buildCQL(t, "DELETE FROM t WHERE id = 1")
+	conditional, mutating = mycli.ClassifyForTest(del)
+	if !conditional || !mutating {
+		t.Fatalf("dispatch-built CQL DELETE: conditional=%v mutating=%v, want true/true", conditional, mutating)
 	}
 }

--- a/internal/mycli/cql_readonly_guard_test.go
+++ b/internal/mycli/cql_readonly_guard_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli_test
+
+// Dispatch-level READONLY guard regression for the extracted CQL family (#757,
+// re-homed by #778). These live in the external mycli_test package so they can
+// import feature/cql (which imports mycli) without a cycle, and prove the guard
+// fires through the real dispatch path: build the statement from the merged def
+// table exactly as production does, then execute it against a READONLY session.
+
+import (
+	"testing"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli"
+	"github.com/apstndb/spanner-mycli/internal/mycli/feature/cql"
+)
+
+func buildCQL(t *testing.T, cqlText string) mycli.Statement {
+	t.Helper()
+	defs := mycli.MergedStatementDefs(cql.Feature())
+	stmt, err := mycli.BuildStatementWithDefs(defs, "CQL "+cqlText)
+	if err != nil {
+		t.Fatalf("BuildStatementWithDefs(CQL %s) error = %v", cqlText, err)
+	}
+	return stmt
+}
+
+// TestReadOnlyGuardBlocksMutatingCQL verifies that mutating CQL is rejected by
+// Session.ExecuteStatement in READONLY mode before the statement can reach the
+// Cassandra adapter. These statements short-circuit at the guard before
+// CQLStatement.Execute, so no adapter/proxy is built.
+func TestReadOnlyGuardBlocksMutatingCQL(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		desc string
+		cql  string
+	}{
+		{desc: "DELETE blocked", cql: "DELETE FROM t WHERE id = 1"},
+		{desc: "INSERT blocked", cql: "INSERT INTO t (id) VALUES (1)"},
+		{desc: "unrecognized keyword blocked", cql: "FROBNICATE t"},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			session := mycli.NewReadOnlySessionForTest(t)
+			_, err := session.ExecuteStatement(t.Context(), buildCQL(t, tt.cql))
+			if !mycli.IsReadOnlyError(err) {
+				t.Errorf("%s in READONLY mode: got error %v, want READONLY error", tt.desc, err)
+			}
+		})
+	}
+}
+
+// TestReadOnlyGuardAllowsReadOnlyCQL verifies, at the dispatch level, that a
+// read-only CQL SELECT is not classified as a static MutationStatement, so the
+// READONLY guard does not statically block it.
+//
+// Unlike the BigQuery counterpart, this does NOT run the SELECT through
+// Session.ExecuteStatement: a passing SELECT proceeds to CQLStatement.Execute,
+// which builds the Cassandra adapter via spancql.NewCluster. That call panics
+// when the adapter client cannot be constructed (no live Spanner backend in
+// tests), so it cannot "fail later for a non-READONLY reason" the way BigQuery's
+// project-not-configured guard does. The complementary proof that a wired SELECT
+// classifier reports non-mutating (so the conditional guard lets it through)
+// lives in feature/cql (TestCQLStatementConditionalMutation), which asserts the
+// classification directly without touching the adapter.
+func TestReadOnlyGuardAllowsReadOnlyCQL(t *testing.T) {
+	t.Parallel()
+
+	stmt := buildCQL(t, "SELECT * FROM t")
+	if _, isMutation := stmt.(mycli.MutationStatement); isMutation {
+		t.Fatal("CQLStatement must not be a static MutationStatement")
+	}
+}

--- a/internal/mycli/export_test.go
+++ b/internal/mycli/export_test.go
@@ -58,3 +58,16 @@ func NewSessionWithFeaturesForTest(t *testing.T, features ...Feature) *Session {
 func ListVariablesForTest(s *Session) map[string]string {
 	return s.systemVariables.ListVariables()
 }
+
+// ClassifyForTest reports how the READONLY guard would classify stmt:
+// conditional is true when stmt is a ConditionallyMutatingStatement, and
+// mutating is its runtime classification (false when not conditional). The
+// marker method is unexported, so external dispatch-level tests use this bridge
+// to assert the classification of statements built through the real def table.
+func ClassifyForTest(stmt Statement) (conditional, mutating bool) {
+	cm, ok := stmt.(ConditionallyMutatingStatement)
+	if !ok {
+		return false, false
+	}
+	return true, cm.isConditionallyMutating()
+}

--- a/internal/mycli/feature/all/all.go
+++ b/internal/mycli/feature/all/all.go
@@ -20,6 +20,7 @@ package all
 import (
 	"github.com/apstndb/spanner-mycli/internal/mycli"
 	"github.com/apstndb/spanner-mycli/internal/mycli/feature/bigquery"
+	"github.com/apstndb/spanner-mycli/internal/mycli/feature/cql"
 )
 
 // All returns every optional feature in a fixed, documented order: GEMINI/LLM,
@@ -30,16 +31,17 @@ import (
 // Order-contract note (#778 §7): features append AFTER the core table, so
 // extracting a family moves its statement-help row to the end of the merged
 // table in All() order. The final order is fixed as (llm, cql, bigquery) rather
-// than the pre-extraction core order (llm, bigquery, cql). This makes the single
-// BIGQUERY/CQL row swap in the generated statement help land in PR1 (BIGQUERY
-// extraction) alone; PR2 (CQL) and PR3 (LLM) then re-append at the same relative
-// positions and stay byte-identical.
+// than the pre-extraction core order (llm, bigquery, cql). The single
+// BIGQUERY/CQL row swap in the generated statement help landed in PR1 (BIGQUERY
+// extraction) alone; CQL now re-appends at the same relative position (before
+// BIGQUERY) and stays byte-identical.
 //
-// Only BIGQUERY is extracted so far; LLM and CQL still live in core and will be
-// added here (before BIGQUERY, preserving the llm, cql, bigquery order) as they
-// are extracted under internal/mycli/feature/{llm,cql}.
+// BIGQUERY and CQL are extracted; LLM still lives in core and will be added here
+// (before CQL, preserving the llm, cql, bigquery order) when it is extracted
+// under internal/mycli/feature/llm.
 func All() []mycli.Feature {
 	return []mycli.Feature{
+		cql.Feature(),
 		bigquery.Feature(),
 	}
 }

--- a/internal/mycli/feature/cql/classifier.go
+++ b/internal/mycli/feature/cql/classifier.go
@@ -1,0 +1,50 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cql
+
+import "strings"
+
+// firstCQLKeyword returns the uppercased first whitespace-delimited token of a
+// CQL statement, or "" if there is none.
+func firstCQLKeyword(cql string) string {
+	fields := strings.Fields(cql)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToUpper(fields[0])
+}
+
+// cqlStatementMutates reports whether a CQL statement should be treated as
+// mutating for the purpose of the READONLY guard.
+//
+// It classifies by the statement's first keyword and is deliberately
+// fail-closed: only statements whose first keyword is a known read-only verb
+// are allowed under READONLY. Everything else - data mutations
+// (INSERT/UPDATE/DELETE), batches (BATCH), DDL (CREATE/DROP/ALTER/TRUNCATE),
+// permission changes (GRANT/REVOKE), and any unrecognized or empty keyword - is
+// treated as mutating so the guard blocks it. This avoids silently allowing an
+// unknown CQL verb to bypass READONLY.
+//
+// SELECT is the only clearly read-only data verb in the Spanner Cassandra
+// adapter's supported surface. Other Cassandra read verbs (e.g. LIST, DESCRIBE)
+// are not part of that surface, so they are intentionally not allow-listed.
+func cqlStatementMutates(cql string) bool {
+	switch firstCQLKeyword(cql) {
+	case "SELECT":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/mycli/feature/cql/classifier_test.go
+++ b/internal/mycli/feature/cql/classifier_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cql
+
+import "testing"
+
+// TestCQLStatementMutates exhaustively checks the fail-closed classification of
+// CQL statements: only SELECT is treated as read-only; every other verb
+// (mutations, DDL, permissions) and any unrecognized or empty keyword is
+// treated as mutating. Preserves the #757 coverage moved from the core
+// readonly_guard_test.go (#778).
+func TestCQLStatementMutates(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		cql  string
+		want bool
+	}{
+		{cql: "SELECT * FROM t", want: false},
+		{cql: "select * from t", want: false},
+		{cql: "  SELECT * FROM t", want: false},
+		{cql: "INSERT INTO t (id) VALUES (1)", want: true},
+		{cql: "UPDATE t SET c = 1 WHERE id = 1", want: true},
+		{cql: "DELETE FROM t WHERE id = 1", want: true},
+		{cql: "BEGIN BATCH INSERT INTO t (id) VALUES (1) APPLY BATCH", want: true},
+		{cql: "TRUNCATE t", want: true},
+		{cql: "CREATE TABLE t (id int PRIMARY KEY)", want: true},
+		{cql: "DROP TABLE t", want: true},
+		{cql: "ALTER TABLE t ADD c int", want: true},
+		{cql: "GRANT SELECT ON t TO role", want: true},
+		{cql: "REVOKE SELECT ON t FROM role", want: true},
+		{cql: "BOGUS not a real verb", want: true}, // fail-closed on unknown keyword
+		{cql: "", want: true},                      // fail-closed on empty
+		{cql: "   ", want: true},                   // fail-closed on whitespace-only
+	} {
+		t.Run(tt.cql, func(t *testing.T) {
+			t.Parallel()
+			if got := cqlStatementMutates(tt.cql); got != tt.want {
+				t.Errorf("cqlStatementMutates(%q) = %v, want %v", tt.cql, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mycli/feature/cql/cql.go
+++ b/internal/mycli/feature/cql/cql.go
@@ -1,0 +1,232 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cql contributes the CQL (Cassandra interface) statement family to
+// spanner-mycli through the Feature registration seam (issue #778). It is
+// imported only by the full binary (via internal/mycli/feature/all); the core
+// internal/mycli package does not import it, so github.com/gocql/gocql and
+// github.com/googleapis/go-spanner-cassandra stay off the core import path.
+//
+// The family is EARLY EXPERIMENTAL: it executes CQL through the Cloud Spanner
+// Cassandra adapter (go-spanner-cassandra), which spins up an in-process proxy
+// bound to the session's Spanner database.
+package cql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/gocql/gocql"
+	spancql "github.com/googleapis/go-spanner-cassandra/cassandra/gocql"
+	"github.com/samber/lo"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli"
+)
+
+// sessionStateKey namespaces the lazy CQL (Cassandra adapter) session in the
+// per-Session feature store (mycli.FeatureState).
+const sessionStateKey = "cql.session"
+
+// Feature returns the CQL Feature value. The family contributes a single
+// statement and no variables or flags. Each call constructs fresh def
+// instances, so no state is shared between Feature values (#778 §4.4
+// session-isolation commitment); the statement itself carries only its own CQL
+// text, so there is no package-level mutable state.
+func Feature() mycli.Feature {
+	return mycli.Feature{
+		Name: "CQL",
+		StatementDefs: []*mycli.StatementDef{
+			{
+				Descriptions: []mycli.StatementDescription{
+					{
+						Usage:  `Execute CQL`,
+						Syntax: `CQL ...`,
+						Note:   "EARLY EXPERIMENTAL",
+					},
+				},
+				Pattern: regexp.MustCompile(`(?is)^CQL\s+(?P<cql>.+)$`),
+				HandleGroups: func(groups map[string]string) (mycli.Statement, error) {
+					return newCQLStatement(groups["cql"]), nil
+				},
+			},
+		},
+	}
+}
+
+// CQLStatement executes a single CQL statement through the Cloud Spanner
+// Cassandra adapter. It embeds mycli.MutationClassifier (Classify wired in the
+// constructor to the fail-closed first-keyword classifier over its own CQL text)
+// so the READONLY guard can reject mutating CQL statements.
+//
+// It is deliberately NOT mycli.MarksDetachedCompatible: the Cassandra adapter
+// binds to the session's Spanner database, so CQL cannot run in detached
+// (admin-only, no database) session mode.
+type CQLStatement struct {
+	mycli.MutationClassifier
+	CQL string
+}
+
+// Compile-time assertion that the marker embed promotes the (unexported) core
+// marker method across the package boundary (#778 §4.3). A typo that dropped the
+// embed would silently bypass the READONLY guard.
+var _ mycli.ConditionallyMutatingStatement = (*CQLStatement)(nil)
+
+// newCQLStatement builds a CQLStatement and wires the mutation classifier over
+// its own CQL text.
+func newCQLStatement(cql string) *CQLStatement {
+	s := &CQLStatement{CQL: cql}
+	s.Classify = func() bool { return cqlStatementMutates(s.CQL) }
+	return s
+}
+
+// cqlSessionHolder is the per-Session lazy CQL (Cassandra adapter) session. It
+// is stored in the Session feature store (mycli.FeatureState) and closed at
+// Session.Close via the io.Closer contract.
+//
+// Access is serialized by mu so the check-then-act on the cached session is
+// atomic (.gemini/styleguide.md §Concurrency). Unlike #781's BigQuery client
+// cache the session is built once and never rebuilt: it binds to the Session's
+// DatabasePath, which cannot change on a live Session (USE creates a new
+// Session), so there is no rebuild-on-reconfigure rule (#778 §4.6).
+type cqlSessionHolder struct {
+	mu      sync.Mutex
+	session *gocql.Session
+}
+
+// Close closes the cached gocql session, if any. The cluster is not closed
+// separately (matching the pre-extraction in-core lifecycle, which closed only
+// cqlSession). Satisfies io.Closer so the feature store closes it at the end of
+// Session.Close.
+func (h *cqlSessionHolder) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.session == nil {
+		return nil
+	}
+	h.session.Close()
+	h.session = nil
+	return nil
+}
+
+// get returns the CQL session, building the Cassandra adapter cluster and gocql
+// session lazily on first use. Deferring the build until the first CQL statement
+// keeps the Cassandra adapter (and its in-process proxy) out of ordinary
+// Spanner/emulator session creation. The build parameters mirror the
+// pre-extraction in-core implementation exactly.
+func (h *cqlSessionHolder) get(session *mycli.Session) (*gocql.Session, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.session != nil {
+		return h.session, nil
+	}
+
+	cluster := spancql.NewCluster(&spancql.Options{
+		LogLevel:    zapcore.WarnLevel.String(),
+		DatabaseUri: session.DatabasePath(),
+	})
+	if cluster == nil {
+		return nil, fmt.Errorf("failed to create cluster")
+	}
+
+	// You can still configure your cluster as usual after connecting to your
+	// spanner database
+	cluster.Timeout = 5 * time.Second
+
+	s, err := cluster.CreateSession()
+	if err != nil {
+		return nil, err
+	}
+	h.session = s
+	return s, nil
+}
+
+// Execute runs the CQL statement and returns the result rows as display
+// strings.
+func (cs *CQLStatement) Execute(ctx context.Context, session *mycli.Session) (result *mycli.Result, err error) {
+	holder, err := mycli.FeatureState(ctx, session, sessionStateKey,
+		func(context.Context, *mycli.Session) (*cqlSessionHolder, error) {
+			return &cqlSessionHolder{}, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := holder.get(session)
+	if err != nil {
+		return nil, err
+	}
+
+	q := s.Query(cs.CQL)
+	it := q.WithContext(ctx).Iter()
+	defer func() {
+		closeErr := it.Close()
+		if closeErr == nil {
+			return
+		}
+		if err == nil {
+			err = closeErr
+			return
+		}
+		if errors.Is(err, closeErr) {
+			return
+		}
+		err = errors.Join(err, closeErr)
+	}()
+
+	var headers []string
+	for _, col := range it.Columns() {
+		headers = append(headers, col.Name+"\n"+formatCassandraTypeName(col.TypeInfo))
+	}
+
+	var rows []mycli.Row
+	for {
+		rd, err := it.RowData()
+		if err != nil {
+			return nil, err
+		}
+
+		if !it.Scan(rd.Values...) {
+			break
+		}
+
+		var rowStrs []string
+		for _, value := range rd.Values {
+			rowStrs = append(rowStrs, fmt.Sprint(reflect.Indirect(reflect.ValueOf(value)).Interface()))
+		}
+		rows = append(rows, mycli.NewRow(rowStrs...))
+	}
+
+	result = &mycli.Result{TableHeader: mycli.NewTableHeader(headers...), Rows: rows, AffectedRows: len(rows)}
+	return result, nil
+}
+
+// formatCassandraTypeName renders a Cassandra column type for the result
+// header, expanding collection types (list/set/map) with their element (and
+// key) types.
+func formatCassandraTypeName(typeInfo gocql.TypeInfo) string {
+	if ct, ok := typeInfo.(gocql.CollectionType); ok {
+		return fmt.Sprintf("%v<%v%v>",
+			ct.Type(),
+			lo.Ternary(ct.Key != nil, fmt.Sprint(ct.Key)+", ", ""),
+			ct.Elem)
+	} else {
+		return fmt.Sprint(typeInfo)
+	}
+}

--- a/internal/mycli/feature/cql/cql_test.go
+++ b/internal/mycli/feature/cql/cql_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cql
+
+import (
+	"testing"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli"
+)
+
+// TestFeatureDefDispatch proves the CQL def, when merged into the statement
+// table, dispatches "CQL <text>" to a *CQLStatement carrying the CQL remainder.
+// Moved from the core statement_processing_test.go "CQL statement" case (#778).
+func TestFeatureDefDispatch(t *testing.T) {
+	t.Parallel()
+
+	defs := mycli.MergedStatementDefs(Feature())
+	stmt, err := mycli.BuildStatementWithDefs(defs, "CQL SELECT id, active, username FROM users")
+	if err != nil {
+		t.Fatalf("BuildStatementWithDefs() error = %v", err)
+	}
+	cs, ok := stmt.(*CQLStatement)
+	if !ok {
+		t.Fatalf("dispatch returned %T, want *CQLStatement", stmt)
+	}
+	if cs.CQL != "SELECT id, active, username FROM users" {
+		t.Fatalf("CQL = %q, want %q", cs.CQL, "SELECT id, active, username FROM users")
+	}
+}
+
+// TestCQLStatementConditionalMutation preserves the classification coverage of
+// the core TestReadOnlyGuardAllowsReadOnlyCQL (#757, re-homed by #778): a
+// read-only SELECT is not a static MutationStatement and its wired classifier
+// reports non-mutating, so the READONLY guard lets it through; a mutating
+// statement's classifier reports mutating, so the guard blocks it.
+//
+// This asserts the wired classification directly (via the exported Classify
+// field) rather than through Session.ExecuteStatement, because a passing SELECT
+// proceeds to Execute, which spins up the Cassandra adapter against a live
+// Spanner backend. The dispatch-level guard is proven for the blocked (mutating)
+// path — which short-circuits before Execute — in the external mycli_test
+// package (cql_readonly_guard_test.go).
+func TestCQLStatementConditionalMutation(t *testing.T) {
+	t.Parallel()
+
+	readOnly := newCQLStatement("SELECT * FROM t")
+	if _, isMutation := any(readOnly).(mycli.MutationStatement); isMutation {
+		t.Fatal("CQLStatement must not be a static MutationStatement")
+	}
+	if readOnly.Classify() {
+		t.Error("read-only SELECT CQL classified as mutating; READONLY guard would wrongly block it")
+	}
+
+	mutating := newCQLStatement("DELETE FROM t WHERE id = 1")
+	if !mutating.Classify() {
+		t.Error("mutating DELETE CQL classified as read-only; READONLY guard would wrongly allow it")
+	}
+}

--- a/internal/mycli/readonly_guard_test.go
+++ b/internal/mycli/readonly_guard_test.go
@@ -71,90 +71,13 @@ func TestReadOnlyGuardPreservesActiveBatch(t *testing.T) {
 	}
 }
 
-// TestCQLStatementMutates exhaustively checks the fail-closed classification of
-// CQL statements: only SELECT is treated as read-only; every other verb
-// (mutations, DDL, permissions) and any unrecognized or empty keyword is
-// treated as mutating.
-func TestCQLStatementMutates(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		cql  string
-		want bool
-	}{
-		{cql: "SELECT * FROM t", want: false},
-		{cql: "select * from t", want: false},
-		{cql: "  SELECT * FROM t", want: false},
-		{cql: "INSERT INTO t (id) VALUES (1)", want: true},
-		{cql: "UPDATE t SET c = 1 WHERE id = 1", want: true},
-		{cql: "DELETE FROM t WHERE id = 1", want: true},
-		{cql: "BEGIN BATCH INSERT INTO t (id) VALUES (1) APPLY BATCH", want: true},
-		{cql: "TRUNCATE t", want: true},
-		{cql: "CREATE TABLE t (id int PRIMARY KEY)", want: true},
-		{cql: "DROP TABLE t", want: true},
-		{cql: "ALTER TABLE t ADD c int", want: true},
-		{cql: "GRANT SELECT ON t TO role", want: true},
-		{cql: "REVOKE SELECT ON t FROM role", want: true},
-		{cql: "BOGUS not a real verb", want: true}, // fail-closed on unknown keyword
-		{cql: "", want: true},                      // fail-closed on empty
-		{cql: "   ", want: true},                   // fail-closed on whitespace-only
-	} {
-		t.Run(tt.cql, func(t *testing.T) {
-			t.Parallel()
-			if got := cqlStatementMutates(tt.cql); got != tt.want {
-				t.Errorf("cqlStatementMutates(%q) = %v, want %v", tt.cql, got, tt.want)
-			}
-		})
-	}
-}
-
-// TestReadOnlyGuardBlocksMutatingCQL verifies that mutating CQL is rejected by
-// Session.ExecuteStatement in READONLY mode. These statements short-circuit at
-// the guard before CQLStatement.Execute, so no Cassandra adapter is needed.
-//
-// The complementary case (read-only SELECT is NOT blocked) is covered by
-// TestReadOnlyGuardAllowsReadOnlyCQL and TestCQLStatementMutates; it is not
-// exercised through ExecuteStatement here because a passing SELECT proceeds to
-// Execute, which would attempt a real Cassandra/Spanner connection.
-func TestReadOnlyGuardBlocksMutatingCQL(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		desc string
-		cql  string
-	}{
-		{desc: "DELETE blocked", cql: "DELETE FROM t WHERE id = 1"},
-		{desc: "INSERT blocked", cql: "INSERT INTO t (id) VALUES (1)"},
-		{desc: "unrecognized keyword blocked", cql: "FROBNICATE t"},
-	} {
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-			session := newSessionForLocalVarTest(t)
-			session.systemVariables.Transaction.ReadOnly = true
-
-			_, err := session.ExecuteStatement(t.Context(), &CQLStatement{CQL: tt.cql})
-			if !errors.Is(err, errReadOnly) {
-				t.Errorf("%s in READONLY mode: got error %v, want errReadOnly", tt.desc, err)
-			}
-		})
-	}
-}
-
-// TestReadOnlyGuardAllowsReadOnlyCQL verifies that a read-only CQL statement is
-// not classified as mutating, so the READONLY guard lets it through. The guard
-// input is isConditionallyMutating; asserting it directly avoids running
-// CQLStatement.Execute, which would need a live Cassandra adapter.
-func TestReadOnlyGuardAllowsReadOnlyCQL(t *testing.T) {
-	t.Parallel()
-
-	stmt := &CQLStatement{CQL: "SELECT * FROM t"}
-	if _, isMutation := any(stmt).(MutationStatement); isMutation {
-		t.Fatal("CQLStatement must not be a static MutationStatement")
-	}
-	if stmt.isConditionallyMutating() {
-		t.Error("read-only SELECT CQL classified as mutating; READONLY guard would wrongly block it")
-	}
-}
+// CQL READONLY guard coverage moved with the family to
+// internal/mycli/feature/cql (#778): the fail-closed classifier is unit tested
+// there (TestCQLStatementMutates), the wired read-only/mutating classification
+// is asserted directly in TestCQLStatementConditionalMutation, and the
+// dispatch-level guard for mutating CQL is proven through real dispatch in the
+// external mycli_test package (cql_readonly_guard_test.go), which can import the
+// feature package without an import cycle.
 
 // BIGQUERY READONLY guard coverage moved with the family to
 // internal/mycli/feature/bigquery (#778): the fail-closed classifier is unit

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -34,7 +34,6 @@ import (
 	"github.com/apstndb/adcplus"
 	"github.com/apstndb/adcplus/tokensource"
 	"github.com/apstndb/go-grpcinterceptors/selectlogging"
-	"github.com/gocql/gocql"
 	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -126,10 +125,6 @@ type Session struct {
 	// through the Feature seam (issue #778). Values implementing io.Closer are
 	// closed at the end of Close in reverse creation order.
 	featureState featureStore
-
-	// experimental support of Cassandra interface
-	cqlCluster *gocql.ClusterConfig
-	cqlSession *gocql.Session
 
 	// output is the per-statement output destination for streamed results,
 	// set for the duration of one statement execution via withOutput /
@@ -577,10 +572,6 @@ func (s *Session) Close() {
 		if err != nil {
 			slog.Error("error on adminClient.Close()", "err", err)
 		}
-	}
-
-	if s.cqlSession != nil {
-		s.cqlSession.Close()
 	}
 
 	s.docCacheMu.Lock()

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -83,14 +83,13 @@ var (
 	_ MutationStatement = (*AddSplitPointsStatement)(nil)
 )
 
-// Compile-time assertions for every ConditionallyMutatingStatement
-// implementation. As with the marker above, the method is unexported so a typo
-// silently drops the type out of the interface and bypasses the READONLY guard.
-// BigQueryStatement's assertion moved to internal/mycli/feature/bigquery when
-// the family was extracted (#778); it embeds mycli.MutationClassifier there.
-var (
-	_ ConditionallyMutatingStatement = (*CQLStatement)(nil)
-)
+// No core statement implements ConditionallyMutatingStatement any more: both
+// implementations were extracted into feature packages, where each carries its
+// own compile-time assertion. BigQueryStatement moved to
+// internal/mycli/feature/bigquery and CQLStatement to internal/mycli/feature/cql
+// (#778); both embed mycli.MutationClassifier there. The unexported marker
+// method means a feature that drops the embed silently bypasses the READONLY
+// guard, so the assertion travels with the type.
 
 // DetachedCompatible is a marker interface for statements that can run in Detached session mode (admin operation only mode).
 // Statements implementing this interface can execute when session.IsDetached() is true.

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -1098,11 +1098,6 @@ TABLE Singers (42)
 			},
 		},
 		{
-			desc:  "CQL statement",
-			input: `CQL SELECT id, active, username FROM users`,
-			want:  &CQLStatement{CQL: "SELECT id, active, username FROM users"},
-		},
-		{
 			desc:  "HELP statement",
 			input: `HELP`,
 			want:  &HelpStatement{},

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -38,12 +37,9 @@ import (
 	"github.com/apstndb/spanvalue/gcvctor"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"github.com/cloudspannerecosystem/memefish/token"
-	"github.com/gocql/gocql"
-	spancql "github.com/googleapis/go-spanner-cassandra/cassandra/gocql"
 	"github.com/samber/lo"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
-	"go.uber.org/zap/zapcore"
 )
 
 var transactionRe = regexp.MustCompile(`(?is)^(?:(READ\s+ONLY)|(READ\s+WRITE))$`)
@@ -662,131 +658,7 @@ func runBatch(ctx context.Context, session *Session) (*Result, error) {
 
 // BigQuery related statements live in internal/mycli/feature/bigquery (#778).
 
-// Cassandra interface
-type CQLStatement struct {
-	CQL string
-}
-
-// firstCQLKeyword returns the uppercased first whitespace-delimited token of a
-// CQL statement, or "" if there is none.
-func firstCQLKeyword(cql string) string {
-	fields := strings.Fields(cql)
-	if len(fields) == 0 {
-		return ""
-	}
-	return strings.ToUpper(fields[0])
-}
-
-// cqlStatementMutates reports whether a CQL statement should be treated as
-// mutating for the purpose of the READONLY guard.
-//
-// It classifies by the statement's first keyword and is deliberately
-// fail-closed: only statements whose first keyword is a known read-only verb
-// are allowed under READONLY. Everything else - data mutations
-// (INSERT/UPDATE/DELETE), batches (BATCH), DDL (CREATE/DROP/ALTER/TRUNCATE),
-// permission changes (GRANT/REVOKE), and any unrecognized or empty keyword - is
-// treated as mutating so the guard blocks it. This avoids silently allowing an
-// unknown CQL verb to bypass READONLY.
-//
-// SELECT is the only clearly read-only data verb in the Spanner Cassandra
-// adapter's supported surface. Other Cassandra read verbs (e.g. LIST, DESCRIBE)
-// are not part of that surface, so they are intentionally not allow-listed.
-func cqlStatementMutates(cql string) bool {
-	switch firstCQLKeyword(cql) {
-	case "SELECT":
-		return false
-	default:
-		return true
-	}
-}
-
-func (cs *CQLStatement) isConditionallyMutating() bool {
-	return cqlStatementMutates(cs.CQL)
-}
-
-func (cs *CQLStatement) Execute(ctx context.Context, session *Session) (result *Result, err error) {
-	// lazy initialize gocql.ClusterConfig
-	if session.cqlCluster == nil {
-		cluster := spancql.NewCluster(&spancql.Options{
-			LogLevel:    zapcore.WarnLevel.String(),
-			DatabaseUri: session.DatabasePath(),
-		})
-		if cluster == nil {
-			return nil, fmt.Errorf("failed to create cluster")
-		}
-
-		session.cqlCluster = cluster
-
-		// You can still configure your cluster as usual after connecting to your
-		// spanner database
-		cluster.Timeout = 5 * time.Second
-	}
-	// lazy initialize gocql.Session
-	if session.cqlSession == nil {
-		s, err := session.cqlCluster.CreateSession()
-		if err != nil {
-			return nil, err
-		}
-		session.cqlSession = s
-	}
-
-	s := session.cqlSession
-
-	q := s.Query(cs.CQL)
-	it := q.WithContext(ctx).Iter()
-	defer func() {
-		closeErr := it.Close()
-		if closeErr == nil {
-			return
-		}
-		if err == nil {
-			err = closeErr
-			return
-		}
-		if errors.Is(err, closeErr) {
-			return
-		}
-		err = errors.Join(err, closeErr)
-	}()
-
-	var headers []string
-	for _, col := range it.Columns() {
-		headers = append(headers, col.Name+"\n"+formatCassandraTypeName(col.TypeInfo))
-	}
-
-	var rows []Row
-	for {
-		rd, err := it.RowData()
-		if err != nil {
-			return nil, err
-		}
-
-		if !it.Scan(rd.Values...) {
-			break
-		}
-
-		var rowStrs []string
-		for _, value := range rd.Values {
-			rowStrs = append(rowStrs, fmt.Sprint(reflect.Indirect(reflect.ValueOf(value)).Interface()))
-		}
-		row := toRow(rowStrs...)
-		rows = append(rows, row)
-	}
-
-	result = &Result{TableHeader: toTableHeader(headers), Rows: rows, AffectedRows: len(rows)}
-	return result, nil
-}
-
-func formatCassandraTypeName(typeInfo gocql.TypeInfo) string {
-	if ct, ok := typeInfo.(gocql.CollectionType); ok {
-		return fmt.Sprintf("%v<%v%v>",
-			ct.Type(),
-			lo.Ternary(ct.Key != nil, fmt.Sprint(ct.Key)+", ", ""),
-			ct.Elem)
-	} else {
-		return fmt.Sprint(typeInfo)
-	}
-}
+// CQL statements live in internal/mycli/feature/cql (#778).
 
 // CLI control
 


### PR DESCRIPTION
## Summary

PR2 of #778: extract the CQL (Cassandra interface) statement family out of the core `internal/mycli` package into `internal/mycli/feature/cql`, behind the Feature registration seam. After this change core no longer imports `github.com/gocql/gocql` or `github.com/googleapis/go-spanner-cassandra`. Follows the BIGQUERY extraction pattern (#781).

## Scope

- **New package `internal/mycli/feature/cql`**: moves `CQLStatement`, the fail-closed `firstCQLKeyword`/`cqlStatementMutates` classifier, `formatCassandraTypeName`, and `Execute`. The `zapcore.WarnLevel.String()` usage moves with it (zap stays a core dep for gRPC-interceptor logging; only the gocql/spancql import lines leave core).
- **Marker wiring**: `CQLStatement` embeds `mycli.MutationClassifier` with `Classify` wired in `newCQLStatement` to `cqlStatementMutates` over its own CQL text (mirrors `newBigQueryStatement`), carries its own `var _ mycli.ConditionallyMutatingStatement = (*CQLStatement)(nil)` assertion, and the core assertion is removed. It is deliberately **not** `MarksDetachedCompatible` (the Cassandra adapter binds to the Spanner database, so CQL can't run in detached mode).
- **`Feature()`**: contributes the "CQL" def only (EARLY EXPERIMENTAL note preserved), no vars, no flags, fresh instances per call, no package-level mutable state.
- **Session surgery**: removed `cqlCluster`/`cqlSession` fields and the `cqlSession` Close block. The lazy CQL session is reimplemented on `mycli.FeatureState` (key `cql.session`) as a mutex-guarded, build-once `io.Closer` holder that closes the gocql session (the cluster is not separately closed, same as today), preserving today's `spancql.NewCluster` build (`DatabaseUri: session.DatabasePath()`, `Timeout = 5s`) and error messages exactly. No rebuild-on-key-change rule (DatabasePath can't change on a live Session).
- **Registration**: `feature/all.All()` returns `{cql.Feature(), bigquery.Feature()}`; merged order stays LLM, CQL, BIGQUERY (LLM still in core at the end of the core table).
- **Tests**: classifier (`TestCQLStatementMutates`) and dispatch/classification tests move into `feature/cql`; the dispatch-level READONLY guard for mutating CQL moves into an external `package mycli_test` file (`cql_readonly_guard_test.go`).

## Byte-identity proof

`make docs-update` then `git diff --exit-code README.md docs/system_variables.md` -> exit 0 (byte-identical). The CQL statement-help row keeps its position because the merged order (llm, cql, bigquery) matches the pre-extraction ordering already established by #780/#781.

## Dependency check

```
$ go list -deps ./internal/mycli | grep -E 'gocql|go-spanner-cassandra'
(no output)
```

Root main still pulls them via `feature/all` (correct):

```
$ go list -deps . | grep -E 'gocql|go-spanner-cassandra'
github.com/gocql/gocql/internal/lru
github.com/gocql/gocql/internal/murmur
github.com/gocql/gocql/internal/streams
github.com/gocql/gocql
github.com/googleapis/go-spanner-cassandra/logger
github.com/googleapis/go-spanner-cassandra/adapter
github.com/googleapis/go-spanner-cassandra/cassandra/gocql
```

## Validation

- `make check` — pass (0 lint issues, formatting correct)
- `make check-race` — pass
- `go vet ./...` — clean
- docs byte-identity — no diff

## Deviation from the task spec (allowed-SELECT guard test)

The task asked the external guard test to mirror `bigquery_readonly_guard_test.go` "exactly", including running an allowed `CQL SELECT` through `Session.ExecuteStatement` and expecting it to "fail later for a non-READONLY reason". That is **not** safe for CQL and is intentionally not done:

- BigQuery's `Execute` has a pre-network guard (`effectiveProject` returns `""` -> immediate "project not configured" error), so the allowed SELECT fails fast with no I/O.
- CQL's `Execute` has no such guard; a passing SELECT reaches `spancql.NewCluster`, which **panics** (`NewCluster` panics when `NewTCPProxy`/`newAdapterClient` fails) whenever the Cassandra adapter client cannot be built — i.e. always in unit tests, with or without ADC. Running it through `Execute` would crash the test binary, not return an error. This is the same reason the original in-core `TestReadOnlyGuardAllowsReadOnlyCQL` asserted classification directly instead of calling `Execute`.

Coverage is preserved without weakening the #757 guarantees:
- `cql_readonly_guard_test.go` runs the **blocked** mutating cases through real dispatch + `ExecuteStatement` (short-circuit at the guard, no adapter built) and asserts the READONLY sentinel; the allowed SELECT is asserted at dispatch level to be a non-static `MutationStatement`.
- `feature/cql/cql_test.go` (`TestCQLStatementConditionalMutation`) asserts the wired classifier directly (read-only SELECT -> non-mutating, DELETE -> mutating) via the exported `Classify` field.
- `feature/cql/classifier_test.go` (`TestCQLStatementMutates`) keeps the exhaustive fail-closed keyword coverage.

Part of #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V28qKRVwUCkpT5pepTksgr
