### PR TITLE
fix: defer forward foreign keys in schema dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,17 @@ spanner> SELECT * FROM keys;  -- Output goes to file only
 spanner> \O                   -- Disable redirect using \O
 ```
 
+##### DDL restore order
+
+`DUMP SCHEMA` and `DUMP DATABASE` move inline foreign keys that reference
+tables created later into `ALTER TABLE ... ADD` statements after the other DDL,
+before any data. This allows an empty cyclic foreign-key schema to be restored
+even when Spanner returns its constraints inside `CREATE TABLE`. If an affected
+table definition cannot be parsed or safely rewritten, the dump fails before
+emitting SQL. `DUMP TABLES` does not export or modify DDL. This does not remove
+the rejection of populated cycles involving enforced foreign keys or interleave
+relationships, or make database restoration atomic.
+
 #### What gets logged
 
 The tee file will contain:

--- a/internal/mycli/dump_ddl_replay.go
+++ b/internal/mycli/dump_ddl_replay.go
@@ -1,0 +1,249 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cloudspannerecosystem/memefish"
+	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/cloudspannerecosystem/memefish/token"
+)
+
+// prepareDumpDDLForReplay only changes inline forward foreign keys. The admin
+// API can fold ALTER ADD FOREIGN KEY into CREATE TABLE even for a cycle, but
+// Spanner requires the referenced table to exist when the FK is created:
+// https://cloud.google.com/spanner/docs/foreign-keys/overview
+// Install moved constraints after all CREATEs and BEFORE data, not after data
+// loading. TABLES dumps do not use this DDL transformation.
+func prepareDumpDDLForReplay(statements []string) ([]string, error) {
+	return recoverMemefishParserPanic(func() ([]string, error) {
+		created := make(map[tableID]bool)
+		result := make([]string, 0, len(statements))
+		type deferredFK struct {
+			target tableID
+			sql    string
+		}
+		var deferred []deferredFK
+		for _, statement := range statements {
+			lexer := &memefish.Lexer{File: &token.File{Buffer: statement}}
+			if err := lexer.NextToken(); err != nil {
+				return nil, err
+			}
+			isCreate := strings.EqualFold(lexer.Token.Raw, "CREATE")
+			if isCreate {
+				if err := lexer.NextToken(); err != nil {
+					return nil, err
+				}
+			}
+			if !isCreate || !strings.EqualFold(lexer.Token.Raw, "TABLE") {
+				result = append(result, statement)
+				continue
+			}
+			ddl, err := parseMemefishDDL("dump-replay", statement)
+			if err != nil {
+				// A future non-FK column/option syntax must not make a dump
+				// depend on full parser support. A lexical prefix and absence
+				// of FOREIGN KEY are sufficient to leave this statement raw.
+				id, hasFK, inspectErr := inspectDumpCreateTable(statement)
+				if inspectErr == nil && !hasFK {
+					key := dumpDDLTableKey(id)
+					if created[key] {
+						return nil, fmt.Errorf("duplicate CREATE TABLE for %s in dump DDL", id.FQN())
+					}
+					created[key] = true
+					result = append(result, statement)
+					continue
+				}
+				return nil, fmt.Errorf("prepare DUMP table DDL for replay: %w", err)
+			}
+			ct, ok := ddl.(*ast.CreateTable)
+			if !ok {
+				return nil, fmt.Errorf("expected CREATE TABLE in dump DDL")
+			}
+			id, err := tableIDFromPath(ct.Name)
+			if err != nil {
+				return nil, err
+			}
+			key := dumpDDLTableKey(id)
+			if created[key] {
+				return nil, fmt.Errorf("duplicate CREATE TABLE for %s in dump DDL", id.FQN())
+			}
+			// A self-reference is valid in CREATE TABLE. Synonyms name the
+			// same already-created table, including inside named schemas.
+			created[key] = true
+			for _, synonym := range ct.Synonyms {
+				created[dumpDDLTableKey(tableID{Schema: id.Schema, Name: synonym.Name.Name})] = true
+			}
+			var moved []*ast.TableConstraint
+			for _, constraint := range ct.TableConstraints {
+				fk, ok := constraint.Constraint.(*ast.ForeignKey)
+				if !ok {
+					continue
+				}
+				target, err := tableIDFromPath(fk.ReferenceTable)
+				if err != nil {
+					return nil, err
+				}
+				if created[dumpDDLTableKey(target)] {
+					continue
+				}
+				start, end := int(constraint.Pos()), int(constraint.End())
+				if start < 0 || end <= start || end > len(statement) {
+					return nil, fmt.Errorf("invalid FK source range for %s", id.FQN())
+				}
+				moved = append(moved, constraint)
+				deferred = append(deferred, deferredFK{
+					target: target,
+					sql:    "ALTER TABLE " + statement[ct.Name.Pos():ct.Name.End()] + " ADD " + statement[start:end],
+				})
+			}
+			if len(moved) > 0 {
+				statement, err = removeDumpInlineFKs(statement, ct, moved)
+				if err != nil {
+					return nil, fmt.Errorf("prepare DUMP table %s: %w", id.FQN(), err)
+				}
+			}
+			result = append(result, statement)
+		}
+		for _, fk := range deferred {
+			if !created[dumpDDLTableKey(fk.target)] {
+				return nil, fmt.Errorf("dump DDL foreign key references missing CREATE TABLE %s", fk.target.FQN())
+			}
+			result = append(result, fk.sql)
+		}
+		return result, nil
+	})
+}
+
+func dumpDDLTableKey(id tableID) tableID {
+	return tableID{Schema: strings.ToLower(id.Schema), Name: strings.ToLower(id.Name)}
+}
+
+// The caller has already established a CREATE TABLE prefix. This fallback
+// does not validate the table definition; Spanner supplied the DDL. It only
+// identifies the created table and determines whether an FK rewrite might be
+// needed. Strings, quoted identifiers and comments are not keyword tokens.
+func inspectDumpCreateTable(sql string) (tableID, bool, error) {
+	p := newParser("dump-replay-prefix", sql)
+	for range 3 {
+		if err := p.NextToken(); err != nil {
+			return tableID{}, false, err
+		}
+	}
+	if strings.EqualFold(p.Token.Raw, "IF") {
+		for _, word := range []string{"IF", "NOT", "EXISTS"} {
+			if !strings.EqualFold(p.Token.Raw, word) {
+				return tableID{}, false, fmt.Errorf("invalid CREATE TABLE prefix")
+			}
+			if err := p.NextToken(); err != nil {
+				return tableID{}, false, err
+			}
+		}
+	}
+	parts, err := parseFQNParts(p)
+	if err != nil {
+		return tableID{}, false, err
+	}
+	id, err := tableIDFromIdents(parts)
+	if err != nil {
+		return tableID{}, false, err
+	}
+	foreign := false
+	for p.Token.Kind != token.TokenEOF {
+		if foreign && strings.EqualFold(p.Token.Raw, "KEY") {
+			return id, true, nil
+		}
+		foreign = strings.EqualFold(p.Token.Raw, "FOREIGN")
+		if err := p.NextToken(); err != nil {
+			return tableID{}, false, err
+		}
+	}
+	return id, false, nil
+}
+
+// Remove only each FK's source bytes and one adjacent comma, preserving all
+// other declarations, options, interleave clauses and surrounding comments.
+// AST SQL() would reserialize unrelated features. Token ranges avoid guessing
+// comma positions inside expressions, quoted identifiers or comments.
+func removeDumpInlineFKs(sql string, ct *ast.CreateTable, moved []*ast.TableConstraint) (string, error) {
+	var declarations []ast.Node
+	for _, col := range ct.Columns {
+		declarations = append(declarations, col)
+	}
+	for _, constraint := range ct.TableConstraints {
+		declarations = append(declarations, constraint)
+	}
+	for _, synonym := range ct.Synonyms {
+		declarations = append(declarations, synonym)
+	}
+	slices.SortFunc(declarations, func(a, b ast.Node) int { return int(a.Pos() - b.Pos()) })
+	type sourceRange struct{ start, end int }
+	var cuts []sourceRange
+	for _, fk := range moved {
+		i := slices.IndexFunc(declarations, func(node ast.Node) bool { return node == fk })
+		if i < 0 || len(declarations) < 2 {
+			return "", fmt.Errorf("FK has no adjacent table declaration")
+		}
+		start, end := int(fk.Pos()), int(fk.End())
+		cuts = append(cuts, sourceRange{start, end})
+		left, right := end, 0
+		if i+1 < len(declarations) {
+			right = int(declarations[i+1].Pos())
+		} else {
+			// Prefer a trailing comma when present. Adjacent removed FKs
+			// can otherwise select the same preceding comma twice, leaving
+			// two commas after the last surviving column.
+			trailing := &memefish.Lexer{File: &token.File{Buffer: sql[end:ct.Rparen]}}
+			if err := trailing.NextToken(); err != nil {
+				return "", err
+			}
+			if trailing.Token.Kind == "," {
+				right = int(ct.Rparen)
+			} else {
+				left, right = int(declarations[i-1].End()), start
+			}
+		}
+		if left < 0 || right < left || right > len(sql) {
+			return "", fmt.Errorf("invalid FK delimiter range")
+		}
+		lexer := &memefish.Lexer{File: &token.File{Buffer: sql[left:right]}}
+		if err := lexer.NextToken(); err != nil {
+			return "", err
+		}
+		if lexer.Token.Kind != "," {
+			return "", fmt.Errorf("missing comma adjacent to FK")
+		}
+		comma := left + int(lexer.Token.Pos)
+		cuts = append(cuts, sourceRange{comma, comma + 1})
+	}
+	slices.SortFunc(cuts, func(a, b sourceRange) int { return a.start - b.start })
+	var out strings.Builder
+	previous := 0
+	for _, cut := range cuts {
+		if cut.start > previous {
+			out.WriteString(sql[previous:cut.start])
+		}
+		previous = max(previous, cut.end)
+	}
+	out.WriteString(sql[previous:])
+	result := out.String()
+	if _, err := parseMemefishDDL("dump-replay-rewritten", result); err != nil {
+		return "", fmt.Errorf("rewritten CREATE TABLE is invalid: %w", err)
+	}
+	return result, nil
+}

--- a/internal/mycli/dump_ddl_replay_test.go
+++ b/internal/mycli/dump_ddl_replay_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPrepareDumpDDLForReplayUnchanged(t *testing.T) {
+	t.Parallel()
+	input := []string{
+		"CREATE SCHEMA S",
+		"CREATE TABLE S.P (Id INT64 NOT NULL, SYNONYM (Parent)) PRIMARY KEY(Id)",
+		"CREATE TABLE C (Id INT64 NOT NULL, Ref INT64, CONSTRAINT fk FOREIGN KEY(Ref) REFERENCES S.p(Id)) PRIMARY KEY(Id)",
+		"CREATE TABLE D (Id INT64 NOT NULL, CONSTRAINT fk_self FOREIGN KEY(Id) REFERENCES d(Id)) PRIMARY KEY(Id)",
+		"CREATE TABLE E (Id INT64 NOT NULL, CONSTRAINT fk_alias FOREIGN KEY(Id) REFERENCES S.Parent(Id)) PRIMARY KEY(Id)",
+		"CREATE SOMETHING FUTURE SYNTAX THAT THIS PARSER DOES NOT KNOW",
+		"CREATE TABLE Future (Id INT64 NOT NULL) PRIMARY KEY(Id) NEW_UNPARSED_OPTION ('FOREIGN KEY')",
+		"CREATE TABLE F (Id INT64 NOT NULL, FOREIGN KEY(Id) REFERENCES Future(Id)) PRIMARY KEY(Id)",
+		"CREATE TABLE IF NOT EXISTS Other (Id INT64 NOT NULL) PRIMARY KEY(Id) NEW_UNPARSED_OPTION (1)",
+	}
+	want := slices.Clone(input)
+	got, err := prepareDumpDDLForReplay(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("changed valid DDL (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(want, input); diff != "" {
+		t.Fatalf("mutated input: %s", diff)
+	}
+}
+
+func TestPrepareDumpDDLForReplayConstraintPositions(t *testing.T) {
+	t.Parallel()
+	const col = "Id INT64 NOT NULL"
+	const fk1 = "CONSTRAINT fk1 FOREIGN KEY(Id) REFERENCES B(Id) ON DELETE CASCADE"
+	const fk2 = "CONSTRAINT fk2 FOREIGN KEY(Id) REFERENCES B(Id) NOT ENFORCED"
+	const check = "CONSTRAINT ck CHECK(Id > 0)"
+	for _, decls := range []string{
+		col + ", " + fk1,
+		col + ", " + fk1 + ",",
+		fk1 + ", " + col,
+		col + ", " + fk1 + ", " + check,
+		col + ", " + fk1 + ", " + fk2,
+		col + ", " + fk1 + ", " + fk2 + ",",
+		fk1 + ", " + fk2 + ", " + col,
+		col + ", " + fk1 + ", " + check + ", " + fk2 + ",",
+		col + ", /* keep , comment */ " + fk1 + " /* another , */ , -- keep line\n " + fk2 + ",",
+	} {
+		t.Run(decls, func(t *testing.T) {
+			source := "/* leading */ cReAtE TABLE A (" + decls + ") PRIMARY KEY(Id)"
+			input := []string{source, "CREATE TABLE B (Id INT64 NOT NULL) PRIMARY KEY(Id)"}
+			got, err := prepareDumpDDLForReplay(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantMoved := 1
+			if strings.Contains(decls, "fk2") {
+				wantMoved++
+			}
+			if len(got) != 2+wantMoved || got[1] != input[1] {
+				t.Fatalf("unexpected result: %v", got)
+			}
+			if got[2] != "ALTER TABLE A ADD "+fk1 {
+				t.Fatalf("lost FK identity/action: %s", got[2])
+			}
+			if wantMoved == 2 && got[3] != "ALTER TABLE A ADD "+fk2 {
+				t.Fatalf("lost enforcement: %s", got[3])
+			}
+			for _, fragment := range []string{col, "/* leading */", "/* keep , comment */", "/* another , */", "-- keep line", check} {
+				if strings.Contains(source, fragment) && !strings.Contains(got[0], fragment) {
+					t.Errorf("lost original %q", fragment)
+				}
+			}
+			parsed, err := parseMemefishDDL("", got[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, constraint := range parsed.(*ast.CreateTable).TableConstraints {
+				if _, ok := constraint.Constraint.(*ast.ForeignKey); ok {
+					t.Fatal("forward FK left inline")
+				}
+			}
+		})
+	}
+}
+
+func TestPrepareDumpDDLForReplayNamedTables(t *testing.T) {
+	t.Parallel()
+	input := []string{
+		"CREATE SCHEMA Alpha", "CREATE SCHEMA Beta",
+		"CREATE TABLE `Alpha`.`Order` (`Id` INT64 NOT NULL, CONSTRAINT `select` FOREIGN KEY(`Id`) REFERENCES `Beta`.`Order`(`Id`) NOT ENFORCED, SYNONYM (OldOrder)) PRIMARY KEY(`Id`)",
+		"CREATE TABLE `Beta`.`Order` (`Id` INT64 NOT NULL) PRIMARY KEY(`Id`), INTERLEAVE IN PARENT `Alpha`.`Order` ON DELETE CASCADE",
+	}
+	got, err := prepareDumpDDLForReplay(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ALTER TABLE `Alpha`.`Order` ADD CONSTRAINT `select` FOREIGN KEY(`Id`) REFERENCES `Beta`.`Order`(`Id`) NOT ENFORCED"
+	if got[len(got)-1] != want {
+		t.Fatalf("got %s, want %s", got[len(got)-1], want)
+	}
+	if got[3] != input[3] || !strings.Contains(got[2], "SYNONYM (OldOrder)") {
+		t.Fatal("interleave or synonym changed")
+	}
+}
+
+func TestPrepareDumpDDLForReplayErrors(t *testing.T) {
+	t.Parallel()
+	for _, input := range [][]string{
+		{"CREATE TABLE T (Id INT64 NOT NULL, FOREIGN KEY(Id) REFERENCES Missing(Id)) PRIMARY KEY(Id)"},
+		{"CREATE TABLE T (Id INT64 NOT NULL) PRIMARY KEY(Id)", "CREATE TABLE t (Id INT64 NOT NULL) PRIMARY KEY(Id)"},
+		{"CREATE TABLE T (Id INT64 NOT NULL, FOREIGN KEY(Id) REFERENCES B()"},
+		{"CREATE TABLE T (Id INT64 NOT NULL, FOREIGN KEY(Id) REFERENCES B(Id)) PRIMARY KEY(Id) NEW_UNPARSED_OPTION (1)"},
+	} {
+		if got, err := prepareDumpDDLForReplay(input); err == nil || got != nil {
+			t.Fatalf("got %v, %v, want pre-output error", got, err)
+		}
+	}
+}

--- a/internal/mycli/integration_dump_catalog_test.go
+++ b/internal/mycli/integration_dump_catalog_test.go
@@ -588,3 +588,101 @@ func TestDumpAncestorFKInterleaveAccepted(t *testing.T) {
 		t.Fatalf("rejected valid ancestor FK schema:\n%s", out)
 	}
 }
+
+func TestDumpDDLRewriteFailureBeforeOutput(t *testing.T) {
+	t.Parallel()
+	skipIfShortIntegration(t)
+	_, session := initializeWithRandomDB(t, []string{"CREATE TABLE A (Id INT64 NOT NULL) PRIMARY KEY(Id)"}, nil)
+	for _, invalid := range []string{
+		"CREATE TABLE A (Id INT64 NOT NULL, FOREIGN KEY(Id) REFERENCES Missing(Id)) PRIMARY KEY(Id)",
+		"CREATE TABLE A (Id INT64 NOT NULL, FOREIGN KEY(Id) REFERENCES B()",
+	} {
+		response := &adminpb.GetDatabaseDdlResponse{Statements: []string{"CREATE SCHEMA Earlier", invalid}}
+		session.ddlCache.response = response
+		session.ddlCache.fetchedAt = time.Now()
+		session.ddlCache.schemaGeneration = session.SchemaGeneration()
+		session.dumpDDLOverride = func(context.Context) (*adminpb.GetDatabaseDdlResponse, error) { return response, nil }
+		for _, statement := range []Statement{&DumpSchemaStatement{}, &DumpDatabaseStatement{}} {
+			for _, streaming := range []bool{false, true} {
+				var buf strings.Builder
+				original := session.systemVariables.StreamManager
+				if streaming {
+					session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
+				}
+				result, err := statement.Execute(t.Context(), session)
+				session.systemVariables.StreamManager = original
+				if err == nil || result != nil || buf.Len() != 0 {
+					t.Fatalf("%T streaming=%v: result=%+v error=%v output=%q; want error before any output", statement, streaming, result, err, buf.String())
+				}
+			}
+		}
+	}
+}
+
+func TestDumpDDLForwardForeignKeyReplay(t *testing.T) {
+	t.Parallel()
+	skipIfShortIntegration(t)
+	for _, tc := range []struct {
+		name string
+		ddl  []string
+	}{
+		{"mutual", []string{
+			"CREATE TABLE A (Id INT64 NOT NULL, Ref INT64) PRIMARY KEY(Id)",
+			"CREATE TABLE B (Id INT64 NOT NULL, Ref INT64) PRIMARY KEY(Id)",
+			"ALTER TABLE A ADD CONSTRAINT fk_a FOREIGN KEY(Ref) REFERENCES B(Id)",
+			"ALTER TABLE B ADD CONSTRAINT fk_b FOREIGN KEY(Ref) REFERENCES A(Id)",
+		}},
+		{"ancestor", []string{
+			"CREATE TABLE A (Id INT64 NOT NULL, ChildId INT64) PRIMARY KEY(Id)",
+			"CREATE TABLE B (Id INT64 NOT NULL, ChildId INT64 NOT NULL) PRIMARY KEY(Id,ChildId), INTERLEAVE IN PARENT A ON DELETE CASCADE",
+			"ALTER TABLE A ADD CONSTRAINT fk_child FOREIGN KEY(Id,ChildId) REFERENCES B(Id,ChildId)",
+		}},
+		{"self_synonym", []string{
+			"CREATE TABLE A (Id INT64 NOT NULL, Ref INT64, SYNONYM (AliasA)) PRIMARY KEY(Id)",
+			"ALTER TABLE A ADD CONSTRAINT fk_self FOREIGN KEY(Ref) REFERENCES AliasA(Id)",
+		}},
+		{"unnamed_mutual", []string{
+			"CREATE TABLE A (Id INT64 NOT NULL, Ref INT64) PRIMARY KEY(Id)",
+			"CREATE TABLE B (Id INT64 NOT NULL, Ref INT64) PRIMARY KEY(Id)",
+			"ALTER TABLE A ADD FOREIGN KEY(Ref) REFERENCES B(Id)",
+			"ALTER TABLE B ADD FOREIGN KEY(Ref) REFERENCES A(Id)",
+		}},
+		{"informational_named", []string{
+			"CREATE SCHEMA Alpha", "CREATE SCHEMA Beta",
+			"CREATE TABLE Alpha.T (Id INT64 NOT NULL, Ref INT64) PRIMARY KEY(Id)",
+			"CREATE TABLE Beta.T (Id INT64 NOT NULL, Ref INT64) PRIMARY KEY(Id)",
+			"ALTER TABLE Alpha.T ADD CONSTRAINT fk_alpha FOREIGN KEY(Ref) REFERENCES Beta.T(Id) NOT ENFORCED",
+			"ALTER TABLE Beta.T ADD CONSTRAINT fk_beta FOREIGN KEY(Ref) REFERENCES Alpha.T(Id) NOT ENFORCED",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, source := initializeWithRandomDB(t, tc.ddl, nil)
+			want, err := source.GetDatabaseDdlFresh(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("source canonical DDL: %q", want.Statements)
+			for _, mode := range []string{"SCHEMA", "DATABASE"} {
+				t.Run(mode, func(t *testing.T) {
+					var statement Statement = &DumpSchemaStatement{}
+					if mode == "DATABASE" {
+						statement = &DumpDatabaseStatement{}
+					}
+					buffered := dumpSQL(t, source, statement)
+					if streamed := dumpStreamingSQL(t, source, statement); buffered != streamed {
+						t.Fatal("buffered/streaming DDL differs")
+					}
+					_, target := initializeWithRandomDB(t, nil, nil)
+					replayDumpSQL(t, target, buffered)
+					got, err := target.GetDatabaseDdlFresh(t.Context())
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(want.Statements, got.Statements); diff != "" {
+						t.Fatalf("restored schema changed (-want +got):\n%s", diff)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -218,7 +218,11 @@ func prepareDumpWithTxn(ctx context.Context, session *Session, mode dumpMode, sp
 		if err != nil {
 			return nil, err
 		}
-		plan.DDL = renderDDLStatements(stmts)
+		replayDDL, err := prepareDumpDDLForReplay(stmts)
+		if err != nil {
+			return nil, err
+		}
+		plan.DDL = renderDDLStatements(replayDDL)
 		if err := resolver.applyInterleaveParents(stmts, selected); err != nil {
 			return nil, err
 		}
@@ -370,19 +374,11 @@ func exportDDL(ctx context.Context, session *Session) (*Result, error) {
 		return nil, err
 	}
 
-	var out bytes.Buffer
-	fmt.Fprintln(&out, "-- Database DDL exported by spanner-mycli")
-	fmt.Fprintln(&out)
-
-	for _, stmt := range ddl.Statements {
-		if !strings.HasSuffix(stmt, ";") {
-			stmt += ";"
-		}
-		fmt.Fprintln(&out, stmt)
-		fmt.Fprintln(&out)
+	replayDDL, err := prepareDumpDDLForReplay(ddl.Statements)
+	if err != nil {
+		return nil, err
 	}
-
-	return &Result{RenderedOutput: out.Bytes()}, nil
+	return &Result{RenderedOutput: renderDDLStatements(replayDDL)}, nil
 }
 
 func renderDDLStatements(statements []string) []byte {


### PR DESCRIPTION
## Summary

Spanner can return a foreign key inside `CREATE TABLE` even if that constraint
was originally added by `ALTER TABLE`. An inline reference to a table appearing
later in the returned DDL makes a fresh schema restore fail with `NotFound`.

- Move forward inline foreign keys from `DUMP SCHEMA` and `DUMP DATABASE` into
  `ALTER TABLE ... ADD` statements after the other DDL, before any data.
- Preserve the original constraint text, names, actions, enforcement and
  unrelated declarations; keep valid backward and self references inline.
- Fail before emitting SQL if an affected table cannot be safely transformed.
- Leave `DUMP TABLES`, rejection of populated enforced-FK/interleave cycles,
  and restoration atomicity unchanged.

## Validation

- `make check` (Go 1.26.8, golangci-lint 2.13.2).
- `make check-race`.
- Unit cases for source ranges, adjacent/trailing commas, comments, qualified
  and quoted names, synonyms, unchanged DDL, and failure handling.
- Local emulator replay into empty targets for mutual FKs, ancestor reverse FKs,
  and named-schema `NOT ENFORCED` cycles, through both SCHEMA and DATABASE dumps.
  Restored canonical DDL matches the source and buffered/streamed output agrees.
- Additional replay covers unnamed mutual FKs and a self-reference originally
  added through a synonym. The emulator canonicalizes that reference to the
  actual table name; this does not establish same-CREATE synonym resolution.
- Invalid rewrite candidates emit no SQL in either output mode.
- The six fresh-target replay cases fail on the unmodified base at the intended
  missing-referenced-table error.

This change does not add cyclic data restoration or make a restore globally
atomic. It repairs the DDL prerequisite for existing empty-schema exports.
