### PR TITLE
chore: adopt released protoyaml for SHOW PLAN NODE canonical output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/apstndb/go-tabwrap v0.1.4
 	github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0
 	github.com/apstndb/memebridge v0.6.4
+	github.com/apstndb/protoyaml v0.1.0
 	github.com/apstndb/spancodec v0.1.2
 	github.com/apstndb/spanemuboost v0.4.6
 	github.com/apstndb/spaniter v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0 h1:VySrhGRfqXUDC
 github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0/go.mod h1:VwhJDip+HamDWWt+Ol4ECFU0g0HiveA27DeNkt3U8S0=
 github.com/apstndb/memebridge v0.6.4 h1:OoOXj+m5YtosbAPz0pLNVUwhhCohf1mC2o+Dy9WMsjQ=
 github.com/apstndb/memebridge v0.6.4/go.mod h1:gw6dfrUAsT+GvmuRGiG/fnGbrKfiVvnjBriQt6nLnys=
+github.com/apstndb/protoyaml v0.1.0 h1:xbps9Yly1rciJhLOFdA+KLIdEpEcIaTCboFB3QtUMKI=
+github.com/apstndb/protoyaml v0.1.0/go.mod h1:bsZCSj3nYZKfLiKRogOxuUjlURUOJpBb+G5f1b3g5Fc=
 github.com/apstndb/ptyhelp v0.2.3 h1:aLFKm19WlM+/hts6EsFLzbGStNiv8yKHcIAyUJ18vMk=
 github.com/apstndb/ptyhelp v0.2.3/go.mod h1:2+LTM9QNEEBkwMRMPjLvCwKD9vPejJ7lAzY1cB7r+Ag=
 github.com/apstndb/spancodec v0.1.2 h1:QPRHmn989WV4lyzvYW7hSyzSYu5106hWDiEA1qMVdc0=

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -25,19 +25,16 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/protoyaml"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
 	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/plantree"
 	planref "github.com/apstndb/spannerplan/plantree/reference"
-	"github.com/apstndb/spannerplan/protoyaml"
 	spstats "github.com/apstndb/spannerplan/stats"
-	"github.com/goccy/go-yaml"
 	"github.com/olekukonko/tablewriter/tw"
 	"github.com/samber/lo"
 	loi "github.com/samber/lo/it"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type ExplainStatement struct {
@@ -137,7 +134,7 @@ func (s *ShowPlanNodeStatement) Execute(ctx context.Context, session *Session) (
 	}
 
 	planNode := planNodes[s.NodeID]
-	y, err := protoyaml.Marshal(planNode, getGlobalOpts()...)
+	y, err := protoyaml.Marshal(planNode, protoyaml.WithFlowLeafCollections())
 	if err != nil {
 		return nil, err
 	}
@@ -192,52 +189,6 @@ func formatShowPlanNodeIncomingLinks(links []spannerplan.ResolvedParentLink) str
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-func hasCompound(fields map[string]*structpb.Value) bool {
-	for _, v := range fields {
-		switch v.GetKind().(type) {
-		case *structpb.Value_ListValue, *structpb.Value_StructValue:
-			return true
-		}
-	}
-	return false
-}
-
-func getStructOpts() []yaml.EncodeOption {
-	return []yaml.EncodeOption{
-		yaml.CustomMarshaler[*structpb.Value](func(value *structpb.Value) ([]byte, error) {
-			switch kind := value.GetKind().(type) {
-			case *structpb.Value_ListValue:
-				return yaml.MarshalWithOptions(kind.ListValue.GetValues(), getStructOpts()...)
-			case *structpb.Value_StructValue:
-				return yaml.MarshalWithOptions(kind.StructValue, getStructOpts()...)
-			case *structpb.Value_StringValue:
-				// Use yaml.Marshal() to follow YAML quotation rule
-				return yaml.Marshal(kind.StringValue)
-			default:
-				return protojson.Marshal(value)
-			}
-		}),
-		yaml.CustomMarshaler[*structpb.Struct](func(value *structpb.Struct) ([]byte, error) {
-			opts := getStructOpts()
-			if !hasCompound(value.GetFields()) {
-				opts = append(opts, yaml.Flow(true))
-			}
-			return yaml.MarshalWithOptions(value.GetFields(), opts...)
-		}),
-	}
-}
-
-func getGlobalOpts() []yaml.EncodeOption {
-	return slices.Concat(
-		[]yaml.EncodeOption{
-			yaml.CustomMarshaler[*sppb.PlanNode_ChildLink](func(link *sppb.PlanNode_ChildLink) ([]byte, error) {
-				return yaml.MarshalWithOptions(link, yaml.UseJSONMarshaler(), yaml.Flow(true))
-			}),
-		},
-		getStructOpts(),
-	)
 }
 
 type DescribeStatement struct {

--- a/internal/mycli/statements_explain_describe_test.go
+++ b/internal/mycli/statements_explain_describe_test.go
@@ -898,12 +898,12 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 				QueryStats: selectProfileResultSet.GetStats().GetQueryStats().AsMap(),
 			},
 			"index: 1\n" +
-				"kind: 1\n" +
-				"display_name: Unit Relation\n" +
-				"child_links:\n" +
-				"- {child_index: 2}\n" +
+				"kind: RELATIONAL\n" +
+				"displayName: Unit Relation\n" +
+				"childLinks:\n" +
+				"- {childIndex: 2}\n" +
 				"metadata: {execution_method: Row}\n" +
-				"execution_stats:\n" +
+				"executionStats:\n" +
 				"  cpu_time: {total: \"0\", unit: msecs}\n" +
 				"  execution_summary: {num_executions: \"1\"}\n" +
 				"  latency: {total: \"0\", unit: msecs}\n" +
@@ -938,7 +938,7 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 					},
 				},
 			},
