### PR TITLE
docs: update SHOW PLAN NODE example to canonical protojson YAML

### DIFF
--- a/docs/query_plan.md
+++ b/docs/query_plan.md
@@ -217,17 +217,17 @@ spanner> SHOW PLAN NODE 18;
 | Content of Node 18                                                                              |
 +-------------------------------------------------------------------------------------------------+
 | index: 18                                                                                       |
-| kind: 1                                                                                         |
-| display_name: Scan                                                                              |
-| child_links:                                                                                    |
-| - {child_index: 19, variable: SingerId}                                                         |
-| - {child_index: 20, variable: FirstName}                                                        |
-| - {child_index: 21, variable: LastName}                                                         |
-| - {child_index: 22, variable: SingerInfo}                                                       |
-| - {child_index: 23, variable: BirthDate}                                                        |
-| - {child_index: 27, type: Seek Condition}                                                       |
+| kind: RELATIONAL                                                                                |
+| displayName: Scan                                                                               |
+| childLinks:                                                                                     |
+| - {childIndex: 19, variable: SingerId}                                                          |
+| - {childIndex: 20, variable: FirstName}                                                         |
+| - {childIndex: 21, variable: LastName}                                                          |
+| - {childIndex: 22, variable: SingerInfo}                                                        |
+| - {childIndex: 23, variable: BirthDate}                                                         |
+| - {childIndex: 27, type: Seek Condition}                                                        |
 | metadata: {execution_method: Row, scan_method: Row, scan_target: Singers, scan_type: TableScan} |
-| execution_stats:                                                                                |
+| executionStats:                                                                                 |
 |   cpu_time: {mean: "0.04", std_deviation: "0.03", total: "0.08", unit: msecs}                   |
 |   deleted_rows: {mean: "0", std_deviation: "0", total: "0", unit: rows}                         |
 |   execution_summary: {num_executions: "2"}                                                      |


### PR DESCRIPTION
## Summary

Follow-up to #784, which changed `SHOW PLAN NODE` output from the accidental reflection YAML dialect (snake_case proto field names like `display_name`/`child_links`, numeric enums like `kind: 1`) to canonical protojson-over-YAML (camelCase `displayName`/`childLinks`, named enums `kind: RELATIONAL`) with compact flow rendering for all-scalar sub-maps.

The `SHOW PLAN NODE 18` example in `docs/query_plan.md` still depicted the old dialect. This updates it to match the new golden output in `internal/mycli/statements_explain_describe_test.go` (`TestShowPlanNodeStatement_Execute`).

## Transformation applied

- `kind: 1` -> `kind: RELATIONAL`
- `display_name:` -> `displayName:`
- `child_links:` -> `childLinks:` (stays a block container)
- `child_index:` -> `childIndex:` inside each childLinks flow item
- `execution_stats:` -> `executionStats:` (stays a block container)

Keys **inside** `metadata` and each `executionStats` child (`execution_method`, `cpu_time`, `scan_method`, ...) are plan data and remain unchanged. The `scanned_rows`/`histogram` nesting and the document root stay block style.

The unchanged `metadata: {...}` line is the widest content, so the CLI table frame stays 99 columns wide; only the shrunk lines were re-padded to keep the box aligned.

## Scope

Repo-wide grep for stale dialect (`display_name:`, `child_links:`, `child_index:`, `kind: <n>`, `execution_stats:`) across all `*.md` found no other `SHOW PLAN NODE`-style YAML dumps. Other snake_case matches (e.g. `(scan_method: Row)`) are rendertree operator inline metadata, a different rendering, and were intentionally left untouched.

## Validation

Docs-only change. `make docs-update` regenerates only `README.md` and `docs/system_variables.md` (not `query_plan.md`), and there is no markdownlint gate, so CI docs checks are unaffected. `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g
