### PR TITLE
docs: align split point syntax with gcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,8 +591,8 @@ and `{A|B|...}` for a mutually exclusive keyword.
 | Export specific tables as SQL INSERT statements                             | `DUMP TABLES <table1> [, <table2>, ...];`                                                                  |                                                                                                                                                                                                           |
 | Show schema update operations                                               | `SHOW SCHEMA UPDATE OPERATIONS;`                                                                           |                                                                                                                                                                                                           |
 | Show specific operation (async)                                             | `SHOW OPERATION <operation-id-or-name> [ASYNC\|SYNC];`                                                     | Attach to and monitor a specific Long Running Operation by its operation ID or full operation name. ASYNC (default) returns current status, SYNC provides real-time monitoring (planned).                 |
-| Add split points                                                            | `ADD SPLIT POINTS [EXPIRED AT <timestamp>] <type> <fqn> (<key>, ...) [TableKey (<key>, ...)] ...;`         |                                                                                                                                                                                                           |
-| Drop split points                                                           | `DROP SPLIT POINTS <type> <fqn> (<key>, ...) [TableKey (<key>, ...)] ...;`                                 |                                                                                                                                                                                                           |
+| Add split points                                                            | `ADD SPLIT POINTS [EXPIRED AT <timestamp>] {TABLE\|INDEX} <fqn> (<key>, ...) [TableKey (<key>, ...)] ...;` | TableKey is valid only for INDEX entries.                                                                                                                                                                 |
+| Drop split points                                                           | `DROP SPLIT POINTS {TABLE\|INDEX} <fqn> (<key>, ...) [TableKey (<key>, ...)] ...;`                         | TableKey is valid only for INDEX entries.                                                                                                                                                                 |
 | Show split points                                                           | `SHOW SPLIT POINTS;`                                                                                       |                                                                                                                                                                                                           |
 | Show local proto descriptors                                                | `SHOW LOCAL PROTO;`                                                                                        |                                                                                                                                                                                                           |
 | Show remote proto bundle                                                    | `SHOW REMOTE PROTO;`                                                                                       |                                                                                                                                                                                                           |
@@ -1530,6 +1530,8 @@ spanner-mycli can [manage split points](https://cloud.google.com/spanner/docs/cr
 You can add split points using `ADD SPLIT POINTS` statement.
 
 - You can add multiple split points in a statement.
+- Table and index split points can use composite keys.
+- Index split points can include the complete table primary key with `TableKey (...)`.
 - You can specify the expiration of split points.
 
 ```
@@ -1548,7 +1550,7 @@ spanner> ADD SPLIT POINTS EXPIRED AT "2025-05-05T00:00:00Z"
          INDEX SingersByFirstLastName ("Mary", "Sue") TableKey (12);
 ```
 
-This syntax is similar to [`gcloud spanner databases splits add --splits-file`](https://cloud.google.com/spanner/docs/create-manage-split-points#create-split-points), but there are some differences.
+The entry structure follows [`gcloud spanner databases splits add --splits-file`](https://cloud.google.com/spanner/docs/create-manage-split-points#create-split-points), including composite keys and the optional index `TableKey (...)` suffix. Literal syntax differs as follows:
 
 - It is implemented using memefish so it follows GoogleSQL lexical structure.
 - `INT64` and `NUMERIC` Spanner data types can be integer literal. For example, `123` or `99.99`

--- a/internal/mycli/client_side_statement_def.go
+++ b/internal/mycli/client_side_statement_def.go
@@ -428,7 +428,8 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		Descriptions: []clientSideStatementDescription{
 			{
 				Usage:  "Add split points",
-				Syntax: "ADD SPLIT POINTS [EXPIRED AT <timestamp>] <type> <fqn> (<key>, ...) [TableKey (<key>, ...)] ...",
+				Syntax: "ADD SPLIT POINTS [EXPIRED AT <timestamp>] {TABLE|INDEX} <fqn> (<key>, ...) [TableKey (<key>, ...)] ...",
+				Note:   "TableKey is valid only for INDEX entries.",
 			},
 		},
 		Pattern: regexp.MustCompile(`(?is)^ADD\s+SPLIT\s+POINTS\s+(?P<body>.*)$`),
@@ -447,7 +448,8 @@ var clientSideStatementDefs = []*clientSideStatementDef{
 		Descriptions: []clientSideStatementDescription{
 			{
 				Usage:  "Drop split points",
-				Syntax: "DROP SPLIT POINTS <type> <fqn> (<key>, ...) [TableKey (<key>, ...)] ...",
+				Syntax: "DROP SPLIT POINTS {TABLE|INDEX} <fqn> (<key>, ...) [TableKey (<key>, ...)] ...",
+				Note:   "TableKey is valid only for INDEX entries.",
 			},
 		},
 		Pattern: regexp.MustCompile(`(?is)^DROP\s+SPLIT\s+POINTS\s+(?P<body>.*)$`),

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -935,6 +935,36 @@ INDEX SingersByFirstLastName ("Mary", "Sue") TableKey (12)
 			},
 		},
 		{
+			desc: "ADD SPLIT POINTS statement with composite keys and TableKey",
+			input: `ADD SPLIT POINTS
+TABLE TableD (0, '7ef9db22-d0e5-6041-8937-4bc6a7ef9db2')
+INDEX IndexXYZ ('8762203435012030000', NULL, NULL)
+INDEX IndexABC (0, '2020-06-18T17:24:53Z', '2020-06-18T17:24:53Z') TableKey (123, 'ab,c')`,
+			want: &AddSplitPointsStatement{
+				SplitPoints: []*databasepb.SplitPoints{
+					{
+						Table: "TableD",
+						Keys: []*databasepb.SplitPoints_Key{
+							{KeyParts: &structpb.ListValue{Values: []*structpb.Value{structpb.NewStringValue("0"), structpb.NewStringValue("7ef9db22-d0e5-6041-8937-4bc6a7ef9db2")}}},
+						},
+					},
+					{
+						Index: "IndexXYZ",
+						Keys: []*databasepb.SplitPoints_Key{
+							{KeyParts: &structpb.ListValue{Values: []*structpb.Value{structpb.NewStringValue("8762203435012030000"), structpb.NewNullValue(), structpb.NewNullValue()}}},
+						},
+					},
+					{
+						Index: "IndexABC",
+						Keys: []*databasepb.SplitPoints_Key{
+							{KeyParts: &structpb.ListValue{Values: []*structpb.Value{structpb.NewStringValue("0"), structpb.NewStringValue("2020-06-18T17:24:53Z"), structpb.NewStringValue("2020-06-18T17:24:53Z")}}},
+							{KeyParts: &structpb.ListValue{Values: []*structpb.Value{structpb.NewStringValue("123"), structpb.NewStringValue("ab,c")}}},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "DROP SPLIT POINTS statement",
 			input: `
 DROP SPLIT POINTS


### PR DESCRIPTION
## Summary

- clarify the client-side help syntax for `TABLE` and `INDEX` split-point entries
- document composite keys and the index-only `TableKey (...)` suffix
- add regression coverage for the split-file structure now documented by gcloud

## Context

The [Spanner split-points documentation](https://docs.cloud.google.com/spanner/docs/create-manage-split-points) now explicitly documents composite table and index keys and the optional complete table key for index split points. The parser already supported that structure; this change makes the compatibility explicit and keeps it covered.

spanner-mycli continues to use GoogleSQL literal syntax, including an unescaped comma inside a quoted string, as described in the README.

## Testing

- `GOTOOLCHAIN=go1.25.13 make check`
- `make docs-update`
