### PR TITLE
fix: preserve FLOAT32 negative zero in SQL exports

### DIFF
--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -77,7 +77,7 @@ func prepareFormatConfig(sql string, sysVars *systemVariables) (*spanvalue.Forma
 	case format.SQLLiteralValues:
 		// Use SQL literal formatting for modes that declared SQLLiteralValues
 		// LiteralFormatConfig formats values as valid Spanner SQL literals
-		fc := spanvalue.LiteralFormatConfig()
+		fc := sqlLiteralFormatConfig()
 
 		// Auto-detect table name if not explicitly set
 		if sysVars.Display.SQLTableName == "" {
@@ -108,6 +108,27 @@ func prepareFormatConfig(sql string, sysVars *systemVariables) (*spanvalue.Forma
 		fc, err := decoder.FormatConfigWithProto(sysVars.Internal.ProtoDescriptor, sysVars.Display.MultilineProtoText)
 		return fc, vfm, sysVars, err
 	}
+}
+
+// sqlLiteralFormatConfig keeps SQL export and typed replay on the same policy.
+func sqlLiteralFormatConfig() *spanvalue.FormatConfig {
+	// spanvalue v0.8.4 emits CAST(-0 AS FLOAT32), whose integer operand loses
+	// the sign on replay. Remove this bridge after adopting an upstream version
+	// that preserves FLOAT32 negative zero. A typed plugin also covers nested
+	// values without rewriting matching text inside STRING or JSON literals.
+	return spanvalue.LiteralFormatConfig().WithComplexPlugin(spanvalue.PluginForTypeCode(
+		sppb.TypeCode_FLOAT32,
+		func(_ spanvalue.Formatter, value spanner.GenericColumnValue, _ bool) (string, error) {
+			var f spanner.NullFloat32
+			if err := value.Decode(&f); err != nil {
+				return "", err
+			}
+			if f.Valid && f.Float32 == 0 && math.Signbit(float64(f.Float32)) {
+				return "CAST(-0.0 AS FLOAT32)", nil
+			}
+			return "", spanvalue.ErrFallthrough
+		},
+	))
 }
 
 // newMetrics creates and initializes execution metrics from system variables.

--- a/internal/mycli/execute_sql_test.go
+++ b/internal/mycli/execute_sql_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"math"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanvalue"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestSQLLiteralFormatConfigFloat32(t *testing.T) {
+	t.Parallel()
+	negativeZero := float32(math.Copysign(0, -1))
+	structValue := spanner.GenericColumnValue{
+		Type: &sppb.Type{Code: sppb.TypeCode_STRUCT, StructType: &sppb.StructType{
+			Fields: []*sppb.StructType_Field{{Name: "F", Type: &sppb.Type{Code: sppb.TypeCode_FLOAT32}}},
+		}},
+		Value: structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{structpb.NewNumberValue(math.Copysign(0, -1))}}),
+	}
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  string // Empty means preserve the upstream preset's existing bytes.
+	}{
+		{"negative zero", negativeZero, "CAST(-0.0 AS FLOAT32)"},
+		{"nullable negative zero", spanner.NullFloat32{Float32: negativeZero, Valid: true}, "CAST(-0.0 AS FLOAT32)"},
+		{"positive zero", float32(0), ""},
+		{"integer", float32(3), ""},
+		{"finite", float32(1.5), ""},
+		{"NaN", float32(math.NaN()), ""},
+		{"positive infinity", float32(math.Inf(1)), ""},
+		{"negative infinity", float32(math.Inf(-1)), ""},
+		{"NULL", spanner.NullFloat32{}, ""},
+		{"FLOAT64 negative zero", math.Copysign(0, -1), ""},
+		{"STRING with cast text", "CAST(-0 AS FLOAT32)", ""},
+		{"JSON with cast text", spanner.NullJSON{Value: map[string]any{"text": "CAST(-0 AS FLOAT32)"}, Valid: true}, ""},
+		{"array", []spanner.NullFloat32{{Float32: negativeZero, Valid: true}, {Valid: true}, {}}, "[CAST(-0.0 AS FLOAT32), CAST(0 AS FLOAT32), NULL]"},
+		{"empty array", []spanner.NullFloat32{}, ""},
+		{"NULL array", []spanner.NullFloat32(nil), ""},
+		{"struct field", structValue, "STRUCT<F FLOAT32>(CAST(-0.0 AS FLOAT32))"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row, err := spanner.NewRow([]string{"V"}, []any{tc.value})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var value spanner.GenericColumnValue
+			if err := row.Column(0, &value); err != nil {
+				t.Fatal(err)
+			}
+			want := tc.want
+			if want == "" {
+				want, err = spanvalue.LiteralFormatConfig().FormatToplevelColumn(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, mode := range []enums.DisplayMode{enums.DisplayModeSQLInsert, enums.DisplayModeSQLInsertOrIgnore, enums.DisplayModeSQLInsertOrUpdate} {
+				sv := newSystemVariablesWithDefaults()
+				sv.Display.CLIFormat = mode
+				sv.Display.SQLTableName = "Values"
+				streaming, _, _, err := prepareFormatConfig("SELECT V FROM Values", &sv)
+				if err != nil {
+					t.Fatal(err)
+				}
+				buffered, _, err := typedReplayFormatConfig(&sv)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for name, config := range map[string]*spanvalue.FormatConfig{"streaming": streaming, "buffered": buffered} {
+					got, err := config.FormatToplevelColumn(value)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got != want {
+						t.Errorf("%s/%s got %s, want %s", mode, name, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSQLLiteralFormatConfigInvalidFloat32(t *testing.T) {
+	t.Parallel()
+	value := spanner.GenericColumnValue{
+		Type: &sppb.Type{Code: sppb.TypeCode_FLOAT32}, Value: structpb.NewStringValue("not a float"),
+	}
+	sv := newSystemVariablesWithDefaults()
+	sv.Display.CLIFormat = enums.DisplayModeSQLInsert
+	config, _, err := typedReplayFormatConfig(&sv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.FormatToplevelColumn(value); err == nil {
+		t.Fatal("expected invalid FLOAT32 error")
+	}
+}

--- a/internal/mycli/integration_dump_test.go
+++ b/internal/mycli/integration_dump_test.go
@@ -3,9 +3,12 @@ package mycli
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
+	"cloud.google.com/go/spanner"
+	"github.com/apstndb/gsqlutils"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
 	"github.com/google/go-cmp/cmp"
@@ -544,5 +547,114 @@ func TestDumpWithGeneratedColumns(t *testing.T) {
 
 	if diff := cmp.Diff(expectedOutput, dumpRenderedOutputForTest(t, result)); diff != "" {
 		t.Errorf("DUMP output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDumpFloat32NegativeZeroReplay(t *testing.T) {
+	t.Parallel()
+	skipIfShortIntegration(t)
+	const castText = "CAST(-0 AS FLOAT32)"
+	const ddl = `CREATE TABLE FloatValues (
+		Id INT64 NOT NULL, V FLOAT32, A ARRAY<FLOAT32>, EmptyValues ARRAY<FLOAT32>,
+		NullValues ARRAY<FLOAT32>, NullValue FLOAT32, D FLOAT64,
+		TextValue STRING(MAX), JsonValue JSON, BytesValue BYTES(MAX)
+	) PRIMARY KEY(Id)`
+	execute := func(t *testing.T, session *Session, sql string) *Result {
+		t.Helper()
+		stmt, err := BuildStatement(sql)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := stmt.Execute(t.Context(), session)
+		if err != nil {
+			t.Fatalf("execute %s: %v", sql, err)
+		}
+		return result
+	}
+	check := func(t *testing.T, session *Session) {
+		t.Helper()
+		iter := session.client.Single().Query(t.Context(), spanner.Statement{
+			SQL: "SELECT V,A,EmptyValues,NullValues,NullValue,D,TextValue,JsonValue,BytesValue FROM FloatValues WHERE Id=1",
+		})
+		defer iter.Stop()
+		row, err := iter.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var scalar, nullScalar spanner.NullFloat32
+		var values []spanner.NullFloat32
+		var emptyArray, nullArray spanner.GenericColumnValue
+		var double spanner.NullFloat64
+		var text string
+		var json spanner.NullJSON
+		var bytes []byte
+		if err := row.Columns(&scalar, &values, &emptyArray, &nullArray, &nullScalar, &double, &text, &json, &bytes); err != nil {
+			t.Fatal(err)
+		}
+		if !scalar.Valid || math.Float32bits(scalar.Float32) != math.Float32bits(float32(math.Copysign(0, -1))) {
+			t.Errorf("FLOAT32 scalar negative zero changed: %v", scalar)
+		}
+		if len(values) != 7 {
+			t.Fatalf("array length = %d, want 7", len(values))
+		}
+		wantFloats := []float32{float32(math.Copysign(0, -1)), 0, 1.5, float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))}
+		for i, want := range wantFloats {
+			got := values[i]
+			if !got.Valid || !(math.IsNaN(float64(want)) && math.IsNaN(float64(got.Float32))) && math.Float32bits(got.Float32) != math.Float32bits(want) {
+				t.Errorf("FLOAT32 array[%d] = %v, want %v with sign bit preserved", i, got, want)
+			}
+		}
+		if values[6].Valid || nullScalar.Valid || emptyArray.Value.GetListValue() == nil || len(emptyArray.Value.GetListValue().Values) != 0 || nullArray.Value.GetListValue() != nil {
+			t.Error("NULL or empty-array shape changed")
+		}
+		if !double.Valid || math.Float64bits(double.Float64) != math.Float64bits(math.Copysign(0, -1)) {
+			t.Errorf("FLOAT64 negative-zero control changed: %v", double)
+		}
+		if text != castText || string(bytes) != castText || !json.Valid {
+			t.Errorf("literal-text controls changed: string=%q bytes=%q JSON=%v", text, bytes, json)
+		}
+		if diff := cmp.Diff(any(map[string]any{"text": castText}), json.Value); diff != "" {
+			t.Errorf("JSON control changed (-want +got):\n%s", diff)
+		}
+	}
+	for _, mode := range []string{"buffered", "streamed"} {
+		t.Run(mode, func(t *testing.T) {
+			_, source := initializeWithRandomDB(t, nil, nil)
+			_, target := initializeWithRandomDB(t, nil, nil)
+			execute(t, source, ddl)
+			execute(t, target, ddl)
+			execute(t, source, `INSERT INTO FloatValues
+				(Id,V,A,EmptyValues,NullValues,NullValue,D,TextValue,JsonValue,BytesValue) VALUES
+				(1, CAST('-0' AS FLOAT32),
+				[CAST('-0' AS FLOAT32),CAST(0 AS FLOAT32),CAST(1.5 AS FLOAT32),CAST('nan' AS FLOAT32),CAST('inf' AS FLOAT32),CAST('-inf' AS FLOAT32),NULL],
+				[],NULL,NULL,CAST('-0' AS FLOAT64),'CAST(-0 AS FLOAT32)',JSON '{"text":"CAST(-0 AS FLOAT32)"}',b'CAST(-0 AS FLOAT32)')`)
+			check(t, source)
+			if t.Failed() {
+				t.Fatal("invalid source fixture")
+			}
+			var output string
+			if mode == "buffered" {
+				output = dumpRenderedOutputForTest(t, execute(t, source, "DUMP TABLES FloatValues"))
+			} else {
+				result, text, err := executeSQLExportForTest(t, t.Context(), source, "DUMP TABLES FloatValues")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !result.Streamed {
+					t.Fatal("expected streamed DUMP")
+				}
+				output = text
+			}
+			statements, err := gsqlutils.SeparateInputPreserveCommentsWithStatus("", output)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, raw := range statements {
+				if sql := strings.TrimSpace(raw.Statement); sql != "" {
+					execute(t, target, sql)
+				}
+			}
+			check(t, target)
+		})
 	}
 }

--- a/internal/mycli/typed_rows.go
+++ b/internal/mycli/typed_rows.go
@@ -36,7 +36,7 @@ func typedReplayFormatConfig(sysVars *systemVariables) (*spanvalue.FormatConfig,
 	vfm := format.ValueFormatModeFor(format.Mode(sysVars.Display.CLIFormat.String()))
 	switch vfm {
 	case format.SQLLiteralValues:
-		return spanvalue.LiteralFormatConfig(), vfm, nil
+		return sqlLiteralFormatConfig(), vfm, nil
 	case format.JSONValues:
 		return decoder.JSONFormatConfig(), vfm, nil
 	default:


### PR DESCRIPTION
## Summary

Preserve the sign of FLOAT32 negative zero in SQL INSERT exports and DUMP output.
The current literal formatter emits `CAST(-0 AS FLOAT32)`, which loses the sign
when replayed because its operand is integer zero. A narrow type-aware plugin
emits `CAST(-0.0 AS FLOAT32)` for that value only.

Both streaming and typed buffered SQL formatting share this policy, including
nested arrays and STRUCT values. Other FLOAT32 values fall through to the
existing formatter; matching text in STRING, JSON, and BYTES is untouched.
This is a temporary bridge until a corrected upstream formatter is adopted;
no dependency versions change.

## Validation

- `make check` and `make check-race` passed with Go 1.26.8 and golangci-lint 2.13.2.
- Unit tests cover all three SQL INSERT modes and both formatting paths,
  nullable/scalar/array/STRUCT negative zero, special floats, and error behavior.
- Buffered and streamed DUMP TABLES output was replayed unchanged through the
  production splitter and statement dispatcher into fresh emulator databases.
  Scalar and array sign bits, NULL/empty-array shapes, FLOAT64 negative zero,
  and text payload controls are preserved.
- Replacing only the production files with the baseline implementation makes
  the new negative-zero unit and DUMP replay tests fail as expected.

Service replay validation uses Cloud Spanner emulator 1.5.56; no managed
Spanner verification is claimed.
