### PR TITLE
build(deps): avoid moved certificate proxy tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.19 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.21 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apstndb/spanner-mycli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	cloud.google.com/go v0.123.0

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/googleapis/enterprise-certificate-proxy v0.3.19 h1:mMOE7DN2+p76/EdIrmAy9B9bH+yC4563vmnJ34QR8i4=
-github.com/googleapis/enterprise-certificate-proxy v0.3.19/go.mod h1:rSEsBUemEBZEexP2y6jPp16LUmUbjmSbcPMQizR0o4k=
+github.com/googleapis/enterprise-certificate-proxy v0.3.21 h1:OFdQ3tnCX/zaQ0Cedur3D3z7kI6HiLX9g3TiAN4/DFU=
+github.com/googleapis/enterprise-certificate-proxy v0.3.21/go.mod h1:L3D/IQExI6LqEjBdXcZQ1WluSgigQmSwBboFstVPM4w=
 github.com/googleapis/gax-go/v2 v2.23.0 h1:Tchl7qkvE7Ip3y+ztvNufYFvkfqTe7NfLTYGIdJRLuE=
 github.com/googleapis/gax-go/v2 v2.23.0/go.mod h1:rBQKOVJCdb8IFEzg+FCwlt1LP/xMDGuqUXhUG+XMXEg=
 github.com/googleapis/go-spanner-cassandra v0.7.0 h1:qcBoTARj9KTb4GDpuuRy8hCrQ+sWdhVkS1Dxs4Svr3Y=


### PR DESCRIPTION
## Summary

- upgrade the indirect `enterprise-certificate-proxy` dependency from `v0.3.19` to `v0.3.21`
- avoid the moved `v0.3.19` upstream tag, whose live source no longer matches the immutable Go module proxy copy
- restore reproducible installation through both the default module proxy and `GOPROXY=direct`
- update the Go baseline from 1.25.12 to 1.25.13 to pick up standard-library security fixes reported by CI

## Validation

- `make check`
- `make check-race`
- `go mod verify`
- `govulncheck ./...`
- `make check`, `make check-race`, and `govulncheck ./...` with Go 1.25.13
- fresh-cache `go install .` with `GOPROXY=https://proxy.golang.org`
- fresh-cache `go install .` with `GOPROXY=direct`
- verified `v0.3.21` resolves to the same tag commit and checksums through the module proxy and direct Git retrieval
