### PR TITLE
ci: update golangci-lint to v2.13.2

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4
+          version: v2.13.2
           args: --timeout=5m
 
   # Race detector on unit tests only (short mode, no Docker/emulator needed).


### PR DESCRIPTION
## Summary

- update the CI golangci-lint pin from v2.4 to v2.13.2
- keep the linter update separate from the GoReleaser scaffold work in #789

CI continues to use the Go 1.25 toolchain, where golangci-lint v2.4 still works. Developers running the repository with Go 1.27 encounter a loader panic because v2.4 was built with an older Go version and cannot analyze Go 1.27 source. golangci-lint v2.13 added Go 1.27 support while remaining compatible with the CI toolchain.

## Validation

- golangci-lint v2.13.2 version check
- `golangci-lint fmt --diff .`
- `golangci-lint run --timeout=5m`
- `make check`
- workflow YAML parse
- `git diff --check origin/main...HEAD`