-			"index: 1\nkind: 1\ndisplay_name: Child\n",
+			"index: 1\nkind: RELATIONAL\ndisplayName: Child\n",
 			"Incoming Parent Links:\n  - Parent Node Index: 0\n    Parent Node Title: Root\n    Child Link Type: Map\n    Variable: v",
 			false,
 			false,
@@ -962,7 +962,7 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 					},
 				},
 			},
-			"kind: 1\ndisplay_name: Root\n",
+			"kind: RELATIONAL\ndisplayName: Root\n",
 			"Incoming Parent Links:\n  - No incoming parent links",
 			false,
 			false,
@@ -995,7 +995,7 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 					},
 				},
 			},
-			"kind: 1\ndisplay_name: Root\nchild_links:\n- {child_index: 99}\n",
+			"kind: RELATIONAL\ndisplayName: Root\nchildLinks:\n- {childIndex: 99}\n",
 			// Assert only spanner-mycli's own "parent links unavailable: "
 			// prefix, not spannerplan's internal validation-error text. The
 			// message wording is explicitly not part of spannerplan's stable


### PR DESCRIPTION
## Summary

Migrates `SHOW PLAN NODE` from the in-tree `spannerplan/protoyaml` marshalers to the released standalone module `github.com/apstndb/protoyaml` v0.1.0 (canonical protojson-over-YAML).

`github.com/apstndb/spannerplan` stays as a dependency; only the `protoyaml` subpackage import moves to the standalone module.

## What changes for users

`SHOW PLAN NODE` output switches dialect from an **accidental proto-reflection format** (snake_case proto field names, numeric enums) to **canonical protojson-over-YAML** (camelCase, named enums) — matching the field names used in `gcloud` output and the official query plan visualizer JSON.

The **layout is identical**: all-scalar sub-maps still render as compact flow (`{...}`) via `protoyaml.WithFlowLeafCollections()`. Root-level scalar-only nodes stay as block documents (e.g. `index: 1\nkind: RELATIONAL\ndisplayName: Child\n`), not inline flow.

`structpb` data keys (the contents of `execution_stats`, `metadata`, etc.) are **unchanged** — those come from the plan payload, not proto field names.

### Before / after

Before (proto-reflection dialect):

```yaml
index: 1
kind: 1
display_name: Unit Relation
child_links:
- {child_index: 2}
metadata: {execution_method: Row}
execution_stats:
  cpu_time: {total: "0", unit: msecs}
```

After (canonical protojson-over-YAML):

```yaml
index: 1
kind: RELATIONAL
displayName: Unit Relation
childLinks:
- {childIndex: 2}
metadata: {execution_method: Row}
executionStats:
  cpu_time: {total: "0", unit: msecs}
```

Note how the proto field names change (`display_name` -> `displayName`, `kind: 1` -> `kind: RELATIONAL`) while the structpb-sourced `metadata` / `execution_stats` data keys stay as-is.

## Implementation

- `go get github.com/apstndb/protoyaml@v0.1.0 && go mod tidy`.
- Swap the import `github.com/apstndb/spannerplan/protoyaml` -> `github.com/apstndb/protoyaml`.
- Replace the custom option builder call with `protoyaml.Marshal(planNode, protoyaml.WithFlowLeafCollections())`.
- Delete ~50 lines of custom `goccy/go-yaml` marshalers (`getGlobalOpts`, `getStructOpts`, `hasCompound`) and now-unused imports.
- Update `TestShowPlanNodeStatement_Execute` golden strings to the canonical output.

Net: 13 insertions, 59 deletions.

## Validation

- `go build ./...`, `go vet ./...` clean.
- `make check` green (test + lint + fmt-check; `golangci-lint` 0 issues, formatting correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g
