### PR TITLE
feat: execute Spanner Graph EXPORT DATA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/apstndb/genaischema v0.2.0
 	github.com/apstndb/go-grpcinterceptors v0.0.0-20241120095005-f07edaf5bdfe
 	github.com/apstndb/go-tabwrap v0.1.4
-	github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0
+	github.com/apstndb/gsqlutils v0.0.0-20260813143423-9e5dff7c7357
 	github.com/apstndb/memebridge v0.7.0
 	github.com/apstndb/protoyaml v0.1.1
 	github.com/apstndb/spancodec v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/apstndb/go-tabwrap v0.1.4 h1:havRzBHehrCzUSHtaeF9oaSK+R53+aEUXQP37OBQ
 github.com/apstndb/go-tabwrap v0.1.4/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
 github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba h1:l9MMbSfCb/JBF3wY3HuDM6cB5Y0AzGkXbmVzQ87J1vU=
 github.com/apstndb/go-yamlformat v0.0.0-20250624144133-5961930dd0ba/go.mod h1:adI+0n+0AY1J+qhb7UbW3HjsUD15JCQPIih7FHLcrI4=
-github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0 h1:VySrhGRfqXUDCrUuAEz70DrDnPrvj/nXGnUHwJF3PG4=
-github.com/apstndb/gsqlutils v0.0.0-20260502161854-d7d6011a36e0/go.mod h1:VwhJDip+HamDWWt+Ol4ECFU0g0HiveA27DeNkt3U8S0=
+github.com/apstndb/gsqlutils v0.0.0-20260813143423-9e5dff7c7357 h1:p+BkwgLeIL5MM9wvhaGLw2NlZsvNjiK6lXMHfKVWa9w=
+github.com/apstndb/gsqlutils v0.0.0-20260813143423-9e5dff7c7357/go.mod h1:VwhJDip+HamDWWt+Ol4ECFU0g0HiveA27DeNkt3U8S0=
 github.com/apstndb/memebridge v0.7.0 h1:6YDUc+xpOtP0aP3p3b6cyWe5qNcBKQW+75ICIOJ90kA=
 github.com/apstndb/memebridge v0.7.0/go.mod h1:TkN51CaMfhBEYrGR9bDoUPpYKoOiTMiSnQNH2/gYZ9o=
 github.com/apstndb/protoyaml v0.1.1 h1:qCxi4l6twinpF+tM3qXG2qeRq6OmIklWK+LWtuM1eBk=

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -215,6 +215,22 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 
 // executeSQLImplWithVars is the actual implementation that accepts custom system variables
 func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, sysVars *systemVariables) (*Result, error) {
+	return executeSQLImplWithQueryRunner(ctx, session, sql, sysVars, session.txn.RunQueryWithStats, true)
+}
+
+// executeSQLImplSingleUse executes SQL outside the session's explicit
+// transaction while preserving normal query options and one-shot request-tag
+// consumption.
+func executeSQLImplSingleUse(ctx context.Context, session *Session, sql string, sysVars *systemVariables) (*Result, error) {
+	run := func(ctx context.Context, stmt spanner.Statement, _ bool, mode sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
+		return session.txn.RunSingleUseQueryWithStats(ctx, stmt, mode)
+	}
+	return executeSQLImplWithQueryRunner(ctx, session, sql, sysVars, run, false)
+}
+
+type queryWithStatsRunner func(context.Context, spanner.Statement, bool, sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error)
+
+func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql string, sysVars *systemVariables, run queryWithStatsRunner, rollbackActiveTransactionOnAbort bool) (*Result, error) {
 	m := newMetrics(sysVars)
 
 	fc, vfm, sysVars, err := prepareFormatConfig(sql, sysVars)
@@ -227,7 +243,7 @@ func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, s
 		return nil, err
 	}
 
