### PR TITLE
fix: preserve ordinary SET after SET LOCAL

### DIFF
--- a/docs/system_variables.md
+++ b/docs/system_variables.md
@@ -15,6 +15,10 @@ SHOW VARIABLES;                 -- List all variables with their current values
 SHOW VARIABLE CLI_FORMAT;       -- Show a single variable
 SET CLI_FORMAT = 'VERTICAL';    -- Set a variable
 SET LOCAL CLI_FORMAT = 'TAB';   -- Set a variable only for the current transaction
+-- Ordinary SET is session-durable through COMMIT and ROLLBACK, including after
+-- SET LOCAL. This is not PostgreSQL transactional SET: ROLLBACK does not undo
+-- a successful SET. A later SET LOCAL in the same transaction saves the new
+-- session value and restores that value when the transaction ends.
 HELP VARIABLES;                 -- Show the reference table below interactively
 ```
 

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -943,6 +943,64 @@ func TestSetLocalStatements(t *testing.T) {
 	runStatementTests(t, tests)
 }
 
+func TestOrdinarySetAfterSetLocalEnds(t *testing.T) {
+	showFormat := func(want string) stmtResult {
+		return sr("SHOW VARIABLE CLI_FORMAT", &Result{
+			KeepVariables: true,
+			TableHeader:   toTableHeader("CLI_FORMAT"),
+			Rows:          sliceOf(toRow(want)),
+		})
+	}
+	tests := []statementTestCase{
+		{
+			desc: "ordinary SET after SET LOCAL survives COMMIT of a read-write transaction",
+			stmtResults: []stmtResult{
+				srEmpty(testTableSimpleDDL),
+				srEmpty("BEGIN RW"),
+				srKeep("SET LOCAL CLI_FORMAT = 'CSV'"),
+				srKeep("SET CLI_FORMAT = 'JSONL'"),
+				showFormat("JSONL"),
+				srDML("INSERT INTO TestTable (id, active) VALUES (1, true)", 1),
+				srEmpty("COMMIT"),
+				showFormat("JSONL"),
+			},
+		},
+		{
+			desc: "ordinary SET after SET LOCAL survives ROLLBACK of a read-write transaction",
+			stmtResults: []stmtResult{
+				srEmpty("BEGIN RW"),
+				srKeep("SET LOCAL CLI_FORMAT = 'CSV'"),
+				srKeep("SET CLI_FORMAT = 'JSONL'"),
+				srEmpty("ROLLBACK"),
+				showFormat("JSONL"),
+			},
+		},
+		{
+			desc: "ordinary SET after SET LOCAL survives closing a read-only transaction",
+			stmtResults: []stmtResult{
+				srEmpty("BEGIN RO"),
+				srKeep("SET LOCAL CLI_FORMAT = 'CSV'"),
+				srKeep("SET CLI_FORMAT = 'JSONL'"),
+				srEmpty("COMMIT"),
+				showFormat("JSONL"),
+			},
+		},
+		{
+			desc: "ordinary SET after SET LOCAL survives pending to active then ROLLBACK",
+			stmtResults: []stmtResult{
+				srEmpty(testTableSimpleDDL),
+				srEmpty("BEGIN"),
+				srKeep("SET LOCAL CLI_FORMAT = 'CSV'"),
+				srKeep("SET CLI_FORMAT = 'JSONL'"),
+				srDML("INSERT INTO TestTable (id, active) VALUES (1, true)", 1),
+				srEmpty("ROLLBACK"),
+				showFormat("JSONL"),
+			},
+		},
+	}
+	runStatementTests(t, tests)
+}
+
 // TestShowStatements tests SHOW, DESCRIBE, and HELP statement functionality
 func TestShowStatements(t *testing.T) {
 	tests := []statementTestCase{

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -544,6 +544,7 @@ func (s *Session) Close() {
 	// Close any active transaction context (which stops heartbeat)
 	if s.txn != nil {
 		s.txn.clearTransactionContext()
+		s.txn.restoreLocalVarsIfIdle()
 	}
 
 	if s.client != nil {

--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -390,14 +390,21 @@ func TestOrdinarySetSurvivesAutomaticQueryAbort(t *testing.T) {
 
 	mustExec(t, ctx, session, "BEGIN RW")
 	mustExec(t, ctx, session, "SET LOCAL CLI_PROMPT = 'local> '")
+	mustExec(t, ctx, session, "SET LOCAL CLI_FORMAT = 'CSV'")
 	mustExec(t, ctx, session, "SET CLI_FORMAT = 'JSONL'")
+	const injectedCollectorAbortMsg = "injected collector abort for SET LOCAL"
+	var hookFired bool
 	session.txn.queryAfterCollectHook = func() error {
-		return status.Error(codes.Aborted, "injected collector result")
+		hookFired = true
+		return status.Error(codes.Aborted, injectedCollectorAbortMsg)
 	}
 	t.Cleanup(func() { session.txn.queryAfterCollectHook = nil })
 	_, err := execSQL(t, ctx, session, "SELECT 1")
 	session.txn.queryAfterCollectHook = nil
-	if spanner.ErrCode(err) != codes.Aborted {
+	if !hookFired {
+		t.Fatal("queryAfterCollectHook did not run")
+	}
+	if spanner.ErrCode(err) != codes.Aborted || err == nil || !strings.Contains(err.Error(), injectedCollectorAbortMsg) {
 		t.Fatalf("SELECT abort: %v", err)
 	}
 	if session.txn.InTransaction() {

--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -149,6 +149,197 @@ func TestSetLocalRejectsUnsupportedVariables(t *testing.T) {
 	}
 }
 
+func TestOrdinarySetPersistsAfterSetLocal(t *testing.T) {
+	t.Parallel()
+	for _, variable := range []struct{ name, initial, local, session string }{
+		{"CLI_PROMPT", "original> ", "local> ", "session> "},
+		{"CLI_FORMAT", "TABLE", "CSV", "JSONL"},
+	} {
+		for _, end := range []Statement{&CommitStatement{}, &RollbackStatement{}} {
+			for _, tc := range []struct {
+				name        string
+				kinds       []string
+				wantSession bool
+			}{
+				{"local_only_control", []string{"LOCAL"}, false},
+				{"session_only_control", []string{"SESSION"}, true},
+				{"session_then_local_control", []string{"SESSION", "LOCAL"}, true},
+				{"local_then_session", []string{"LOCAL", "SESSION"}, true},
+				{"local_session_local", []string{"LOCAL", "SESSION", "LOCAL"}, true},
+			} {
+				t.Run(variable.name+"/"+endName(end)+"/"+tc.name, func(t *testing.T) {
+					t.Parallel()
+					session := newSessionForLocalVarTest(t)
+					ctx := t.Context()
+					if err := session.systemVariables.SetFromSimple(variable.name, variable.initial); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+						t.Fatal(err)
+					}
+					for _, kind := range tc.kinds {
+						if kind == "LOCAL" {
+							if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: variable.name, Value: quoteGoogleSQL(variable.local)}); err != nil {
+								t.Fatal(err)
+							}
+						} else if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: variable.name, Value: quoteGoogleSQL(variable.session)}); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if _, err := session.ExecuteStatement(ctx, end); err != nil {
+						t.Fatal(err)
+					}
+					want := variable.initial
+					if tc.wantSession {
+						want = variable.session
+					}
+					if got := mustGetVar(t, session, variable.name); got != want {
+						t.Errorf("got %q want %q", got, want)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestOrdinarySetFailedLeavesLocalUndo(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_VERBOSE", Value: "'not-a-bool'"}); err == nil {
+		t.Fatal("invalid SET succeeded")
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("failed SET changed current value: %s", got)
+	}
+	if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("failed SET retired LOCAL undo: %s", got)
+	}
+}
+
+func TestOrdinarySetRetiresCanonicalAliasUndo(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	rv := session.systemVariables.Registry.vars["CLI_FORMAT"]
+	session.systemVariables.Registry.putUnique("CLI_FMT", rv.def.name, rv)
+	ctx := t.Context()
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "cli_fmt", Value: "'CSV'"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_FORMAT", Value: "'JSONL'"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
+		t.Fatalf("alias/case SET did not persist: %s", got)
+	}
+}
+
+func TestOrdinarySetDoesNotRetireUnrelatedLocal(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+	if err := session.systemVariables.SetFromSimple("CLI_PROMPT", "original> "); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_PROMPT", Value: "'local> '"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_PROMPT", Value: "'session> '"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_PROMPT"); got != "session> " {
+		t.Fatalf("PROMPT = %s", got)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("VERBOSE undo was retired: %s", got)
+	}
+}
+
+func TestOrdinarySetPersistsOnSessionClose(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_TYPE_STYLES", Value: "'STRING=green'"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_TYPE_STYLES", Value: "'INT64=bold'"}); err != nil {
+		t.Fatal(err)
+	}
+	session.Close()
+	if got := mustGetVar(t, session, "CLI_TYPE_STYLES"); got != "INT64=bold" {
+		t.Fatalf("Close restored LOCAL over SET: %s", got)
+	}
+	if session.systemVariables.typeStyles[sppb.TypeCode_INT64] == "" {
+		t.Fatal("derived typeStyles not kept after Close")
+	}
+}
+
+func TestSetLocalTypeStylesRestoreDerivedState(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+	wantRaw := mustGetVar(t, session, "CLI_TYPE_STYLES")
+	wantDerived := session.systemVariables.typeStyles[sppb.TypeCode_STRING]
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_TYPE_STYLES", Value: "'STRING=green'"}); err != nil {
+		t.Fatal(err)
+	}
+	if session.systemVariables.typeStyles[sppb.TypeCode_STRING] == "" {
+		t.Fatal("SET LOCAL did not update derived typeStyles")
+	}
+	if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_TYPE_STYLES"); got != wantRaw {
+		t.Fatalf("raw value after rollback: %s", got)
+	}
+	if session.systemVariables.typeStyles[sppb.TypeCode_STRING] != wantDerived {
+		t.Fatal("derived typeStyles not restored on LOCAL rollback")
+	}
+}
+
+func endName(end Statement) string {
+	switch end.(type) {
+	case *CommitStatement:
+		return "COMMIT"
+	default:
+		return "ROLLBACK"
+	}
+}
+
+func quoteGoogleSQL(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "\\'") + "'"
+}
+
 func TestSessionSwitchGuards(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -5,11 +5,15 @@
 package mycli
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // newSessionForLocalVarTest builds a Session wired for the pending-transaction
@@ -298,6 +302,137 @@ func TestOrdinarySetPersistsOnSessionClose(t *testing.T) {
 	}
 	if session.systemVariables.typeStyles[sppb.TypeCode_INT64] == "" {
 		t.Fatal("derived typeStyles not kept after Close")
+	}
+}
+
+func TestSessionCloseRestoresOutstandingLocal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mixed remaining LOCAL restores while ordinary SET remains", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		ctx := t.Context()
+		wantPrompt := mustGetVar(t, session, "CLI_PROMPT")
+		wantStyles := mustGetVar(t, session, "CLI_TYPE_STYLES")
+		wantDerived := session.systemVariables.typeStyles[sppb.TypeCode_STRING]
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_PROMPT", Value: "'local> '"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_TYPE_STYLES", Value: "'STRING=green'"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_FORMAT", Value: "'CSV'"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_FORMAT", Value: "'JSONL'"}); err != nil {
+			t.Fatal(err)
+		}
+		session.Close()
+		if got := mustGetVar(t, session, "CLI_PROMPT"); got != wantPrompt {
+			t.Fatalf("Close left unrelated LOCAL CLI_PROMPT: got %q want %q", got, wantPrompt)
+		}
+		if got := mustGetVar(t, session, "CLI_TYPE_STYLES"); got != wantStyles {
+			t.Fatalf("Close left LOCAL CLI_TYPE_STYLES: got %q want %q", got, wantStyles)
+		}
+		if session.systemVariables.typeStyles[sppb.TypeCode_STRING] != wantDerived {
+			t.Fatal("Close did not restore derived typeStyles")
+		}
+		if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
+			t.Fatalf("Close lost session SET CLI_FORMAT: %q", got)
+		}
+		if n := len(session.txn.localVarUndo); n != 0 {
+			t.Fatalf("Close left %d stale undo entries", n)
+		}
+		session.Close()
+		if n := len(session.txn.localVarUndo); n != 0 {
+			t.Fatalf("repeated Close left %d undo entries", n)
+		}
+		if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
+			t.Fatalf("repeated Close changed session SET: %q", got)
+		}
+	})
+
+	t.Run("LOCAL after ordinary SET restores the session value", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		ctx := t.Context()
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_FORMAT", Value: "'JSONL'"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_FORMAT", Value: "'CSV'"}); err != nil {
+			t.Fatal(err)
+		}
+		session.Close()
+		if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
+			t.Fatalf("Close left LOCAL over session SET: %q", got)
+		}
+		if n := len(session.txn.localVarUndo); n != 0 {
+			t.Fatalf("Close left %d stale undo entries", n)
+		}
+	})
+}
+
+func TestOrdinarySetSurvivesAutomaticQueryAbort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping emulator integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 180*time.Second)
+	defer cancel()
+	_, session := initializeWithRandomDB(t, []string{testTableSimpleDDL}, nil)
+	wantPrompt := mustGetVar(t, session, "CLI_PROMPT")
+
+	mustExec(t, ctx, session, "BEGIN RW")
+	mustExec(t, ctx, session, "SET LOCAL CLI_PROMPT = 'local> '")
+	mustExec(t, ctx, session, "SET CLI_FORMAT = 'JSONL'")
+	session.txn.queryAfterCollectHook = func() error {
+		return status.Error(codes.Aborted, "injected collector result")
+	}
+	t.Cleanup(func() { session.txn.queryAfterCollectHook = nil })
+	_, err := execSQL(t, ctx, session, "SELECT 1")
+	session.txn.queryAfterCollectHook = nil
+	if spanner.ErrCode(err) != codes.Aborted {
+		t.Fatalf("SELECT abort: %v", err)
+	}
+	if session.txn.InTransaction() {
+		t.Fatal("query abort left an active transaction")
+	}
+	if n := len(session.txn.localVarUndo); n != 0 {
+		t.Fatalf("query abort left %d stale undo entries", n)
+	}
+	if got := mustGetVar(t, session, "CLI_PROMPT"); got != wantPrompt {
+		t.Fatalf("query abort left LOCAL CLI_PROMPT: got %q want %q", got, wantPrompt)
+	}
+	if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
+		t.Fatalf("query abort lost session SET CLI_FORMAT: %q", got)
+	}
+
+	if err := session.RecreateClient(ctx); err != nil {
+		t.Fatalf("RecreateClient after abort: %v", err)
+	}
+	mustExec(t, ctx, session, "BEGIN RW")
+	mustExec(t, ctx, session, "SET LOCAL CLI_VERBOSE = TRUE")
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("later LOCAL CLI_VERBOSE: %q", got)
+	}
+	mustExec(t, ctx, session, "ROLLBACK")
+	if session.txn.InTransaction() {
+		t.Fatal("later ROLLBACK left an active transaction")
+	}
+	if n := len(session.txn.localVarUndo); n != 0 {
+		t.Fatalf("later transaction left %d undo entries", n)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("later LOCAL contaminated session: CLI_VERBOSE=%q", got)
+	}
+	if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
+		t.Fatalf("later transaction lost prior session SET: %q", got)
 	}
 }
 

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -85,8 +85,18 @@ type SetStatement struct {
 func (s *SetStatement) isDetachedCompatible() {}
 
 func (s *SetStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	if err := session.systemVariables.SetFromGoogleSQL(s.VarName, s.Value); err != nil {
+	sysVars := session.systemVariables
+	sysVars.ensureRegistry()
+	// Ordinary SET is session-durable through COMMIT and ROLLBACK. It is not
+	// PostgreSQL transactional SET. Invalidation must not live in Registry.Set:
+	// that path also restores LOCAL values and would erase LOCAL itself.
+	if err := sysVars.SetFromGoogleSQL(s.VarName, s.Value); err != nil {
 		return nil, err
+	}
+	if session.txn != nil && session.txn.InTransaction() {
+		if def := sysVars.Registry.lookupDef(s.VarName); def != nil {
+			session.txn.retireLocalVarUndo(def.name)
+		}
 	}
 	return &Result{KeepVariables: true}, nil
 }
@@ -146,7 +156,7 @@ func (s *SetLocalStatement) Execute(ctx context.Context, session *Session) (*Res
 		return nil, err
 	}
 
-	if err := session.txn.pushLocalVarUndo(upperName, oldValue); err != nil {
+	if err := session.txn.pushLocalVarUndo(def.name, oldValue); err != nil {
 		// The transaction ended between the check above and the push;
 		// undo the set so the value does not silently outlive the transaction.
 		if restoreErr := sysVars.Registry.Set(upperName, oldValue, false); restoreErr != nil {
@@ -166,6 +176,8 @@ type SetAddStatement struct {
 func (s *SetAddStatement) isDetachedCompatible() {}
 
 func (s *SetAddStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+	// The only ADD handler is CLI_PROTO_DESCRIPTOR_FILE, which is noLocal, so
+	// SET += cannot retire SET LOCAL undo. Do not hook ADD into that lifecycle.
 	if err := session.systemVariables.AddFromGoogleSQL(s.VarName, s.Value); err != nil {
 		return nil, err
 	}

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -304,12 +304,29 @@ func (tm *TransactionManager) withReadOnlyTransactionOrStart(ctx context.Context
 
 // pushLocalVarUndo appends a SET LOCAL undo entry for the current transaction.
 // It fails if no transaction is active, because the entry would never be replayed.
+// name must be the canonical registry identity (def.name), not a user alias.
 func (tm *TransactionManager) pushLocalVarUndo(name, oldValue string) error {
 	return tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
 		if *tcPtr == nil {
 			return ErrNoTransaction
 		}
 		tm.localVarUndo = append(tm.localVarUndo, savedLocalVar{name: name, oldValue: oldValue})
+		return nil
+	})
+}
+
+// retireLocalVarUndo drops undo entries for canonical after a successful
+// ordinary SET. A later SET LOCAL then saves the new session value. Only the
+// undo slice is touched under mu; setters are not called here because they may
+// inspect transaction state and tm.mu is not reentrant.
+func (tm *TransactionManager) retireLocalVarUndo(canonical string) {
+	_ = tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
+		if *tcPtr == nil || len(tm.localVarUndo) == 0 {
+			return nil
+		}
+		tm.localVarUndo = slices.DeleteFunc(tm.localVarUndo, func(e savedLocalVar) bool {
+			return e.name == canonical
+		})
 		return nil
 	})
 }


### PR DESCRIPTION
# Preserve ordinary SET after SET LOCAL

## Summary

Successful ordinary `SET` now stays in effect after the transaction ends, even if `SET LOCAL` ran first.

Previously `SET LOCAL` always kept an undo entry with the pre-LOCAL value. `COMMIT` and `ROLLBACK` replayed that undo and wiped a later ordinary `SET` of the same variable. Ordinary `SET` is session-durable through both `COMMIT` and `ROLLBACK`; this is not PostgreSQL transactional `SET`. After a successful `SET`, later `SET LOCAL` in the same transaction saves the new session value and restores that value when the transaction ends. Failed `SET` leaves the current value and undo unchanged. Session `Close` restores remaining LOCAL values instead of leaking them.

## Validation

- Twenty-case unit matrix for `CLI_PROMPT` and `CLI_FORMAT` across `COMMIT`/`ROLLBACK` and LOCAL / SET / SET then LOCAL / LOCAL then SET / LOCAL then SET then LOCAL.
- Failed SET, canonical alias/case identity via a test-only registry alias, unrelated-variable undo, `CLI_TYPE_STYLES` derived-state restore, and Close.
- Close coverage that still has outstanding LOCAL undo: mixed-variable restore vs ordinary SET, LOCAL after ordinary SET, derived type styles, drained undo, and repeated Close. Removing only the Close restoration line fails those tests and still passes the SET-only Close case.
- Emulator coverage for read-write COMMIT/ROLLBACK, read-only close, pending-to-active ROLLBACK, and automatic rollback after an injected SELECT abort (`queryAfterCollectHook`). The abort path uses LOCAL then ordinary SET on `CLI_FORMAT`, restores unrelated LOCAL `CLI_PROMPT`, requires the named collector injection to have run, drains undo, and leaves a later transaction uncontaminated. Removing only ordinary SET undo retirement fails that abort test.
- `make check`, `make check-race`, and `golangci-lint fmt --diff` passed on Go 1.26.8 / golangci-lint 2.13.2.
