### PR TITLE
build: bump Go to 1.25.12 for the crypto/tls stdlib fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apstndb/spanner-mycli
 
-go 1.25.11
+go 1.25.12
 
 require (
 	cloud.google.com/go v0.123.0


### PR DESCRIPTION
govulncheck fails on every branch since GO-2026-5856 (crypto/tls, found in go1.25.11, fixed in go1.25.12) entered the vulnerability database — first observed on #783's re-run, where all other checks stay green. CI resolves the toolchain from go.mod (`go-version-file`), so bumping the `go` directive is the complete fix; no code changes.

Unblocks #783 and every subsequent PR's govulncheck job.

Validation: `make check` pass locally; the decisive proof is this PR's own govulncheck job running with 1.25.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V28qKRVwUCkpT5pepTksgr