-	iter, roTxn, err := session.txn.RunQueryWithStats(ctx, stmt, false, effectiveQueryMode(sysVars.Query.QueryMode))
+	iter, roTxn, err := run(ctx, stmt, false, effectiveQueryMode(sysVars.Query.QueryMode))
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +260,7 @@ func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, s
 	})
 	if err != nil {
 		// Handle aborted transaction
-		if session.txn.InReadWriteTransaction() && spanner.ErrCode(err) == codes.Aborted {
+		if rollbackActiveTransactionOnAbort && session.txn.InReadWriteTransaction() && spanner.ErrCode(err) == codes.Aborted {
 			rollback := &RollbackStatement{}
 			if _, rollbackErr := rollback.Execute(ctx, session); rollbackErr != nil {
 				return nil, errors.Join(err, fmt.Errorf("error on rollback: %w", rollbackErr))

--- a/internal/mycli/query_mode_test.go
+++ b/internal/mycli/query_mode_test.go
@@ -70,6 +70,18 @@ func TestEffectiveQueryMode(t *testing.T) {
 	}
 }
 
+func TestExportDataStatementRejectsPlanMode(t *testing.T) {
+	t.Parallel()
+
+	session := newSessionForLocalVarTest(t)
+	session.systemVariables.Query.QueryMode = sppb.ExecuteSqlRequest_PLAN.Enum()
+
+	_, err := (&ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS SELECT 1"}).Execute(t.Context(), session)
+	if err == nil || !strings.Contains(err.Error(), "CLI_QUERY_MODE=PLAN") {
+		t.Fatalf("ExportDataStatement.Execute() error = %v, want PLAN-mode rejection", err)
+	}
+}
+
 func TestSetCLIQueryModeStatsValues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mycli/query_mode_test.go
+++ b/internal/mycli/query_mode_test.go
@@ -82,6 +82,18 @@ func TestExportDataStatementRejectsPlanMode(t *testing.T) {
 	}
 }
 
+func TestExportDataStatementRejectsTryPartitionQuery(t *testing.T) {
+	t.Parallel()
+
+	session := newSessionForLocalVarTest(t)
+	session.systemVariables.Query.TryPartitionQuery = true
+
+	_, err := (&ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS SELECT 1"}).Execute(t.Context(), session)
+	if err == nil || !strings.Contains(err.Error(), "CLI_TRY_PARTITION_QUERY=TRUE") {
+		t.Fatalf("ExportDataStatement.Execute() error = %v, want partition-probe rejection", err)
+	}
+}
+
 func TestSetCLIQueryModeStatsValues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mycli/readonly_guard_test.go
+++ b/internal/mycli/readonly_guard_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	"github.com/apstndb/spanner-mycli/enums"
 )
 
 // TestReadOnlyGuardCoversBatchStatements is the regression test for issue
@@ -29,6 +30,7 @@ func TestReadOnlyGuardCoversBatchStatements(t *testing.T) {
 		{desc: "CREATE DATABASE", stmt: &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d"}},
 		{desc: "SYNC PROTO BUNDLE", stmt: &SyncProtoStatement{UpsertPaths: []string{"examples.ProtoType"}}},
 		{desc: "ADD SPLIT POINTS", stmt: &AddSplitPointsStatement{}},
+		{desc: "EXPORT DATA", stmt: &ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS GRAPH g RETURN 1"}},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
@@ -40,6 +42,37 @@ func TestReadOnlyGuardCoversBatchStatements(t *testing.T) {
 				t.Errorf("%s in READONLY mode: got error %v, want errReadOnly", tt.desc, err)
 			}
 		})
+	}
+}
+
+func TestExportDataStatementUsesNonTransactionalMutationGuard(t *testing.T) {
+	t.Parallel()
+
+	const sql = `EXPORT DATA OPTIONS (
+  format = "CLOUD_SPANNER",
+  table = "Account",
+  write_mode = 'update_ignore_all'
+) AS
+GRAPH FinGraph
+CALL PageRank() YIELD node, score
+RETURN node.id, score`
+
+	stmt, err := BuildStatementWithCommentsWithMode(sql, sql, enums.ParseModeFallback)
+	if err != nil {
+		t.Fatalf("BuildStatementWithCommentsWithMode() error = %v", err)
+	}
+	if _, ok := stmt.(MutationStatement); ok {
+		t.Fatal("ExportDataStatement must not participate in the Spanner transaction machinery")
+	}
+	if _, ok := stmt.(nonTransactionalMutationStatement); !ok {
+		t.Fatal("ExportDataStatement must participate in the non-transactional READONLY guard")
+	}
+
+	session := newSessionForLocalVarTest(t)
+	session.systemVariables.Transaction.ReadOnly = true
+	_, err = session.ExecuteStatement(t.Context(), stmt)
+	if !errors.Is(err, errReadOnly) {
+		t.Fatalf("EXPORT DATA in READONLY mode: got error %v, want errReadOnly", err)
 	}
 }
 

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -766,6 +766,12 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 		return stmt.Execute(ctx, s)
 	}
 
+	if _, ok := stmt.(nonTransactionalMutationStatement); ok {
+		if err := s.failStatementIfReadOnly(); err != nil {
+			return &Result{}, err
+		}
+	}
+
 	// Conditionally mutating statements (e.g. mutating CQL) participate in the
 	// READONLY guard but do not determine a pending Spanner transaction, since
 	// they do not use the Spanner transaction machinery.

--- a/internal/mycli/session_slow_test.go
+++ b/internal/mycli/session_slow_test.go
@@ -3,6 +3,7 @@ package mycli
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -159,6 +160,123 @@ func TestRequestPriority(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExportDataRequestUsesIsolatedSingleUseOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping emulator test in short mode")
+	}
+
+	ctx := t.Context()
+	clients := spanemuboost.SetupClients(t, lazyRuntime,
+		spanemuboost.WithRandomInstanceID(),
+		spanemuboost.WithProjectID(project),
+		spanemuboost.WithDatabaseID(database),
+		spanemuboost.EnableAutoConfig(),
+	)
+	var recorder requestRecorder
+	unaryInterceptor, streamInterceptor := recordRequestsInterceptors(&recorder)
+	conn, err := grpc.NewClient(clients.URI(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(unaryInterceptor),
+		grpc.WithStreamInterceptor(streamInterceptor),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	sysVars := newSystemVariablesWithDefaultsForTest()
+	sysVars.Connection = ConnectionVars{
+		Project:  clients.ProjectID,
+		Instance: clients.InstanceID,
+		Database: clients.DatabaseID,
+	}
+	sysVars.Query.StatementTimeout = lo.ToPtr(time.Hour)
+	session, err := NewSession(ctx, sysVars, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	if err := session.txn.BeginReadWriteTransaction(ctx, 0, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatalf("failed to begin read-write transaction: %v", err)
+	}
+	iter, _, err := session.txn.RunQuery(ctx, spanner.NewStatement("SELECT 1"))
+	if err != nil {
+		t.Fatalf("failed to activate read-write transaction: %v", err)
+	}
+	if _, _, _, _, err := consumeRowIterDiscard(iter); err != nil {
+		t.Fatalf("failed to consume activation query: %v", err)
+	}
+
+	const (
+		exportSQL  = "EXPORT DATA OPTIONS (format = 'CLOUD_SPANNER', table = 'Account') AS SELECT 1"
+		requestTag = "graph-export"
+	)
+	sysVars.Transaction.RequestTag = requestTag
+	sysVars.Query.OptimizerVersion = "7"
+	sysVars.Query.OptimizerStatisticsPackage = "auto_test_package"
+	sysVars.Query.ReadOnlyStaleness = lo.ToPtr(spanner.ExactStaleness(time.Minute))
+
+	// The emulator does not implement EXPORT DATA, but it still records the
+	// exact ExecuteSqlRequest before returning the expected syntax error.
+	if _, err := session.ExecuteStatement(ctx, &ExportDataStatement{SQL: exportSQL}); err == nil {
+		t.Fatal("ExportDataStatement.Execute() error = nil, want emulator syntax error")
+	}
+	if !session.txn.InReadWriteTransaction() {
+		t.Fatal("EXPORT DATA must not replace or close the explicit transaction")
+	}
+	if got := sysVars.Transaction.RequestTag; got != "" {
+		t.Fatalf("STATEMENT_TAG after EXPORT DATA = %q, want consumed", got)
+	}
+
+	var exportRequest *sppb.ExecuteSqlRequest
+	for _, request := range recorder.requests {
+		if execute, ok := request.(*sppb.ExecuteSqlRequest); ok && strings.HasPrefix(execute.GetSql(), "EXPORT DATA") {
+			exportRequest = execute
+			break
+		}
+	}
+	if exportRequest == nil {
+		t.Fatal("recorded requests contain no EXPORT DATA ExecuteSqlRequest")
+	}
+	if exportRequest.GetTransaction().GetSingleUse() == nil {
+		t.Fatalf("EXPORT DATA transaction selector = %T, want single-use", exportRequest.GetTransaction().GetSelector())
+	}
+	if got := exportRequest.GetRequestOptions().GetRequestTag(); got != requestTag {
+		t.Errorf("EXPORT DATA request tag = %q, want %q", got, requestTag)
+	}
+	if got := exportRequest.GetQueryOptions().GetOptimizerVersion(); got != "7" {
+		t.Errorf("EXPORT DATA optimizer version = %q, want 7", got)
+	}
+	if got := exportRequest.GetQueryOptions().GetOptimizerStatisticsPackage(); got != "auto_test_package" {
+		t.Errorf("EXPORT DATA optimizer statistics package = %q, want auto_test_package", got)
+	}
+	if got := exportRequest.GetTransaction().GetSingleUse().GetReadOnly().GetExactStaleness().AsDuration(); got != time.Minute {
+		t.Errorf("EXPORT DATA exact staleness = %v, want %v", got, time.Minute)
+	}
+
+	iter, _, err = session.txn.RunQuery(ctx, spanner.NewStatement("SELECT 1"))
+	if err != nil {
+		t.Fatalf("failed to run query after EXPORT DATA: %v", err)
+	}
+	if _, _, _, _, err := consumeRowIterDiscard(iter); err != nil {
+		t.Fatalf("failed to consume query after EXPORT DATA: %v", err)
+	}
+	foundFollowingSelect := false
+	for i := len(recorder.requests) - 1; i >= 0; i-- {
+		execute, ok := recorder.requests[i].(*sppb.ExecuteSqlRequest)
+		if !ok || execute.GetSql() != "SELECT 1" {
+			continue
+		}
+		foundFollowingSelect = true
+		if got := execute.GetRequestOptions().GetRequestTag(); got != "" {
+			t.Errorf("following SELECT request tag = %q, want empty", got)
+		}
+		break
+	}
+	if !foundFollowingSelect {
+		t.Fatal("recorded requests contain no following SELECT ExecuteSqlRequest")
 	}
 }
 

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -48,6 +48,13 @@ type MutationStatement interface {
 	isMutationStatement()
 }
 
+// nonTransactionalMutationStatement marks statements that have side effects
+// but must not participate in the Spanner transaction machinery. They are
+// rejected by the READONLY guard without determining a pending transaction.
+type nonTransactionalMutationStatement interface {
+	isNonTransactionalMutationStatement()
+}
+
 // ConditionallyMutatingStatement is a marker interface for statements whose
 // mutation-ness cannot be decided statically from their Go type but only from
 // their content (e.g. a CQL statement text). The READONLY guard in
@@ -82,6 +89,8 @@ var (
 	_ MutationStatement = (*SyncProtoStatement)(nil)
 	_ MutationStatement = (*AddSplitPointsStatement)(nil)
 )
+
+var _ nonTransactionalMutationStatement = (*ExportDataStatement)(nil)
 
 // No core statement implements ConditionallyMutatingStatement any more: both
 // implementations were extracted into feature packages, where each carries its
@@ -426,6 +435,8 @@ func BuildNativeStatementMemefish(stripped, raw string) (Statement, error) {
 	// DML statements are compatible with ExecuteSQL, but they should be executed with DmlStatement, not SelectStatement.
 	case kind.IsDML():
 		return &DmlStatement{Dml: raw}, nil
+	case kind.IsExportData():
+		return &ExportDataStatement{SQL: raw}, nil
 	// All ExecuteSQL compatible statements can be executed with SelectStatement.
 	case kind.IsExecuteSQLCompatible():
 		return &SelectStatement{Query: raw}, nil
@@ -451,6 +462,8 @@ func BuildNativeStatementLexical(stripped string, raw string) (Statement, error)
 	// DML statements are compatible with ExecuteSQL, but they should be executed with DmlStatement, not SelectStatement.
 	case kind.IsDML():
 		return &DmlStatement{Dml: raw}, nil
+	case kind.IsExportData():
+		return &ExportDataStatement{SQL: raw}, nil
 	// All ExecuteSQL compatible statements can be executed with SelectStatement.
 	case kind.IsExecuteSQLCompatible():
 		return &SelectStatement{Query: raw}, nil

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -679,6 +679,26 @@ func TestBuildStatement(t *testing.T) {
 			skipParseModes: []enums.ParseMode{enums.ParseModeMemefishOnly},
 		},
 		{
+			desc: "EXPORT DATA Spanner Graph algorithm statement",
+			input: `EXPORT DATA OPTIONS (
+  format = "CLOUD_SPANNER",
+  table = "Account",
+  write_mode = 'update_ignore_all'
+) AS
+GRAPH FinGraph
+CALL PageRank() YIELD node, score
+RETURN node.id, score AS page_rank`,
+			want: &ExportDataStatement{SQL: `EXPORT DATA OPTIONS (
+  format = "CLOUD_SPANNER",
+  table = "Account",
+  write_mode = 'update_ignore_all'
+) AS
+GRAPH FinGraph
+CALL PageRank() YIELD node, score
+RETURN node.id, score AS page_rank`},
+			skipParseModes: []enums.ParseMode{enums.ParseModeMemefishOnly},
+		},
+		{
 			desc:  "EXPLAIN GRAPH statement",
 			input: "EXPLAIN GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id",
 			want:  &ExplainStatement{Explain: "GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id"},

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -82,6 +82,33 @@ func (s *SelectStatement) Execute(ctx context.Context, session *Session) (*Resul
 	}
 }
 
+// ExportDataStatement runs a Spanner Graph algorithm query and persists its
+// results according to the EXPORT DATA options. The persistence operation is
+// non-transactional, so execution deliberately uses a single-use transaction
+// instead of joining the session's current transaction.
+//
+// https://cloud.google.com/spanner/docs/graph/run-algorithms
+type ExportDataStatement struct {
+	SQL string
+}
+
+func (s *ExportDataStatement) String() string {
+	return s.SQL
+}
+
+func (ExportDataStatement) isNonTransactionalMutationStatement() {}
+
+func (s *ExportDataStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	// Unlike SELECT and DML, EXPORT DATA cannot use the regular EXPLAIN path:
+	// it must remain outside the session transaction. Fail closed instead of
+	// letting effectiveQueryMode convert PLAN to PROFILE and execute the export.
+	if lo.FromPtr(session.systemVariables.Query.QueryMode) == sppb.ExecuteSqlRequest_PLAN {
+		return nil, errors.New("EXPORT DATA cannot be executed with CLI_QUERY_MODE=PLAN")
+	}
+
+	return executeSQLImplWithTxn(ctx, session, session.client.Single(), s.SQL, session.systemVariables)
+}
+
 type DmlStatement struct {
 	Dml string
 }

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -99,6 +99,10 @@ func (s *ExportDataStatement) String() string {
 func (ExportDataStatement) isNonTransactionalMutationStatement() {}
 
 func (s *ExportDataStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	if session.systemVariables.Query.TryPartitionQuery {
+		return nil, errors.New("EXPORT DATA cannot be executed with CLI_TRY_PARTITION_QUERY=TRUE")
+	}
+
 	// Unlike SELECT and DML, EXPORT DATA cannot use the regular EXPLAIN path:
 	// it must remain outside the session transaction. Fail closed instead of
 	// letting effectiveQueryMode convert PLAN to PROFILE and execute the export.
@@ -106,7 +110,7 @@ func (s *ExportDataStatement) Execute(ctx context.Context, session *Session) (*R
 		return nil, errors.New("EXPORT DATA cannot be executed with CLI_QUERY_MODE=PLAN")
 	}
 
-	return executeSQLImplWithTxn(ctx, session, session.client.Single(), s.SQL, session.systemVariables)
+	return executeSQLImplSingleUse(ctx, session, s.SQL, session.systemVariables)
 }
 
 type DmlStatement struct {

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -956,6 +956,21 @@ func (tm *TransactionManager) RunQueryWithStats(ctx context.Context, stmt spanne
 	return iter, roTxn, nil
 }
 
+// RunSingleUseQueryWithStats executes a statement in a single-use read-only
+// transaction even when the session has an active explicit transaction. It
+// preserves the query options and one-shot request-tag behavior of ordinary
+// query execution.
+func (tm *TransactionManager) RunSingleUseQueryWithStats(ctx context.Context, stmt spanner.Statement, mode sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
+	if err := tm.ValidateDatabaseOperation(); err != nil {
+		return nil, nil, err
+	}
+
+	opts := tm.buildQueryOptions(&mode)
+	tm.prepareQueryOptions(&opts)
+	iter, roTxn := tm.runSingleUseQuery(ctx, stmt, opts)
+	return iter, roTxn, nil
+}
+
 // RunQuery executes a statement either on the running transaction or on the temporal read-only transaction.
 // It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
 // An error is returned when no database connection is available; this should not


### PR DESCRIPTION
## Summary

- recognize documented Spanner Graph `EXPORT DATA` algorithm statements in lexical and fallback parse modes
- execute exports through a single-use transaction so they do not join the session's explicit transaction
- block exports in `READONLY` mode and fail closed for non-executing `CLI_QUERY_MODE=PLAN` and `CLI_TRY_PARTITION_QUERY=TRUE` settings
- preserve one-shot statement tags, optimizer options, read staleness, and the active explicit transaction through an isolated single-use request path
- update gsqlutils to the version that classifies `EXPORT DATA`

## Validation

- `make check`
- `make check-race`
- `govulncheck ./...`

## Compatibility

`MEMEFISH_ONLY` still rejects `EXPORT DATA` because memefish does not yet expose this statement in its AST/parser. `FALLBACK`, `NO_MEMEFISH`, and the default parse mode execute it through the lexical classification path.

Managed Spanner execution was not exercised because this Pre-GA feature persists output to an external destination. The statement shape is covered with the documented Spanner Graph algorithm form.
