### PR TITLE
Use writer.RowSeq for typed replay

### DIFF
--- a/internal/mycli/typed_rows.go
+++ b/internal/mycli/typed_rows.go
@@ -17,7 +17,6 @@ package mycli
 import (
 	"fmt"
 	"io"
-	"iter"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -43,18 +42,6 @@ func typedReplayFormatConfig(sysVars *systemVariables) (*spanvalue.FormatConfig,
 	default:
 		fc, err := decoder.FormatConfigWithProto(sysVars.Internal.ProtoDescriptor, sysVars.Display.MultilineProtoText)
 		return fc, vfm, err
-	}
-}
-
-// rowSeq adapts a materialized slice of rows to the iter.Seq2 shape consumed by
-// writer.WriteRowSeq. The rows are already decoded, so iteration never errors.
-func rowSeq(rows []*spanner.Row) iter.Seq2[*spanner.Row, error] {
-	return func(yield func(*spanner.Row, error) bool) {
-		for _, r := range rows {
-			if !yield(r, nil) {
-				return
-			}
-		}
 	}
 }
 
@@ -89,7 +76,7 @@ func writeTypedRows(out io.Writer, sysVars *systemVariables, result *Result) err
 		// format sets ever diverge.
 		return fmt.Errorf("no spanvalue writer for typed replay in format %v", sv.Display.CLIFormat)
 	}
-	if _, err := writer.WriteRowSeq(result.Typed.Metadata, rowSeq(result.Typed.Rows), w); err != nil {
+	if _, err := writer.WriteRowSeq(result.Typed.Metadata, writer.RowSeq(result.Typed.Rows...), w); err != nil {
 		return normalizeSpanvalueWriterError(err)
 	}
 	return nil

--- a/internal/mycli/typed_rows_test.go
+++ b/internal/mycli/typed_rows_test.go
@@ -98,7 +98,7 @@ func TestTypedRowsByteIdentity(t *testing.T) {
 				if err != nil || !handled {
 					t.Fatalf("newSpanvalueRowIteratorWriterFor: handled=%v err=%v", handled, err)
 				}
-				if _, err := writer.WriteRowSeq(md, rowSeq(rawRows), w); err != nil {
+				if _, err := writer.WriteRowSeq(md, writer.RowSeq(rawRows...), w); err != nil {
 					t.Fatalf("WriteRowSeq: %v", err)
 				}
 			} else {


### PR DESCRIPTION
## Summary

- replace the local typed-row sequence adapter with `writer.RowSeq`
- use the same adapter in the byte-identity reference path
- remove the duplicate helper and unused `iter` import

This is behavior-preserving and keeps row-sequence adaptation in the existing
spanvalue writer API.

## Validation

- `go test ./internal/mycli -run '^TestTypedRowsByteIdentity$'`
- `make check` with Go 1.25.13 and golangci-lint 2.12.2
