### PR TITLE
build(deps): bump spanvalue to v0.8.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/apstndb/spannerplan v0.3.0
 	github.com/apstndb/spanstats v0.1.0
 	github.com/apstndb/spantype v0.3.13
-	github.com/apstndb/spanvalue v0.8.3
+	github.com/apstndb/spanvalue v0.8.4
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/cloudspannerecosystem/memefish v0.8.0
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/apstndb/spanstats v0.1.0 h1:wAPqtFn1AfQaIudB4HwTLiIPinwWJw/gQhgE7NQWV
 github.com/apstndb/spanstats v0.1.0/go.mod h1:DFGYC9e7WE0BFQL0st6EQwrl1Pn2FuvDWSefwI9FTWc=
 github.com/apstndb/spantype v0.3.13 h1:FTP3zUpVXMfPlZ3P+1RK6SYHND+96YVht0I+ZHGIzMc=
 github.com/apstndb/spantype v0.3.13/go.mod h1:9eHowE7LcJ155ukCYUyuNzVAw9Ne0GXPXpHmu+iaMyk=
-github.com/apstndb/spanvalue v0.8.3 h1:7cjBIVnJ0lIqRZTL560eT5lC6dJjRxAo6svX8zwksPo=
-github.com/apstndb/spanvalue v0.8.3/go.mod h1:krLMj3J9sKS/IBLIUkEUlFufcxeLkIGJon+ypSPgrl0=
+github.com/apstndb/spanvalue v0.8.4 h1:1xpGflaLKQEUeFmSkpE25q2aainyM5zBkyy1FHbVLRI=
+github.com/apstndb/spanvalue v0.8.4/go.mod h1:krLMj3J9sKS/IBLIUkEUlFufcxeLkIGJon+ypSPgrl0=
 github.com/apstndb/structfields v0.1.0 h1:TQbi8EpzLyDr1GOsLWJfMQrtw+cq7BQhNCHhqZTCtEg=
 github.com/apstndb/structfields v0.1.0/go.mod h1:iZuSnr5cvgVvMaEhm0ceB+auA+MeNmA1mtnBA05m9Qw=
 github.com/apstndb/structfields/spannertag v0.1.0 h1:faXv5yYgKHV4DA3V0UpL4D9cTgMM87yacNbno0p3ulM=


### PR DESCRIPTION
## Summary

- update `github.com/apstndb/spanvalue` from v0.8.3 to v0.8.4

v0.8.4 adds lazy row-sequence formatting, JSONL row-sequence support, and deferred-metadata writer conveniences. Existing spanner-mycli call sites remain source-compatible, so this is a dependency-only change.

## Validation

- `go mod verify`
- focused `internal/mycli` and decoder tests
- `make check` with golangci-lint v2.13.2
- `git diff --check origin/main...HEAD`
