### PR TITLE
fix: mark MCP application errors with IsError

### DIFF
--- a/internal/mycli/bigquery_mcp_readonly_test.go
+++ b/internal/mycli/bigquery_mcp_readonly_test.go
@@ -36,7 +36,10 @@ func TestMCPReadOnlyGuardBigQuery(t *testing.T) {
 
 	t.Run("READONLY mutating script", func(t *testing.T) {
 		session := mycli.NewReadOnlySessionForTest(t)
-		got := callMCPExecuteStatement(t, session, mutatingScript)
+		got, isError := callMCPExecuteStatement(t, session, mutatingScript)
+		if !isError {
+			t.Fatalf("IsError=false, want true; got %q", got)
+		}
 		if !strings.Contains(got, readOnlyErr) {
 			t.Fatalf("got %q, want READONLY error", got)
 		}
@@ -47,7 +50,10 @@ func TestMCPReadOnlyGuardBigQuery(t *testing.T) {
 
 	t.Run("READONLY query script", func(t *testing.T) {
 		session := mycli.NewReadOnlySessionForTest(t)
-		got := callMCPExecuteStatement(t, session, readOnlyScript)
+		got, isError := callMCPExecuteStatement(t, session, readOnlyScript)
+		if !isError {
+			t.Fatalf("IsError=false, want true; got %q", got)
+		}
 		if strings.Contains(got, readOnlyErr) {
 			t.Fatalf("query script wrongly blocked by READONLY: %q", got)
 		}
@@ -58,7 +64,10 @@ func TestMCPReadOnlyGuardBigQuery(t *testing.T) {
 
 	t.Run("READONLY false mutating script", func(t *testing.T) {
 		session := mycli.NewSessionForTest(t)
-		got := callMCPExecuteStatement(t, session, mutatingScript)
+		got, isError := callMCPExecuteStatement(t, session, mutatingScript)
+		if !isError {
+			t.Fatalf("IsError=false, want true; got %q", got)
+		}
 		if strings.Contains(got, readOnlyErr) {
 			t.Fatalf("READONLY=false wrongly blocked: %q", got)
 		}
@@ -69,7 +78,10 @@ func TestMCPReadOnlyGuardBigQuery(t *testing.T) {
 
 	t.Run("READONLY overlapping comment", func(t *testing.T) {
 		session := mycli.NewReadOnlySessionForTest(t)
-		got := callMCPExecuteStatement(t, session, overlapScript)
+		got, isError := callMCPExecuteStatement(t, session, overlapScript)
+		if !isError {
+			t.Fatalf("IsError=false, want true; got %q", got)
+		}
 		if !strings.Contains(got, readOnlyErr) {
 			t.Fatalf("got %q, want READONLY error", got)
 		}
@@ -80,7 +92,10 @@ func TestMCPReadOnlyGuardBigQuery(t *testing.T) {
 
 	t.Run("READONLY false overlapping comment", func(t *testing.T) {
 		session := mycli.NewSessionForTest(t)
-		got := callMCPExecuteStatement(t, session, overlapScript)
+		got, isError := callMCPExecuteStatement(t, session, overlapScript)
+		if !isError {
+			t.Fatalf("IsError=false, want true; got %q", got)
+		}
 		if strings.Contains(got, readOnlyErr) {
 			t.Fatalf("READONLY=false wrongly blocked: %q", got)
 		}
@@ -88,9 +103,20 @@ func TestMCPReadOnlyGuardBigQuery(t *testing.T) {
 			t.Fatalf("got %q, want missing BigQuery project", got)
 		}
 	})
+
+	t.Run("READONLY local HELP", func(t *testing.T) {
+		session := mycli.NewReadOnlySessionForTest(t)
+		got, isError := callMCPExecuteStatement(t, session, "HELP")
+		if isError {
+			t.Fatalf("HELP IsError=true, want false; got %q", got)
+		}
+		if !strings.Contains(got, "Usage") {
+			t.Fatalf("HELP output missing Usage: %q", got)
+		}
+	})
 }
 
-func callMCPExecuteStatement(t *testing.T, session *mycli.Session, statement string) string {
+func callMCPExecuteStatement(t *testing.T, session *mycli.Session, statement string) (string, bool) {
 	t.Helper()
 	ctx := t.Context()
 	client, _, err := mycli.SetupMCPClientServerForTest(t, ctx, session)
@@ -107,6 +133,7 @@ func callMCPExecuteStatement(t *testing.T, session *mycli.Session, statement str
 		t.Fatalf("CallTool: %v", err)
 	}
 	var got string
+	isError := result != nil && result.IsError
 	if result != nil {
 		for _, content := range result.Content {
 			if text, ok := content.(*mcp.TextContent); ok {
@@ -115,5 +142,5 @@ func callMCPExecuteStatement(t *testing.T, session *mycli.Session, statement str
 			}
 		}
 	}
-	return got
+	return got, isError
 }

--- a/internal/mycli/cli_mcp.go
+++ b/internal/mycli/cli_mcp.go
@@ -72,6 +72,18 @@ func (c *mcpOutputCapture) String() string {
 	return c.builder.String()
 }
 
+// mcpApplicationErrorResult is an execute_statement application failure:
+// error text in Content with IsError set, and a nil protocol/handler error so
+// the LLM can see the failure. Unknown tools remain SDK protocol errors.
+func mcpApplicationErrorResult(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: text},
+		},
+		IsError: true,
+	}
+}
+
 // executeStatementHandler handles the execute_statement tool
 func executeStatementHandler(cli *Cli) func(context.Context, *mcp.CallToolRequest, ExecuteStatementArgs) (*mcp.CallToolResult, any, error) {
 	// Mutex to protect concurrent access to cli.executeStatement
@@ -102,22 +114,14 @@ func executeStatementHandler(cli *Cli) func(context.Context, *mcp.CallToolReques
 				"error", err.Error(),
 				"duration", time.Since(start))
 			// Per MCP spec, return execution errors as tool output, not protocol errors.
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{Text: fmt.Sprintf("ERROR: %v", err)},
-				},
-			}, nil, nil
+			return mcpApplicationErrorResult(fmt.Sprintf("ERROR: %v", err)), nil, nil
 		}
 
 		if _, ok := stmt.(MetaCommandStatement); ok {
 			slog.Debug("MCP request rejected meta command",
 				"duration", time.Since(start))
 			// Per MCP spec, return execution errors as tool output, not protocol errors.
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{Text: "ERROR: meta commands are not supported by MCP execute_statement"},
-				},
-			}, nil, nil
+			return mcpApplicationErrorResult("ERROR: meta commands are not supported by MCP execute_statement"), nil, nil
 		}
 
 		// Capture output without allowing one MCP call to grow memory unbounded.
@@ -130,11 +134,7 @@ func executeStatementHandler(cli *Cli) func(context.Context, *mcp.CallToolReques
 				"error", err.Error(),
 				"duration", time.Since(start))
 			// Per MCP spec, return execution errors as tool output, not protocol errors.
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					&mcp.TextContent{Text: fmt.Sprintf("ERROR: %v", err)},
-				},
-			}, nil, nil
+			return mcpApplicationErrorResult(fmt.Sprintf("ERROR: %v", err)), nil, nil
 		}
 
 		text := output.String()

--- a/internal/mycli/cli_mcp_error_test.go
+++ b/internal/mycli/cli_mcp_error_test.go
@@ -30,14 +30,18 @@ func TestMCPExecuteStatementIsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	const metaPolicyText = "ERROR: meta commands are not supported by MCP execute_statement"
 	for _, tc := range []struct {
 		name      string
 		sql       string
 		wantError bool
+		wantText  string
 	}{
 		{name: "success HELP", sql: "HELP", wantError: false},
 		{name: "parse failure", sql: "SHOW QUERY PROFILE nope", wantError: true},
-		{name: "meta command policy", sql: `\q`, wantError: true},
+		// \q is unsupported and fails in ParseMetaCommand; \R is a supported
+		// local MetaCommandStatement that must hit the dedicated MCP guard.
+		{name: "meta command policy", sql: `\R audit`, wantError: true, wantText: metaPolicyText},
 		{name: "execution failure", sql: "SET CLI_FORMAT = 'not-a-format'", wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -55,7 +59,11 @@ func TestMCPExecuteStatementIsError(t *testing.T) {
 			if result.IsError != tc.wantError {
 				t.Fatalf("IsError=%v want %v; text=%q", result.IsError, tc.wantError, text)
 			}
-			if tc.wantError {
+			if tc.wantText != "" {
+				if text != tc.wantText {
+					t.Fatalf("tool text = %q, want %q", text, tc.wantText)
+				}
+			} else if tc.wantError {
 				if !strings.HasPrefix(text, "ERROR:") {
 					t.Fatalf("error text %q, want ERROR: prefix", text)
 				}

--- a/internal/mycli/cli_mcp_error_test.go
+++ b/internal/mycli/cli_mcp_error_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestMCPExecuteStatementIsError(t *testing.T) {
+	t.Parallel()
+	session := newDetachedTestSession(io.Discard)
+	client, _, err := setupMCPClientServer(t, t.Context(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		sql       string
+		wantError bool
+	}{
+		{name: "success HELP", sql: "HELP", wantError: false},
+		{name: "parse failure", sql: "SHOW QUERY PROFILE nope", wantError: true},
+		{name: "meta command policy", sql: `\q`, wantError: true},
+		{name: "execution failure", sql: "SET CLI_FORMAT = 'not-a-format'", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+				Name:      "execute_statement",
+				Arguments: map[string]any{"statement": tc.sql},
+			})
+			if err != nil {
+				t.Fatalf("unexpected protocol error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("nil tool result")
+			}
+			text := mcpResultText(t, result)
+			if result.IsError != tc.wantError {
+				t.Fatalf("IsError=%v want %v; text=%q", result.IsError, tc.wantError, text)
+			}
+			if tc.wantError {
+				if !strings.HasPrefix(text, "ERROR:") {
+					t.Fatalf("error text %q, want ERROR: prefix", text)
+				}
+			} else if strings.HasPrefix(text, "ERROR:") {
+				t.Fatalf("success text unexpectedly starts with ERROR: %q", text)
+			}
+		})
+	}
+
+	t.Run("unknown tool is protocol error", func(t *testing.T) {
+		_, err := client.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      "audit_nonexistent_tool",
+			Arguments: map[string]any{},
+		})
+		if err == nil {
+			t.Fatal("expected protocol error for missing tool")
+		}
+	})
+}

--- a/internal/mycli/integration_mcp_test.go
+++ b/internal/mycli/integration_mcp_test.go
@@ -126,16 +126,10 @@ func testExecuteStatementTool(t *testing.T, ctx context.Context, session *Sessio
 		},
 	}
 	result, err := mcpClient.CallTool(ctx, params)
-	// Handle errors
 	if err != nil {
-		if wantError {
-			t.Logf("Got expected error: %v", err)
-			return // Expected error
-		}
-		t.Fatalf("Failed to call execute_statement tool: %v", err)
+		t.Fatalf("unexpected protocol error: %v", err)
 	}
 
-	// Extract the text content from the result
 	gotOutput := ""
 	if result != nil && len(result.Content) > 0 {
 		for _, content := range result.Content {
@@ -146,23 +140,17 @@ func testExecuteStatementTool(t *testing.T, ctx context.Context, session *Sessio
 		}
 	}
 
-	// For error cases, check if we got an error message in the output
 	if wantError {
-		t.Logf("Testing error case, got output: %q", gotOutput)
-		// Check if the output contains error indicators or is empty
-		// Empty output means the statement failed before producing any results
-		if strings.Contains(gotOutput, "ERROR:") ||
-			strings.Contains(gotOutput, "error:") ||
-			strings.Contains(gotOutput, "unknown statement") ||
-			strings.Contains(gotOutput, "syntax error") ||
-			strings.Contains(gotOutput, "invalid") ||
-			strings.Contains(gotOutput, "Invalid") ||
-			len(gotOutput) == 0 {
-			t.Logf("Got expected error in output")
-			return
+		if result == nil || !result.IsError {
+			t.Fatalf("IsError=false, want true; output=%q", gotOutput)
 		}
-		t.Errorf("Expected error but got successful output: %s", gotOutput)
+		if !strings.Contains(gotOutput, "ERROR:") {
+			t.Fatalf("expected ERROR: tool text, got %q", gotOutput)
+		}
 		return
+	}
+	if result != nil && result.IsError {
+		t.Fatalf("unexpected IsError on success; output=%q", gotOutput)
 	}
 
 	// Extract the first line of the result message (after the table output)


### PR DESCRIPTION
# Mark MCP application errors with IsError

## Summary

The MCP `execute_statement` tool now sets `isError` on application failures.

Parse errors, rejected backslash meta commands, and statement execution errors still return `ERROR:` text as tool output with a normal tool result (not an MCP protocol error). Clients can now see `isError: true` on those results. Successful calls keep `isError` unset/false. Unknown tool names remain protocol errors.

## Validation

- In-memory client/server tests cover HELP success, parse failure, meta-command rejection, execution failure, and an unknown-tool protocol error.
- Existing MCP integration error cases now require `isError` and `ERROR:` text instead of treating empty output or protocol errors as success.
- BIGQUERY READONLY policy errors and missing-project execution errors set `isError` without running a BigQuery job; HELP on a READONLY session does not.
- `make check`, `make check-race`, and `golangci-lint fmt --diff` passed on Go 1.26.8 / golangci-lint 2.13.2.
