### PR TITLE
fix: preserve SHOW OPERATION SYNC cancellation recovery

### DIFF
--- a/internal/mycli/show_operation_test.go
+++ b/internal/mycli/show_operation_test.go
@@ -428,6 +428,92 @@ func TestShowOperationStatement_SyncModeCanceledDDLPoll(t *testing.T) {
 	}
 }
 
+func TestShowOperationStatement_SyncModeFormatsInitiallyDoneWithoutRefetch(t *testing.T) {
+	t.Parallel()
+
+	operationName := "projects/test/instances/test/databases/test/operations/auto_op_123"
+	done := ddlShowOperation(operationName)
+	done.Done = true
+	server := &showOperationTestServer{responses: []showOperationResponse{
+		{operation: done},
+	}}
+	session := newShowOperationTestSession(t, server)
+	stmt := &ShowOperationStatement{OperationId: "auto_op_123", Mode: "SYNC"}
+
+	result, err := stmt.executeSyncModeWithTicks(t.Context(), session, make(chan time.Time))
+	if err != nil {
+		t.Fatalf("executeSyncModeWithTicks() error = %v", err)
+	}
+	assertDoneShowOperationRow(t, result)
+	if len(server.responses) != 0 {
+		t.Fatalf("unused GetOperation responses = %d, want 0", len(server.responses))
+	}
+}
+
+func TestShowOperationStatement_SyncModeFormatsPollDoneWithoutRefetch(t *testing.T) {
+	t.Parallel()
+
+	operationName := "projects/test/instances/test/databases/test/operations/auto_op_123"
+	inProgress := ddlShowOperation(operationName)
+	done := ddlShowOperation(operationName)
+	done.Done = true
+	server := &showOperationTestServer{responses: []showOperationResponse{
+		{operation: inProgress},
+		{operation: done},
+	}}
+	session := newShowOperationTestSession(t, server)
+	stmt := &ShowOperationStatement{OperationId: "auto_op_123", Mode: "SYNC"}
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Now()
+
+	result, err := stmt.executeSyncModeWithTicks(t.Context(), session, ticks)
+	if err != nil {
+		t.Fatalf("executeSyncModeWithTicks() error = %v", err)
+	}
+	assertDoneShowOperationRow(t, result)
+	if len(server.responses) != 0 {
+		t.Fatalf("unused GetOperation responses = %d, want 0", len(server.responses))
+	}
+}
+
+func TestShowOperationStatement_AsyncModeStillFetches(t *testing.T) {
+	t.Parallel()
+
+	operationName := "projects/test/instances/test/databases/test/operations/auto_op_123"
+	done := ddlShowOperation(operationName)
+	done.Done = true
+	server := &showOperationTestServer{responses: []showOperationResponse{
+		{operation: done},
+	}}
+	session := newShowOperationTestSession(t, server)
+	stmt := &ShowOperationStatement{OperationId: "auto_op_123", Mode: "ASYNC"}
+
+	result, err := stmt.executeAsyncMode(t.Context(), session, operationName)
+	if err != nil {
+		t.Fatalf("executeAsyncMode() error = %v", err)
+	}
+	assertDoneShowOperationRow(t, result)
+	if len(server.responses) != 0 {
+		t.Fatalf("ASYNC skipped GetOperation; unused responses = %d", len(server.responses))
+	}
+}
+
+func assertDoneShowOperationRow(t *testing.T, result *Result) {
+	t.Helper()
+	if result == nil {
+		t.Fatal("result = nil")
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("len(result.Rows) = %d, want 1", len(result.Rows))
+	}
+	if got := result.Rows[0][0].RawText(); got != "auto_op_123" {
+		t.Errorf("OPERATION_ID = %q, want auto_op_123", got)
+	}
+	if got := result.Rows[0][2].RawText(); got != "true" {
+		t.Errorf("DONE = %q, want true", got)
+	}
+}
+
 type showOperationResponse struct {
 	operation *longrunningpb.Operation
 	err       error

--- a/internal/mycli/show_operation_test.go
+++ b/internal/mycli/show_operation_test.go
@@ -4,15 +4,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
+	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -387,5 +393,100 @@ func TestShowOperationStatement_MetadataTypes(t *testing.T) {
 			progress := stmt.getOperationProgress(op)
 			assert.Equal(t, tt.expectedProg, progress)
 		})
