### PR TITLE
build(deps): pin certificate proxy commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.21 // indirect
+	// The v0.3.21 tag was deleted upstream; this pins the same commit for direct module resolution.
+	github.com/googleapis/enterprise-certificate-proxy v0.3.21-0.20260811172054-82da9ba164a0 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/googleapis/enterprise-certificate-proxy v0.3.21 h1:OFdQ3tnCX/zaQ0Cedur3D3z7kI6HiLX9g3TiAN4/DFU=
-github.com/googleapis/enterprise-certificate-proxy v0.3.21/go.mod h1:L3D/IQExI6LqEjBdXcZQ1WluSgigQmSwBboFstVPM4w=
+github.com/googleapis/enterprise-certificate-proxy v0.3.21-0.20260811172054-82da9ba164a0 h1:6bWCboNV72G9Nh4P2m5vqckkeg3KaA4TudWWPVtjx2g=
+github.com/googleapis/enterprise-certificate-proxy v0.3.21-0.20260811172054-82da9ba164a0/go.mod h1:L3D/IQExI6LqEjBdXcZQ1WluSgigQmSwBboFstVPM4w=
 github.com/googleapis/gax-go/v2 v2.23.0 h1:Tchl7qkvE7Ip3y+ztvNufYFvkfqTe7NfLTYGIdJRLuE=
 github.com/googleapis/gax-go/v2 v2.23.0/go.mod h1:rBQKOVJCdb8IFEzg+FCwlt1LP/xMDGuqUXhUG+XMXEg=
 github.com/googleapis/go-spanner-cassandra v0.7.0 h1:qcBoTARj9KTb4GDpuuRy8hCrQ+sWdhVkS1Dxs4Svr3Y=


### PR DESCRIPTION
## Summary

- replace the deleted `enterprise-certificate-proxy` v0.3.21 tag with the canonical pseudo-version for the same commit
- preserve the dependency source while restoring builds that use `GOPROXY=direct`
- document why the pseudo-version is intentional

## Background

A fresh `GOPROXY=direct go install github.com/apstndb/spanner-mycli@v0.34.1` fails because the upstream v0.3.21 tag no longer exists. The commit that tag referenced still exists as `82da9ba164a0143476697b3426f7609f8914f32a`.

The canonical pseudo-version resolves to that exact commit, and its extracted module contents are identical to the previously published v0.3.21 module contents.

## Verification

- `make check`
- `GOTOOLCHAIN=go1.25.13 make check-race`
- `go mod verify`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...`
- fresh `go build ./...` with `GOPROXY=direct`
- fresh `go build ./...` with `GOPROXY=https://proxy.golang.org`
