### PR TITLE
fix: unblock pager writes after child exit or cancel

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -386,7 +386,9 @@ func (c *Cli) PrintResult(screenWidth int, result *Result, interactive bool, inp
 		w = c.GetWriter()
 	}
 
-	sink := c.newResultSink(w, input)
+	// PrintResult has no statement context; pager lifetime is stdin EOF plus
+	// Wait. executeStatement passes its cancellable context instead.
+	sink := c.newResultSink(context.Background(), w, input)
 	if err := printResult(c.SystemVariables, screenWidth, sink, result, interactive); err != nil {
 		sink.abort()
 		return err
@@ -547,7 +549,7 @@ func (c *Cli) executeStatement(ctx context.Context, stmt Statement, interactive 
 	outW := w
 	var sink *resultSink
 	if !isMetaCommand {
-		sink = c.newResultSink(w, input)
+		sink = c.newResultSink(ctx, w, input)
 		// On the error path abort() closes a fence opened by already-streamed
 		// rows and releases the pager; if nothing was written it stays silent.
 		defer sink.abort()

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -353,7 +353,7 @@ Empty set
 				// displayResult does, so decorated cases (markdown fence,
 				// echo) assert the full byte-identical output.
 				cli := &Cli{SystemVariables: test.sysVars}
-				sink := cli.newResultSink(out, test.input)
+				sink := cli.newResultSink(context.Background(), out, test.input)
 				err := printResult(test.sysVars, test.screenWidth, sink, test.result, false)
 				if err == nil {
 					err = sink.finish()

--- a/internal/mycli/result_sink.go
+++ b/internal/mycli/result_sink.go
@@ -17,11 +17,13 @@ package mycli
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
+	"sync"
 
 	"github.com/kballard/go-shellquote"
 )
@@ -45,20 +47,25 @@ import (
 // time, not at statement submission).
 type resultSink struct {
 	c     *Cli
-	dst   io.Writer // caller-provided destination
-	input string    // raw statement text for CLI_ECHO_INPUT
+	ctx   context.Context // statement context; PrintResult uses Background
+	dst   io.Writer       // caller-provided destination
+	input string          // raw statement text for CLI_ECHO_INPUT
 
 	out       io.Writer    // active destination once started (pager pipe or dst)
 	startErr  error        // sticky pager start failure
 	fenceOpen bool         // opening ```sql fence was written
-	stopPager func() error // closes the pager pipe and waits; nil without pager
+	stopPager func() error // closes pager stdin and waits once; nil without pager
 	done      bool
 }
 
 // newResultSink returns a sink writing to dst. input is echoed when
-// CLI_ECHO_INPUT is enabled.
-func (c *Cli) newResultSink(dst io.Writer, input string) *resultSink {
-	return &resultSink{c: c, dst: dst, input: input}
+// CLI_ECHO_INPUT is enabled. ctx bounds the pager child only; it cannot
+// interrupt an independently blocking dst (unpaged output).
+func (c *Cli) newResultSink(ctx context.Context, dst io.Writer, input string) *resultSink {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &resultSink{c: c, ctx: ctx, dst: dst, input: input}
 }
 
 // start lazily initializes the sink: it starts the pager when CLI_USE_PAGER
@@ -70,10 +77,14 @@ func (s *resultSink) start() error {
 	if s.out != nil || s.startErr != nil {
 		return s.startErr
 	}
+	if err := s.ctx.Err(); err != nil {
+		s.startErr = err
+		return err
+	}
 
 	out := s.dst
 	if s.c.SystemVariables.Display.UsePager {
-		pw, stop, err := startPager(s.dst)
+		pw, stop, err := startPager(s.ctx, s.dst)
 		if err != nil {
 			s.startErr = err
 			return err
@@ -84,23 +95,49 @@ func (s *resultSink) start() error {
 	s.out = out
 
 	if s.c.SystemVariables.Display.MarkdownCodeblock {
-		fmt.Fprintln(out, "```sql")
+		if _, err := fmt.Fprintln(out, "```sql"); err != nil {
+			s.startErr = s.wrapPagerWrite(err)
+			return s.startErr
+		}
 		s.fenceOpen = true
 	}
 	// The echo is intentionally sent through the sink (not TtyOutStream) so it
 	// is captured in tee files, providing complete context in logs showing
 	// which queries produced which results.
 	if s.c.SystemVariables.Feature.EchoInput && s.input != "" {
-		fmt.Fprintln(out, s.input+";")
+		if _, err := fmt.Fprintln(out, s.input+";"); err != nil {
+			s.startErr = s.wrapPagerWrite(err)
+			return s.startErr
+		}
 	}
 	return nil
 }
 
 func (s *resultSink) Write(p []byte) (int, error) {
+	if err := s.ctx.Err(); err != nil {
+		return 0, err
+	}
 	if err := s.start(); err != nil {
 		return 0, err
 	}
-	return s.out.Write(p)
+	n, err := s.out.Write(p)
+	if err != nil {
+		return n, s.wrapPagerWrite(err)
+	}
+	return n, nil
+}
+
+func (s *resultSink) wrapPagerWrite(err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctxErr := s.ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if s.stopPager == nil {
+		return err
+	}
+	return fmt.Errorf("pager write: %w", err)
 }
 
 // finish emits the closing decoration and shuts the pager down. It
@@ -141,15 +178,26 @@ func (s *resultSink) abort() {
 		fmt.Fprintln(s.out, "```")
 	}
 	if s.stopPager != nil {
-		_ = s.stopPager() // errors already logged by stopPager
+		_ = s.stopPager() // Wait errors are logged by stop; see startPager.
 	}
 }
 
-// startPager launches the pager command from $PAGER (default "less") writing
-// to w and returns the pipe feeding it plus a function that closes the pipe
-// and waits for the pager to exit. Close/wait failures are logged, not
-// returned, preserving the historical behavior of the pager teardown.
-func startPager(w io.Writer) (io.Writer, func() error, error) {
+// startPager launches $PAGER (default "less") writing to w and returns the
+// stdin writer plus a stop func that closes stdin and Wait()s exactly once.
+//
+// Ownership uses exec.StdinPipe, not an unmanaged io.Pipe as Cmd.Stdin.
+// Cmd.Wait waits for the extra copy goroutine that io.Copy's a non-file
+// Stdin into the child; if the child exits first that copy returns while the
+// PipeWriter stays open, so a later Write blocks forever. StdinPipe is an
+// *os.File, so the child closing stdin yields EPIPE and unblocks writers.
+// CommandContext(ctx) kills the child on statement cancel, which is the same
+// unblock path. stop does not return Wait errors (historical teardown);
+// incomplete output is reported by Write instead, so a user-quit pager is not
+// treated as a fully successful statement.
+func startPager(ctx context.Context, w io.Writer) (io.Writer, func() error, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	pagerpath := cmp.Or(os.Getenv("PAGER"), "less")
 
 	split, err := shellquote.Split(pagerpath)
@@ -161,25 +209,34 @@ func startPager(w io.Writer) (io.Writer, func() error, error) {
 	if len(split) == 0 {
 		return nil, nil, fmt.Errorf("invalid pager command: %q", pagerpath)
 	}
-	cmd := exec.CommandContext(context.Background(), split[0], split[1:]...)
-
-	pr, pw := io.Pipe()
-	cmd.Stdin = pr
+	cmd := exec.CommandContext(ctx, split[0], split[1:]...)
 	cmd.Stdout = w
 
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to start pager: %w", err)
+	}
 	if err := cmd.Start(); err != nil {
 		slog.Error("failed to start pager command", "err", err)
+		_ = stdin.Close()
 		return nil, nil, fmt.Errorf("failed to start pager: %w", err)
 	}
 
+	var once sync.Once
 	stop := func() error {
-		if err := pw.Close(); err != nil {
-			slog.Error("failed to close pipe", "err", err)
-		}
-		if err := cmd.Wait(); err != nil {
-			slog.Error("failed to wait for pager command", "err", err)
-		}
+		once.Do(func() {
+			if err := stdin.Close(); err != nil && !ignorePagerCloseErr(err) {
+				slog.Error("failed to close pager stdin", "err", err)
+			}
+			if err := cmd.Wait(); err != nil {
+				slog.Error("failed to wait for pager command", "err", err)
+			}
+		})
 		return nil
 	}
-	return pw, stop, nil
+	return stdin, stop, nil
+}
+
+func ignorePagerCloseErr(err error) bool {
+	return errors.Is(err, os.ErrClosed) || errors.Is(err, io.ErrClosedPipe)
 }

--- a/internal/mycli/result_sink.go
+++ b/internal/mycli/result_sink.go
@@ -94,6 +94,14 @@ func (s *resultSink) start() error {
 	}
 	s.out = out
 
+	// Test seam: fail after the pager is owned and before decorations so
+	// finish/abort must still Wait. Production leaves this nil.
+	if testFailPagerDecorate != nil {
+		err := testFailPagerDecorate()
+		s.startErr = err
+		return err
+	}
+
 	if s.c.SystemVariables.Display.MarkdownCodeblock {
 		if _, err := fmt.Fprintln(out, "```sql"); err != nil {
 			s.startErr = s.wrapPagerWrite(err)
@@ -144,22 +152,21 @@ func (s *resultSink) wrapPagerWrite(err error) error {
 // force-starts the sink so statements that produced no other output still
 // emit the decoration pair (e.g. an empty ```sql fence), matching the
 // historical printResult output byte for byte. Call it only on the success
-// path; use abort for error unwinding.
+// path; use abort for error unwinding. The pager is reaped even when start
+// or the closing fence fails, and done is set only after that reap.
 func (s *resultSink) finish() error {
 	if s.done {
 		return nil
 	}
+	err := s.start()
+	if err == nil && s.fenceOpen {
+		if _, ferr := fmt.Fprintln(s.out, "```"); ferr != nil {
+			err = s.wrapPagerWrite(ferr)
+		}
+	}
+	err = errors.Join(err, s.reapPager())
 	s.done = true
-	if err := s.start(); err != nil {
-		return err
-	}
-	if s.fenceOpen {
-		fmt.Fprintln(s.out, "```")
-	}
-	if s.stopPager != nil {
-		return s.stopPager()
-	}
-	return nil
+	return err
 }
 
 // abort unwinds the sink on the error path without forcing decorations: a
@@ -170,16 +177,20 @@ func (s *resultSink) abort() {
 	if s.done {
 		return
 	}
-	s.done = true
-	if s.out == nil {
-		return // never started; nothing to unwind
-	}
-	if s.fenceOpen {
+	if s.out != nil && s.fenceOpen {
 		fmt.Fprintln(s.out, "```")
 	}
-	if s.stopPager != nil {
-		_ = s.stopPager() // Wait errors are logged by stop; see startPager.
+	_ = s.reapPager()
+	s.done = true
+}
+
+func (s *resultSink) reapPager() error {
+	stop := s.stopPager
+	s.stopPager = nil
+	if stop == nil {
+		return nil
 	}
+	return stop()
 }
 
 // startPager launches $PAGER (default "less") writing to w and returns the
@@ -191,9 +202,12 @@ func (s *resultSink) abort() {
 // PipeWriter stays open, so a later Write blocks forever. StdinPipe is an
 // *os.File, so the child closing stdin yields EPIPE and unblocks writers.
 // CommandContext(ctx) kills the child on statement cancel, which is the same
-// unblock path. stop does not return Wait errors (historical teardown);
-// incomplete output is reported by Write instead, so a user-quit pager is not
-// treated as a fully successful statement.
+// unblock path. stop Wait()s exactly once and returns close/wait errors:
+// canceled contexts map to ctx.Err(), and a nonzero child exit after stdin
+// EOF is an unexpected pager failure (not full success). Interactive user
+// quit while bytes are still being written already fails at Write (EPIPE).
+// If the entire payload fit in the OS pipe and the pager exited 0 after
+// reading only a prefix, that incomplete display is not detectable from Wait.
 func startPager(ctx context.Context, w io.Writer) (io.Writer, func() error, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -223,16 +237,25 @@ func startPager(ctx context.Context, w io.Writer) (io.Writer, func() error, erro
 	}
 
 	var once sync.Once
+	var stopErr error
 	stop := func() error {
 		once.Do(func() {
 			if err := stdin.Close(); err != nil && !ignorePagerCloseErr(err) {
 				slog.Error("failed to close pager stdin", "err", err)
+				stopErr = err
 			}
 			if err := cmd.Wait(); err != nil {
+				if ctx.Err() != nil {
+					stopErr = ctx.Err()
+					return
+				}
 				slog.Error("failed to wait for pager command", "err", err)
+				if stopErr == nil {
+					stopErr = fmt.Errorf("pager wait: %w", err)
+				}
 			}
 		})
-		return nil
+		return stopErr
 	}
 	return stdin, stop, nil
 }
@@ -240,3 +263,8 @@ func startPager(ctx context.Context, w io.Writer) (io.Writer, func() error, erro
 func ignorePagerCloseErr(err error) bool {
 	return errors.Is(err, os.ErrClosed) || errors.Is(err, io.ErrClosedPipe)
 }
+
+// testFailPagerDecorate is invoked after a pager is acquired and before
+// decorations. Production leaves it nil. Tests must not run in parallel
+// with other pager tests while it is set.
+var testFailPagerDecorate func() error

--- a/internal/mycli/result_sink_pager_proc_unix_test.go
+++ b/internal/mycli/result_sink_pager_proc_unix_test.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package mycli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configurePagerSubprocess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killPagerSubprocess(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/mycli/result_sink_pager_proc_unix_test.go
+++ b/internal/mycli/result_sink_pager_proc_unix_test.go
@@ -1,5 +1,19 @@
 //go:build unix
 
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mycli
 
 import (

--- a/internal/mycli/result_sink_pager_proc_windows_test.go
+++ b/internal/mycli/result_sink_pager_proc_windows_test.go
@@ -1,5 +1,19 @@
 //go:build windows
 
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mycli
 
 import "os/exec"

--- a/internal/mycli/result_sink_pager_proc_windows_test.go
+++ b/internal/mycli/result_sink_pager_proc_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package mycli
+
+import "os/exec"
+
+func configurePagerSubprocess(cmd *exec.Cmd) {}
+
+func killPagerSubprocess(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/internal/mycli/result_sink_pager_test.go
+++ b/internal/mycli/result_sink_pager_test.go
@@ -1,0 +1,384 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
+)
+
+const pagerHelperEnv = "SPANNER_MYCLI_PAGER_HELPER"
+
+func init() {
+	mode := os.Getenv(pagerHelperEnv)
+	if mode == "" {
+		return
+	}
+	os.Exit(runPagerHelper(mode))
+}
+
+func runPagerHelper(mode string) int {
+	switch mode {
+	case "cat":
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+		return 0
+	case "head1":
+		line, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
+		if len(line) == 0 && err != nil && !errors.Is(err, io.EOF) {
+			return 1
+		}
+		_, _ = os.Stdout.Write(line)
+		return 0
+	case "exit2":
+		return 2
+	case "hang":
+		fmt.Println("pager-hang-ready")
+		_ = os.Stdout.Sync()
+		select {}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown pager helper %q\n", mode)
+		return 2
+	}
+}
+
+func setPagerHelper(t *testing.T, mode string) {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PAGER", exe)
+	t.Setenv(pagerHelperEnv, mode)
+}
+
+func waitErr(t *testing.T, done <-chan error, d time.Duration, what string) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(d):
+		t.Fatalf("watchdog: %s did not finish", what)
+		return nil
+	}
+}
+
+func largePagerInput() string {
+	return strings.Repeat("audit line\n", 1<<16)
+}
+
+func TestStartPagerCompleteConsumption(t *testing.T) {
+	setPagerHelper(t, "cat")
+	var buf bytes.Buffer
+	out, stop, err := startPager(context.Background(), &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := "hello pager\nsecond line\n"
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(out, payload)
+		done <- err
+	}()
+	if err := waitErr(t, done, 3*time.Second, "cat pager write"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("repeated stop: %v", err)
+	}
+	if got := buf.String(); got != payload {
+		t.Fatalf("pager stdout = %q, want %q", got, payload)
+	}
+}
+
+func TestStartPagerEarlyExit(t *testing.T) {
+	setPagerHelper(t, "head1")
+	out, stop, err := startPager(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stop() }()
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(out, largePagerInput())
+		done <- err
+	}()
+	err = waitErr(t, done, 3*time.Second, "early-exit pager write")
+	if err == nil {
+		t.Fatal("large write succeeded after pager early exit; want write error")
+	}
+}
+
+func TestStartPagerEarlyExitHeadUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses head(1)")
+	}
+	t.Setenv("PAGER", "head -n 1")
+	out, stop, err := startPager(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stop() }()
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(out, largePagerInput())
+		done <- err
+	}()
+	err = waitErr(t, done, 3*time.Second, "head -n 1 pager write")
+	if err == nil {
+		t.Fatal("large write succeeded after head -n 1 exit; want write error")
+	}
+}
+
+func TestStartPagerFailingChild(t *testing.T) {
+	setPagerHelper(t, "exit2")
+	out, stop, err := startPager(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stop() }()
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(out, largePagerInput())
+		done <- err
+	}()
+	if err := waitErr(t, done, 3*time.Second, "failing pager write"); err == nil {
+		t.Fatal("write succeeded through pager that exited 2")
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("stop after failing child: %v", err)
+	}
+}
+
+func TestStartPagerInvalidAndMissingCommand(t *testing.T) {
+	t.Run("whitespace", func(t *testing.T) {
+		t.Setenv("PAGER", "   ")
+		_, _, err := startPager(context.Background(), io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "invalid pager command") {
+			t.Fatalf("err = %v, want invalid pager command", err)
+		}
+	})
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("PAGER", "spanner-mycli-pager-command-missing")
+		_, stop, err := startPager(context.Background(), io.Discard)
+		if err == nil {
+			_ = stop()
+			t.Fatal("missing pager command started")
+		}
+		if !strings.Contains(err.Error(), "failed to start pager") {
+			t.Fatalf("err = %v, want failed to start pager", err)
+		}
+	})
+}
+
+type readyWriter struct {
+	ready chan struct{}
+	once  sync.Once
+}
+
+func (w *readyWriter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte("pager-hang-ready")) {
+		w.once.Do(func() { close(w.ready) })
+	}
+	return len(p), nil
+}
+
+func TestStartPagerCancelDuringBlockedWrite(t *testing.T) {
+	setPagerHelper(t, "hang")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stdout := &readyWriter{ready: make(chan struct{})}
+	out, stop, err := startPager(ctx, stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stop() }()
+
+	select {
+	case <-stdout.ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("hang pager did not print ready")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := out.Write(bytes.Repeat([]byte("x"), 1<<20))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("blocked write returned before cancel: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancel()
+	err = waitErr(t, done, 3*time.Second, "canceled pager write")
+	if err == nil {
+		t.Fatal("canceled write succeeded")
+	}
+	if !errors.Is(err, context.Canceled) && !isBrokenPipe(err) {
+		t.Logf("canceled write error: %v", err)
+	}
+}
+
+func TestResultSinkCancelBeforeLazyStart(t *testing.T) {
+	setPagerHelper(t, "hang")
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+	cli.SystemVariables.Display.MarkdownCodeblock = true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var buf bytes.Buffer
+	sink := cli.newResultSink(ctx, &buf, "SHOW VARIABLES")
+	n, err := sink.Write([]byte("should-not-write"))
+	if n != 0 {
+		t.Fatalf("wrote %d bytes before lazy start", n)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Write err = %v, want context.Canceled", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("canceled sink started pager/decorations: %q", buf.String())
+	}
+	sink.abort()
+	sink.abort()
+	if err := sink.finish(); err != nil {
+		t.Fatalf("finish after abort: %v", err)
+	}
+}
+
+func TestResultSinkRepeatedFinishAbort(t *testing.T) {
+	setPagerHelper(t, "cat")
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+	var buf bytes.Buffer
+	sink := cli.newResultSink(context.Background(), &buf, "")
+	if _, err := sink.Write([]byte("row\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.finish(); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.finish(); err != nil {
+		t.Fatalf("repeated finish: %v", err)
+	}
+	sink.abort()
+	sink.abort()
+	if !strings.Contains(buf.String(), "row") {
+		t.Fatalf("missing payload: %q", buf.String())
+	}
+}
+
+// largeStreamStatement writes a payload larger than a typical OS pipe
+// buffer through the session output writer, which executeStatement binds
+// to the resultSink. It exists only to exercise the streamed pager path.
+type largeStreamStatement struct{}
+
+func (largeStreamStatement) isDetachedCompatible() {}
+
+func (largeStreamStatement) Execute(_ context.Context, session *Session) (*Result, error) {
+	w := session.outputWriter()
+	if w == nil {
+		return nil, errors.New("no output writer")
+	}
+	if _, err := io.WriteString(w, largePagerInput()); err != nil {
+		return nil, err
+	}
+	return &Result{Streamed: true, KeepVariables: true}, nil
+}
+
+func TestExecuteStatementPagerEarlyExit(t *testing.T) {
+	setPagerHelper(t, "head1")
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, err := cli.executeStatement(context.Background(), largeStreamStatement{}, false, "SELECT large", &buf)
+		done <- err
+	}()
+	err := waitErr(t, done, 5*time.Second, "executeStatement pager early exit")
+	if err == nil {
+		t.Fatal("executeStatement succeeded after pager early exit; incomplete output must not be full success")
+	}
+}
+
+func TestExecuteStatementPagerCancelBeforeStart(t *testing.T) {
+	setPagerHelper(t, "hang")
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, err := cli.executeStatement(ctx, &ShowVariablesStatement{}, false, "SHOW VARIABLES", &buf)
+		done <- err
+	}()
+	err := waitErr(t, done, 5*time.Second, "executeStatement cancel before pager start")
+	if err == nil {
+		t.Fatal("executeStatement succeeded on canceled context")
+	}
+	if strings.Contains(buf.String(), "pager-hang-ready") {
+		t.Fatalf("canceled executeStatement started hang pager: %q", buf.String())
+	}
+}
+
+func TestPrintResultPagerEarlyExit(t *testing.T) {
+	setPagerHelper(t, "head1")
+	outBuf := &bytes.Buffer{}
+	sysVars := &systemVariables{
+		Display: DisplayVars{
+			UsePager:  true,
+			CLIFormat: enums.DisplayModeCSV,
+		},
+		StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), outBuf, outBuf),
+	}
+	cli := &Cli{SystemVariables: sysVars}
+	result := &Result{TableHeader: toTableHeader("col1"), Rows: []Row{toRow(largePagerInput())}}
+	done := make(chan error, 1)
+	go func() {
+		done <- cli.PrintResult(80, result, false, "", outBuf)
+	}()
+	err := waitErr(t, done, 5*time.Second, "PrintResult pager early exit")
+	if err == nil {
+		t.Fatal("PrintResult succeeded after pager early exit")
+	}
+}
+
+func isBrokenPipe(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.ErrClosedPipe) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "broken pipe") || strings.Contains(msg, "pipe")
+}

--- a/internal/mycli/result_sink_pager_test.go
+++ b/internal/mycli/result_sink_pager_test.go
@@ -523,6 +523,9 @@ func TestPagerReadyTimeoutCleanupCancelsBeforeWait(t *testing.T) {
 	cmd := pagerTestCommand(t, "^TestPagerHangSilentReadyTimeoutInner$")
 	cmd.Env = append(cmd.Env, pagerReadyFailEnv+"=1")
 	configurePagerSubprocess(cmd)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
 	done := make(chan error, 1)
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
@@ -532,6 +535,10 @@ func TestPagerReadyTimeoutCleanupCancelsBeforeWait(t *testing.T) {
 	case err := <-done:
 		if err == nil {
 			t.Fatal("inner test passed; want readiness assertion failure")
+		}
+		got := out.String()
+		if !strings.Contains(got, "hang pager did not print ready") {
+			t.Fatalf("inner output missing readiness assertion marker:\n%s", got)
 		}
 	case <-time.After(5 * time.Second):
 		killPagerSubprocess(cmd)
@@ -619,6 +626,10 @@ func TestStartPagerHelperPathWithSpacesUnquotedFails(t *testing.T) {
 	if err == nil {
 		t.Fatalf("unquoted space path succeeded; want helper startup failure\n%s", out)
 	}
+	got := string(out)
+	if !strings.Contains(got, "failed to start pager") {
+		t.Fatalf("unquoted space path missing helper-startup failure:\n%s", got)
+	}
 }
 
 func pagerTestCommand(t *testing.T, run string) *exec.Cmd {
@@ -627,7 +638,7 @@ func pagerTestCommand(t *testing.T, run string) *exec.Cmd {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command(exe, "-test.run="+run, "-test.count=1")
+	cmd := exec.Command(exe, "-test.run="+run, "-test.count=1", "-test.v")
 	cmd.Env = filterEnv(os.Environ(), pagerHelperEnv, pagerReadyFailEnv, pagerStopFirstEnv, pagerUnquotedEnv)
 	return cmd
 }

--- a/internal/mycli/result_sink_pager_test.go
+++ b/internal/mycli/result_sink_pager_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -30,9 +32,15 @@ import (
 
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
+	"github.com/kballard/go-shellquote"
 )
 
-const pagerHelperEnv = "SPANNER_MYCLI_PAGER_HELPER"
+const (
+	pagerHelperEnv    = "SPANNER_MYCLI_PAGER_HELPER"
+	pagerReadyFailEnv = "SPANNER_MYCLI_PAGER_READY_FAIL"
+	pagerStopFirstEnv = "SPANNER_MYCLI_PAGER_STOP_FIRST"
+	pagerUnquotedEnv  = "SPANNER_MYCLI_PAGER_UNQUOTED"
+)
 
 func init() {
 	mode := os.Getenv(pagerHelperEnv)
@@ -63,6 +71,8 @@ func runPagerHelper(mode string) int {
 		fmt.Println("pager-hang-ready")
 		_ = os.Stdout.Sync()
 		select {}
+	case "hang-silent":
+		select {}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown pager helper %q\n", mode)
 		return 2
@@ -75,8 +85,20 @@ func setPagerHelper(t *testing.T, mode string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PAGER", exe)
+	pager := exe
+	if os.Getenv(pagerUnquotedEnv) != "1" {
+		pager = shellquote.Join(exe)
+	}
+	t.Setenv("PAGER", pager)
 	t.Setenv(pagerHelperEnv, mode)
+}
+
+// reapPagerAfterCancel registers stop then cancel so Cleanup LIFO cancels
+// the child before Wait. Hang helpers do not exit on stdin EOF.
+func reapPagerAfterCancel(t *testing.T, cancel context.CancelFunc, stop func() error) {
+	t.Helper()
+	t.Cleanup(func() { _ = stop() })
+	t.Cleanup(cancel)
 }
 
 func waitErr(t *testing.T, done <-chan error, d time.Duration, what string) error {
@@ -191,8 +213,7 @@ func TestStartPagerCancelAfterSuccessfulWrite(t *testing.T) {
 		cancel()
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = stop() })
-	t.Cleanup(cancel)
+	reapPagerAfterCancel(t, cancel, stop)
 
 	select {
 	case <-stdout.ready:
@@ -308,13 +329,13 @@ func (w *readyWriter) Write(p []byte) (int, error) {
 func TestStartPagerCancelDuringBlockedWrite(t *testing.T) {
 	setPagerHelper(t, "hang")
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	stdout := &readyWriter{ready: make(chan struct{})}
 	out, stop, err := startPager(ctx, stdout)
 	if err != nil {
+		cancel()
 		t.Fatal(err)
 	}
-	defer func() { _ = stop() }()
+	reapPagerAfterCancel(t, cancel, stop)
 
 	select {
 	case <-stdout.ready:
@@ -476,4 +497,170 @@ func isBrokenPipe(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "broken pipe") || strings.Contains(msg, "pipe")
+}
+
+func TestPagerHangSilentReadyTimeoutInner(t *testing.T) {
+	if os.Getenv(pagerReadyFailEnv) != "1" {
+		t.Skip("inner subprocess for ready-timeout cleanup")
+	}
+	setPagerHelper(t, "hang-silent")
+	ctx, cancel := context.WithCancel(context.Background())
+	_, stop, err := startPager(ctx, io.Discard)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if os.Getenv(pagerStopFirstEnv) == "1" {
+		t.Cleanup(cancel)
+		t.Cleanup(func() { _ = stop() })
+	} else {
+		reapPagerAfterCancel(t, cancel, stop)
+	}
+	t.Fatal("hang pager did not print ready")
+}
+
+func TestPagerReadyTimeoutCleanupCancelsBeforeWait(t *testing.T) {
+	cmd := pagerTestCommand(t, "^TestPagerHangSilentReadyTimeoutInner$")
+	cmd.Env = append(cmd.Env, pagerReadyFailEnv+"=1")
+	configurePagerSubprocess(cmd)
+	done := make(chan error, 1)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("inner test passed; want readiness assertion failure")
+		}
+	case <-time.After(5 * time.Second):
+		killPagerSubprocess(cmd)
+		t.Fatal("outer watchdog: inner ready-timeout test did not exit after cancel-then-wait")
+	}
+}
+
+func TestPagerReadyTimeoutStopFirstNeedsKill(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group kill of hang helper is Unix-only; Windows limitation recorded")
+	}
+	cmd := pagerTestCommand(t, "^TestPagerHangSilentReadyTimeoutInner$")
+	cmd.Env = append(cmd.Env, pagerReadyFailEnv+"=1", pagerStopFirstEnv+"=1")
+	configurePagerSubprocess(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		t.Fatalf("stop-first inner exited before outer wait (%v); cleanup hang was not reproduced", err)
+	case <-time.After(1500 * time.Millisecond):
+	}
+	killPagerSubprocess(cmd)
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("killed stop-first inner did not exit")
+	}
+}
+
+func TestStartPagerHelperPathWithSpaces(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("space-path helper copy is exercised on Unix; Windows path quoting is covered by shellquote.Join in setPagerHelper")
+	}
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(t.TempDir(), "pager tests")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "mycli.test")
+	if err := copyFile(dst, src); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(dst, "-test.run=^TestStartPagerCompleteConsumption$", "-test.count=1", "-test.v")
+	cmd.Env = filterEnv(os.Environ(), pagerHelperEnv, pagerReadyFailEnv, pagerStopFirstEnv, pagerUnquotedEnv)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("space-path helper test failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "PASS") {
+		t.Fatalf("space-path helper output missing PASS:\n%s", out)
+	}
+}
+
+func TestStartPagerHelperPathWithSpacesUnquotedFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("space-path negative quoting is Unix-only")
+	}
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(t.TempDir(), "pager tests")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "mycli.test")
+	if err := copyFile(dst, src); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(dst, "-test.run=^TestStartPagerCompleteConsumption$", "-test.count=1")
+	cmd.Env = append(filterEnv(os.Environ(), pagerHelperEnv, pagerReadyFailEnv, pagerStopFirstEnv, pagerUnquotedEnv), pagerUnquotedEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("unquoted space path succeeded; want helper startup failure\n%s", out)
+	}
+}
+
+func pagerTestCommand(t *testing.T, run string) *exec.Cmd {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(exe, "-test.run="+run, "-test.count=1")
+	cmd.Env = filterEnv(os.Environ(), pagerHelperEnv, pagerReadyFailEnv, pagerStopFirstEnv, pagerUnquotedEnv)
+	return cmd
+}
+
+func filterEnv(env []string, drop ...string) []string {
+	skip := make(map[string]struct{}, len(drop))
+	for _, k := range drop {
+		skip[k] = struct{}{}
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		k, _, _ := strings.Cut(kv, "=")
+		if _, found := skip[k]; found {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func copyFile(dst, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
 }

--- a/internal/mycli/result_sink_pager_test.go
+++ b/internal/mycli/result_sink_pager_test.go
@@ -56,6 +56,9 @@ func runPagerHelper(mode string) int {
 		return 0
 	case "exit2":
 		return 2
+	case "cat-exit2":
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+		return 2
 	case "hang":
 		fmt.Println("pager-hang-ready")
 		_ = os.Stdout.Sync()
@@ -157,6 +160,98 @@ func TestStartPagerEarlyExitHeadUnix(t *testing.T) {
 	}
 }
 
+func TestStartPagerShortOutputNonzeroExit(t *testing.T) {
+	setPagerHelper(t, "cat-exit2")
+	out, stop, err := startPager(context.Background(), io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = stop() })
+	if _, err := io.WriteString(out, "one line\n"); err != nil {
+		t.Fatalf("short write: %v", err)
+	}
+	err = stop()
+	if err == nil {
+		t.Fatal("stop succeeded after pager exited 2; short output must not hide nonzero Wait")
+	}
+	if !strings.Contains(err.Error(), "exit status 2") {
+		t.Fatalf("stop err = %v, want pager wait exit status 2", err)
+	}
+	if err := stop(); err == nil || !strings.Contains(err.Error(), "exit status 2") {
+		t.Fatalf("repeated stop should keep the wait error, got %v", err)
+	}
+}
+
+func TestStartPagerCancelAfterSuccessfulWrite(t *testing.T) {
+	setPagerHelper(t, "hang")
+	ctx, cancel := context.WithCancel(context.Background())
+	stdout := &readyWriter{ready: make(chan struct{})}
+	out, stop, err := startPager(ctx, stdout)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = stop() })
+	t.Cleanup(cancel)
+
+	select {
+	case <-stdout.ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("hang pager did not print ready")
+	}
+	if _, err := io.WriteString(out, "fits-in-pipe\n"); err != nil {
+		t.Fatalf("short write before cancel: %v", err)
+	}
+	cancel()
+	err = stop()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("stop after cancel = %v, want context.Canceled", err)
+	}
+}
+
+func TestResultSinkFinishDecorationFailureReaps(t *testing.T) {
+	// Package-level decorate hook; do not run in parallel with other pager tests.
+	testFailPagerDecorate = func() error { return errors.New("injected decorate failure") }
+	t.Cleanup(func() { testFailPagerDecorate = nil })
+
+	setPagerHelper(t, "exit2")
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+	cli.SystemVariables.Display.MarkdownCodeblock = true
+	var buf bytes.Buffer
+	sink := cli.newResultSink(context.Background(), &buf, "SHOW VARIABLES")
+	err := sink.finish()
+	if err == nil {
+		t.Fatal("finish succeeded after injected decorate failure")
+	}
+	if !strings.Contains(err.Error(), "injected decorate failure") {
+		t.Fatalf("finish err = %v, want injected decorate failure", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 2") {
+		t.Fatalf("finish err = %v, want joined pager wait so the child was reaped", err)
+	}
+	sink.abort()
+	if err := sink.finish(); err != nil {
+		t.Fatalf("repeated finish after abort: %v", err)
+	}
+}
+
+func TestExecuteStatementShortPagerFailure(t *testing.T) {
+	setPagerHelper(t, "cat-exit2")
+	cli := newDecorationTestCli()
+	cli.SystemVariables.Display.UsePager = true
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, err := cli.executeStatement(context.Background(), &ShowVariablesStatement{}, false, "SHOW VARIABLES", &buf)
+		done <- err
+	}()
+	err := waitErr(t, done, 5*time.Second, "executeStatement short pager failure")
+	if err == nil {
+		t.Fatal("executeStatement succeeded although pager exited 2 after consuming a short result")
+	}
+}
+
 func TestStartPagerFailingChild(t *testing.T) {
 	setPagerHelper(t, "exit2")
 	out, stop, err := startPager(context.Background(), io.Discard)
@@ -172,8 +267,8 @@ func TestStartPagerFailingChild(t *testing.T) {
 	if err := waitErr(t, done, 3*time.Second, "failing pager write"); err == nil {
 		t.Fatal("write succeeded through pager that exited 2")
 	}
-	if err := stop(); err != nil {
-		t.Fatalf("stop after failing child: %v", err)
+	if err := stop(); err == nil || !strings.Contains(err.Error(), "exit status 2") {
+		t.Fatalf("stop after failing child = %v, want pager wait exit status 2", err)
 	}
 }
 

--- a/internal/mycli/screen_width_vty_test.go
+++ b/internal/mycli/screen_width_vty_test.go
@@ -2,6 +2,7 @@ package mycli
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -177,7 +178,7 @@ func TestDisplayResultWithPty(t *testing.T) {
 			}
 
 			// Call displayResult with a per-statement sink, as executeStatement does
-			err = cli.displayResult(cli.newResultSink(tty, tt.input), tt.result, tt.interactive, tty)
+			err = cli.displayResult(cli.newResultSink(context.Background(), tty, tt.input), tt.result, tt.interactive, tty)
 			if err != nil {
 				t.Fatalf("displayResult() failed: %v", err)
 			}


### PR DESCRIPTION
## Summary

Fix an unbounded write hang when `CLI_USE_PAGER` is enabled and the pager exits before consuming a large result.

- Use `exec.StdinPipe` instead of an unmanaged `io.Pipe`, so child exit releases blocked writers.
- Tie the pager process to the statement context and reap it exactly once, including lazy-start and decoration failures.
- Propagate pager write, nonzero-exit, and cancellation errors instead of reporting successful output.
- Add subprocess regression tests for early exit, cancellation, complete consumption, startup failure, and finalization errors.

## Behavior and limits

`CLI_USE_PAGER` remains disabled by default. Quitting a pager while output is still being written returns a write error. If the complete payload fits in the OS pipe and the pager exits successfully after reading only a prefix, incomplete display is not detectable from the write or exit status.

Direct `PrintResult` callers have no statement context and retain a background context. An independently blocking output destination is not made cancellable by this change.

## Validation

- `make check` with Go 1.26.8 and golangci-lint 2.13.2, including emulator-backed tests.
- `make check-race` and repeated targeted race tests.
- Negative controls verified that regressions fail when wait errors are discarded or cleanup is skipped after a lazy-start failure.
