### PR TITLE
fix: narrow memefish panic recovery

### DIFF
--- a/internal/mycli/memefish_parser.go
+++ b/internal/mycli/memefish_parser.go
@@ -21,21 +21,23 @@ import (
 	"github.com/cloudspannerecosystem/memefish/ast"
 )
 
-// recoverMemefishParserPanic converts upstream parser panics to returned errors.
-// In memefish v0.7.0, and still in v0.8.0, unclosed string literals and
-// backtick identifiers can reach the lexer's panicfAtPosition path through
-// ParseExpr or ParseType instead of returning an error. Remove this wrapper
-// once a released memefish version converts these cases to returned errors.
+// recoverMemefishParserPanic converts upstream malformed-input panics to
+// returned errors. In memefish v0.7.0, and still in v0.8.0, the initial token
+// read in ParseExpr and ParseType bypasses Lexer.NextToken, so unclosed string
+// literals and backtick identifiers can escape as *memefish.Error panics.
+// Mirror Lexer.NextToken's boundary by re-panicking every other value. Remove
+// this wrapper once a released memefish version returns these errors directly.
 func recoverMemefishParserPanic[T any](parse func() (T, error)) (result T, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			recoveredErr, ok := recovered.(*memefish.Error)
+			if !ok {
+				panic(recovered)
+			}
+
 			var zero T
 			result = zero
-			if recoveredErr, ok := recovered.(error); ok {
-				err = fmt.Errorf("memefish parser panic: %w", recoveredErr)
-			} else {
-				err = fmt.Errorf("memefish parser panic: %v", recovered)
-			}
+			err = fmt.Errorf("memefish parser panic: %w", recoveredErr)
 		}
 	}()
 

--- a/internal/mycli/memefish_parser_test.go
+++ b/internal/mycli/memefish_parser_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cloudspannerecosystem/memefish"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverMemefishParserPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("known malformed input becomes an error", func(t *testing.T) {
+		t.Parallel()
+
+		const input = "'unclosed"
+		rawPanic := capturePanicValue(func() {
+			_, _ = memefish.ParseExpr("", input)
+		})
+		_, ok := rawPanic.(*memefish.Error)
+		require.True(t, ok, "raw memefish.ParseExpr panic = %T, want *memefish.Error", rawPanic)
+
+		_, err := parseMemefishExpr("", input)
+		require.Error(t, err)
+		var parseErr *memefish.Error
+		require.ErrorAs(t, err, &parseErr)
+	})
+
+	t.Run("string panic escapes", func(t *testing.T) {
+		t.Parallel()
+
+		const want = "programmer bug"
+		got := capturePanicValue(func() {
+			_, _ = recoverMemefishParserPanic(func() (int, error) {
+				panic(want)
+			})
+		})
+		require.Equal(t, want, got)
+	})
+
+	t.Run("runtime panic escapes", func(t *testing.T) {
+		t.Parallel()
+
+		got := capturePanicValue(func() {
+			_, _ = recoverMemefishParserPanic(func() (int, error) {
+				var values []int
+				return values[0], nil
+			})
+		})
+		_, ok := got.(runtime.Error)
+		require.True(t, ok, "panic = %T, want runtime.Error", got)
+	})
+}
+
+func capturePanicValue(f func()) (recovered any) {
+	defer func() {
+		recovered = recover()
+	}()
+	f()
+	return nil
+}

--- a/internal/mycli/var_registry.go
+++ b/internal/mycli/var_registry.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/ast"
 )
 
@@ -288,24 +287,11 @@ func (r *VarRegistry) ListVariableInfo() map[string]struct {
 }
 
 // parseGoogleSQLValue parses GoogleSQL-style values using memefish
-func parseGoogleSQLValue(value string) (result string) {
+func parseGoogleSQLValue(value string) string {
 	value = strings.TrimSpace(value)
 
-	// Protect against panics from memefish.
-	// While memefish.ParseExpr normally returns errors, it panics in some cases:
-	// - Unclosed string literals (e.g., 'hello or "world)
-	// - Unclosed triple-quoted strings (e.g., ''')
-	// Without this recovery, entering an unclosed string in SET statements
-	// would crash spanner-mycli entirely.
-	defer func() {
-		if r := recover(); r != nil {
-			// If memefish panics, return the original value
-			result = value
-		}
-	}()
-
 	// Try to parse as an expression using memefish
-	expr, err := memefish.ParseExpr("", value)
+	expr, err := parseMemefishExpr("", value)
 	if err != nil {
 		// If parsing fails, return the original value
 		return value


### PR DESCRIPTION
## Summary

- recover only known malformed-input `*memefish.Error` panics and re-panic unexpected programmer/runtime failures
- route `parseGoogleSQLValue` through the shared narrow parser wrapper while preserving raw-value fallback for parse errors
- add a tripwire for the upstream leading-token panic plus regression coverage for string and `runtime.Error` propagation

## Validation

- confirmed the new string/runtime propagation tests fail against the pre-change catch-all implementation
- `go test ./internal/mycli -run '^(TestRecoverMemefishParserPanic|TestParseGoogleSQLValue|TestSetParamStatementMalformedInput|TestParseMutationMalformedInput)$' -count=1`
- `go test -race ./internal/mycli -run '^(TestRecoverMemefishParserPanic|TestParseGoogleSQLValue)$' -count=1`
- `make check`
- `git diff --check`