+	}
+}
+
+func TestShowOperationStatement_SyncModeCanceledDDLPoll(t *testing.T) {
+	t.Parallel()
+
+	operationName := "projects/test/instances/test/databases/test/operations/auto_op_123"
+	ddlOp := ddlShowOperation(operationName)
+	server := &showOperationTestServer{responses: []showOperationResponse{
+		{operation: ddlOp},
+		{err: status.Error(codes.Canceled, "context canceled")},
+	}}
+	session := newShowOperationTestSession(t, server)
+	stmt := &ShowOperationStatement{OperationId: "auto_op_123", Mode: "SYNC"}
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Now()
+
+	result, err := stmt.executeSyncModeWithTicks(t.Context(), session, ticks)
+	if result != nil {
+		t.Fatalf("executeSyncModeWithTicks() result = %#v, want nil", result)
+	}
+	if err == nil {
+		t.Fatal("executeSyncModeWithTicks() error = nil, want cancellation hint")
+	}
+	if !strings.Contains(err.Error(), "SHOW OPERATION 'auto_op_123'") {
+		t.Errorf("error missing SHOW OPERATION hint: %v", err)
+	}
+	if status.Code(err) != codes.Canceled {
+		t.Errorf("status.Code(err) = %v, want Canceled; err = %v", status.Code(err), err)
+	}
+	if got := session.SchemaGeneration(); got != 1 {
+		t.Errorf("SchemaGeneration() = %d, want 1", got)
+	}
+}
+
+type showOperationResponse struct {
+	operation *longrunningpb.Operation
+	err       error
+}
+
+type showOperationTestServer struct {
+	longrunningpb.UnimplementedOperationsServer
+	responses []showOperationResponse
+}
+
+func (s *showOperationTestServer) GetOperation(_ context.Context, _ *longrunningpb.GetOperationRequest) (*longrunningpb.Operation, error) {
+	if len(s.responses) == 0 {
+		return nil, status.Error(codes.Internal, "unexpected extra GetOperation")
+	}
+	response := s.responses[0]
+	s.responses = s.responses[1:]
+	return response.operation, response.err
+}
+
+func newShowOperationTestSession(t *testing.T, server longrunningpb.OperationsServer) *Session {
+	t.Helper()
+
+	listener := bufconn.Listen(1 << 20)
+	grpcServer := grpc.NewServer()
+	longrunningpb.RegisterOperationsServer(grpcServer, server)
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("serve operation test server: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
+
+	conn, err := grpc.NewClient(
+		"passthrough:///show-operation-test",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("create gRPC test client: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	adminClient, err := adminapi.NewDatabaseAdminClient(t.Context(), option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatalf("create database admin client: %v", err)
+	}
+	t.Cleanup(func() { _ = adminClient.Close() })
+
+	return &Session{
+		adminClient: adminClient,
+		systemVariables: &systemVariables{Connection: ConnectionVars{
+			Project:  "test",
+			Instance: "test",
+			Database: "test",
+		}},
 	}
 }

--- a/internal/mycli/show_operation_test.go
+++ b/internal/mycli/show_operation_test.go
@@ -2,15 +2,163 @@ package mycli
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+func ddlShowOperation(name string) *longrunningpb.Operation {
+	md, err := anypb.New(&databasepb.UpdateDatabaseDdlMetadata{
+		Statements: []string{"CREATE TABLE t (id INT64) PRIMARY KEY (id)"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return &longrunningpb.Operation{Name: name, Metadata: md}
+}
+
+func TestShowOperationSyncWaitError(t *testing.T) {
+	t.Parallel()
+
+	ddlOp := ddlShowOperation("projects/p/instances/i/databases/d/operations/op-ddl")
+	otherOp := &longrunningpb.Operation{
+		Name: "projects/p/instances/i/databases/d/operations/op-other",
+	}
+	fullName := "projects/p/instances/i/databases/d/operations/op-ddl"
+
+	tests := []struct {
+		name           string
+		op             *longrunningpb.Operation
+		operationName  string
+		err            error
+		wantGenDelta   uint64
+		wantIsCanceled bool
+		wantIsDeadline bool
+		wantHintOpID   string
+		wantUnchanged  bool
+	}{
+		{
+			name:           "cancel after DDL identified bumps schema and hints",
+			op:             ddlOp,
+			operationName:  fullName,
+			err:            context.Canceled,
+			wantGenDelta:   1,
+			wantIsCanceled: true,
+			wantHintOpID:   "op-ddl",
+		},
+		{
+			name:           "deadline after DDL identified bumps schema and hints",
+			op:             ddlOp,
+			operationName:  "op-ddl",
+			err:            context.DeadlineExceeded,
+			wantGenDelta:   1,
+			wantIsDeadline: true,
+			wantHintOpID:   "op-ddl",
+		},
+		{
+			name:          "grpc cancel after DDL identified bumps schema and hints",
+			op:            ddlOp,
+			operationName: fullName,
+			err:           status.Error(codes.Canceled, "context canceled"),
+			wantGenDelta:  1,
+			wantHintOpID:  "op-ddl",
+		},
+		{
+			name:           "cancel before identification hints without schema bump",
+			op:             nil,
+			operationName:  fullName,
+			err:            context.Canceled,
+			wantGenDelta:   0,
+			wantIsCanceled: true,
+			wantHintOpID:   "op-ddl",
+		},
+		{
+			name:           "cancel of non-DDL operation hints without schema bump",
+			op:             otherOp,
+			operationName:  "projects/p/instances/i/databases/d/operations/op-other",
+			err:            context.Canceled,
+			wantGenDelta:   0,
+			wantIsCanceled: true,
+			wantHintOpID:   "op-other",
+		},
+		{
+			name:          "non-cancel error after DDL identified bumps schema and keeps original",
+			op:            ddlOp,
+			operationName: fullName,
+			err:           errors.New("boom"),
+			wantGenDelta:  1,
+			wantUnchanged: true,
+		},
+		{
+			name:          "non-cancel error before identification does not bump schema",
+			op:            nil,
+			operationName: fullName,
+			err:           errors.New("not found"),
+			wantGenDelta:  0,
+			wantUnchanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			session := &Session{systemVariables: newSystemVariablesWithDefaultsForTest()}
+			before := session.SchemaGeneration()
+
+			got := handleShowOperationSyncWaitError(session, tt.op, tt.operationName, tt.err)
+			if got == nil {
+				t.Fatal("expected non-nil error")
+			}
+
+			if delta := session.SchemaGeneration() - before; delta != tt.wantGenDelta {
+				t.Errorf("schema generation delta = %d, want %d", delta, tt.wantGenDelta)
+			}
+
+			if tt.wantUnchanged {
+				if !errors.Is(got, tt.err) && got.Error() != tt.err.Error() {
+					t.Errorf("non-cancel error mutated: got %v, want %v", got, tt.err)
+				}
+				if strings.Contains(got.Error(), "SHOW OPERATION") {
+					t.Errorf("non-cancel error unexpectedly contains SHOW OPERATION hint: %v", got)
+				}
+				return
+			}
+
+			if tt.wantIsCanceled && !errors.Is(got, context.Canceled) {
+				t.Errorf("errors.Is(err, context.Canceled) = false; err = %v", got)
+			}
+			if tt.wantIsDeadline && !errors.Is(got, context.DeadlineExceeded) {
+				t.Errorf("errors.Is(err, context.DeadlineExceeded) = false; err = %v", got)
+			}
+			if tt.wantHintOpID != "" && !strings.Contains(got.Error(), "SHOW OPERATION '"+tt.wantHintOpID+"'") {
+				t.Errorf("error missing SHOW OPERATION hint for %q\n  got: %s", tt.wantHintOpID, got)
+			}
+		})
+	}
+}
+
+func TestShowOperationSyncCancellationErrorPreservesCause(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("failed to poll operation %q: %w", "op-ddl", context.Canceled)
+	err := showOperationSyncCancellationError("projects/p/instances/i/databases/d/operations/op-ddl", wrapped)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "SHOW OPERATION 'op-ddl'") {
+		t.Fatalf("error missing hint: %v", err)
+	}
+}
 
 func TestShowOperationStatement_getOperationDescription(t *testing.T) {
 	t.Parallel()

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -348,7 +348,10 @@ func (s *ShowOperationStatement) executeSyncMode(ctx context.Context, session *S
 		Name: operationName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get operation %q: %w", operationName, err)
+		// The operation proto is not identified yet, so schema generation is not
+		// bumped. Cancellation still gets a SHOW OPERATION hint because the ID is
+		// already known from the statement.
+		return nil, handleShowOperationSyncWaitError(session, nil, operationName, fmt.Errorf("failed to get operation %q: %w", operationName, err))
 	}
 
 	// If operation is already done, return the status
@@ -399,16 +402,18 @@ func (s *ShowOperationStatement) executeSyncMode(ctx context.Context, session *S
 		case <-time.After(5 * time.Second):
 			// Continue polling
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, handleShowOperationSyncWaitError(session, op, operationName, ctx.Err())
 		}
 
-		// Poll the operation
-		op, err = session.adminClient.GetOperation(ctx, &longrunningpb.GetOperationRequest{
+		// Poll the operation. Keep the last identified proto on error so a failed
+		// UpdateDatabaseDdl poll can still invalidate the schema cache.
+		polledOp, err := session.adminClient.GetOperation(ctx, &longrunningpb.GetOperationRequest{
 			Name: operationName,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to poll operation %q: %w", operationName, err)
+			return nil, handleShowOperationSyncWaitError(session, op, operationName, fmt.Errorf("failed to poll operation %q: %w", operationName, err))
 		}
+		op = polledOp
 
 		// Update progress bar
 		if bar != nil && !bar.Completed() {
@@ -424,6 +429,35 @@ func (s *ShowOperationStatement) executeSyncMode(ctx context.Context, session *S
 
 	// Return final operation status
 	return s.executeAsyncMode(ctx, session, operationName)
+}
+
+const updateDatabaseDdlMetadataTypeURL = "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata"
+
+func isUpdateDatabaseDdlOperation(op *longrunningpb.Operation) bool {
+	return op.GetMetadata().GetTypeUrl() == updateDatabaseDdlMetadataTypeURL
+}
+
+// handleShowOperationSyncWaitError applies SHOW OPERATION SYNC's wait-exit policy.
+//
+// Schema-cache invalidation is conditional, unlike handleDdlWaitError: this path
+// monitors arbitrary long-running operations, so IncrementSchemaGeneration runs
+// only after an UpdateDatabaseDdl operation has been identified. Cancellation
+// still wraps a SHOW OPERATION hint because the operation ID is known from the
+// statement even when GetOperation never succeeded. The cause is wrapped with %w
+// so errors.Is(err, context.Canceled) continues to work for callers.
+func handleShowOperationSyncWaitError(session *Session, op *longrunningpb.Operation, operationName string, err error) error {
+	if isUpdateDatabaseDdlOperation(op) {
+		session.IncrementSchemaGeneration()
+	}
+	if !isCancellationError(err) {
+		return err
+	}
+	return showOperationSyncCancellationError(operationName, err)
+}
+
+func showOperationSyncCancellationError(operationName string, cause error) error {
+	operationID := lo.LastOrEmpty(strings.Split(operationName, "/"))
+	return fmt.Errorf("stopped waiting for operation; it may still be running server-side, check it with: SHOW OPERATION '%s': %w", operationID, cause)
 }
 
 func (s *ShowOperationStatement) executeAsyncMode(ctx context.Context, session *Session, operationName string) (*Result, error) {
@@ -452,7 +486,7 @@ func (s *ShowOperationStatement) executeAsyncMode(ctx context.Context, session *
 		))
 	} else {
 		switch metadata.GetTypeUrl() {
-		case "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata":
+		case updateDatabaseDdlMetadataTypeURL:
 			var md databasepb.UpdateDatabaseDdlMetadata
 			if err := metadata.UnmarshalTo(&md); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal UpdateDatabaseDdlMetadata: %w", err)
@@ -498,7 +532,7 @@ func (s *ShowOperationStatement) getOperationDescription(op *longrunningpb.Opera
 	}
 
 	switch metadata.GetTypeUrl() {
-	case "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata":
+	case updateDatabaseDdlMetadataTypeURL:
 		var md databasepb.UpdateDatabaseDdlMetadata
 		if err := metadata.UnmarshalTo(&md); err != nil {
 			operationId := lo.LastOrEmpty(strings.Split(op.GetName(), "/"))
@@ -525,7 +559,7 @@ func (s *ShowOperationStatement) getOperationProgress(op *longrunningpb.Operatio
 	}
 
 	switch metadata.GetTypeUrl() {
-	case "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata":
+	case updateDatabaseDdlMetadataTypeURL:
 		var md databasepb.UpdateDatabaseDdlMetadata
 		if err := metadata.UnmarshalTo(&md); err != nil {
 			return 0.0

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -336,6 +336,14 @@ func (s *ShowOperationStatement) Execute(ctx context.Context, session *Session) 
 }
 
 func (s *ShowOperationStatement) executeSyncMode(ctx context.Context, session *Session) (*Result, error) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	return s.executeSyncModeWithTicks(ctx, session, ticker.C)
+}
+
+// executeSyncModeWithTicks is the SYNC wait loop with an injected tick source so
+// unit tests can exercise poll exits without waiting five seconds.
+func (s *ShowOperationStatement) executeSyncModeWithTicks(ctx context.Context, session *Session, ticks <-chan time.Time) (*Result, error) {
 	operationName := s.OperationId
 
 	// If the operation ID doesn't contain a full path, construct the full operation name
@@ -399,7 +407,7 @@ func (s *ShowOperationStatement) executeSyncMode(ctx context.Context, session *S
 	// Polling loop
 	for !op.GetDone() {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-ticks:
 			// Continue polling
 		case <-ctx.Done():
 			return nil, handleShowOperationSyncWaitError(session, op, operationName, ctx.Err())

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -362,9 +362,10 @@ func (s *ShowOperationStatement) executeSyncModeWithTicks(ctx context.Context, s
 		return nil, handleShowOperationSyncWaitError(session, nil, operationName, fmt.Errorf("failed to get operation %q: %w", operationName, err))
 	}
 
-	// If operation is already done, return the status
+	// If operation is already done, format the fetched proto. Do not refetch:
+	// a redundant GetOperation can lose the completed result on cancel/deadline.
 	if op.GetDone() {
-		return s.executeAsyncMode(ctx, session, operationName)
+		return formatShowOperation(op)
 	}
 
 	// Start progress monitoring
@@ -435,8 +436,8 @@ func (s *ShowOperationStatement) executeSyncModeWithTicks(ctx context.Context, s
 		bar.SetCurrent(100)
 	}
 
-	// Return final operation status
-	return s.executeAsyncMode(ctx, session, operationName)
+	// Return final operation status from the last poll. Do not refetch.
+	return formatShowOperation(op)
 }
 
 const updateDatabaseDdlMetadataTypeURL = "type.googleapis.com/google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata"
@@ -476,7 +477,11 @@ func (s *ShowOperationStatement) executeAsyncMode(ctx context.Context, session *
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operation %q: %w", operationName, err)
 	}
+	return formatShowOperation(op)
+}
 
+// formatShowOperation renders a fetched long-running operation as a SHOW OPERATION result.
+func formatShowOperation(op *longrunningpb.Operation) (*Result, error) {
 	var rows []Row
 
 	// Handle different operation types
@@ -522,7 +527,7 @@ func (s *ShowOperationStatement) executeAsyncMode(ctx context.Context, session *
 	}
 
 	if len(rows) == 0 {
-		return nil, fmt.Errorf("operation %q not found or has no statements", operationName)
+		return nil, fmt.Errorf("operation %q not found or has no statements", op.GetName())
 	}
 
 	return &Result{


### PR DESCRIPTION
## Summary

- preserve the last identified operation while `SHOW OPERATION ... SYNC` is polling
- return a recovery hint on cancellation while preserving `errors.Is` semantics
- invalidate the schema cache only when the monitored operation is an identified database DDL operation
- cover cancellation, deadline, gRPC cancellation, DDL/non-DDL, and ordinary error paths

## Validation

- focused SHOW OPERATION and cancellation tests
- `make check` with golangci-lint v2.13.2
- `git diff --check origin/main...HEAD`

Fixes #761
