### PR TITLE
fix: preserve write failures for file-only output

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,10 +457,11 @@ The tee file will NOT contain:
 
 #### File handling
 
-- Files are opened in **append mode** (existing content is preserved)
+- Tee files use **append mode**; `--output` and `\o` overwrite existing content
 - Files are created if they don't exist
 - Only regular files are supported (not directories, FIFOs, or device files)
-- Write errors are handled gracefully with warnings
+- Tee file write failures warn once and leave console output running
+- File-only output preserves write errors instead of treating the failed file as optional. A failed export can leave a partial file; do not replay it as a complete dump.
 
 ```bash
 # Example: Logging a session with CLI_ECHO_INPUT

--- a/internal/mycli/streamio/stream_manager.go
+++ b/internal/mycli/streamio/stream_manager.go
@@ -257,12 +257,9 @@ func (sm *StreamManager) GetWriter() io.Writer {
 
 	// Create and cache new writer based on mode
 	if sm.silentMode {
-		// In silent mode, write only to file
-		sm.cachedWriter = &safeTeeWriter{
-			file:      sm.teeFile,
-			errStream: sm.errStream,
-			hasWarned: false,
-		}
+		// This is the only data destination: preserve partial writes and errors.
+		// safeTeeWriter is appropriate only when stdout still receives the data.
+		sm.cachedWriter = sm.teeFile
 	} else {
 		// In normal mode, write to both stdout and file
 		sm.cachedWriter = createTeeWriter(sm.outStream, sm.teeFile, sm.errStream)

--- a/internal/mycli/streamio/stream_manager_output_error_test.go
+++ b/internal/mycli/streamio/stream_manager_output_error_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streamio
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStreamManagerOutputWriteFailure(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		silent bool
+	}{
+		{name: "sole file", silent: true},
+		{name: "tee retains stdout"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout, stderr bytes.Buffer
+			sm := NewStreamManager(nil, &stdout, &stderr)
+			t.Cleanup(sm.Close)
+			path := filepath.Join(t.TempDir(), "output.txt")
+			if err := sm.EnableTee(path, tc.silent); err != nil {
+				t.Fatal(err)
+			}
+			writer := sm.GetWriter()
+			if err := sm.teeFile.Close(); err != nil {
+				t.Fatal(err)
+			}
+			const data = "result\n"
+			for i := range 2 {
+				if sm.GetWriter() != writer {
+					t.Fatal("writer cache changed after destination failure")
+				}
+				n, err := sm.GetWriter().Write([]byte(data))
+				if tc.silent {
+					if n != 0 || !errors.Is(err, os.ErrClosed) {
+						t.Errorf("write %d = (%d, %v), want (0, ErrClosed)", i, n, err)
+					}
+				} else if n != len(data) || err != nil {
+					t.Errorf("tee write %d = (%d, %v), want (%d, nil)", i, n, err, len(data))
+				}
+			}
+			if tc.silent {
+				if stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Errorf("sole-file writer leaked data or swallowed errors into warnings: stdout=%q stderr=%q", stdout.String(), stderr.String())
+				}
+			} else {
+				if stdout.String() != strings.Repeat(data, 2) {
+					t.Errorf("tee stdout = %q", stdout.String())
+				}
+				if strings.Count(stderr.String(), "Failed to write to output file") != 1 {
+					t.Errorf("want one file failure warning, got %q", stderr.String())
+				}
+			}
+
+			// Disabling output discards the failed cached writer. Re-enabling a
+			// new destination must work instead of retaining its error state.
+			sm.DisableTee()
+			stdout.Reset()
+			if _, err := sm.GetWriter().Write([]byte(data)); err != nil {
+				t.Fatal(err)
+			}
+			if stdout.String() != data {
+				t.Errorf("stdout after disable = %q", stdout.String())
+			}
+			newPath := filepath.Join(t.TempDir(), "new-output.txt")
+			if err := sm.EnableTee(newPath, tc.silent); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := sm.GetWriter().Write([]byte(data)); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(newPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != data {
+				t.Errorf("new file = %q, want %q", got, data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve write errors when `--output` or `\o` uses a file as the only data destination. Previously, failed file writes were treated as optional tee failures and later writes were silently discarded.
- Keep ordinary tee logging best effort: warn once about the extra file while continuing console output.
- Cover repeated failures, cached-writer behavior and recovery after disabling/re-enabling output; clarify append/overwrite and partial-file behavior in the README.

## Validation

- `make check` and `make check-race` with Go 1.26.8 and golangci-lint 2.13.2.
- Targeted stream-manager race tests repeated five times.
- A negative source overlay makes the new sole-file regression fail while the ordinary tee control passes.
- Local subprocess checks against a loopback-only admin service: normal writes, zero-byte failures and partial writes, with both file-only output and tee. Real file-size-limit errors produce a nonzero CLI exit for file-only output; tee preserves stdout. No cloud resources were changed.

This does not make file output atomic or guarantee storage durability. Failed exports may leave partial files. Rendering-side summary/appendix error handling and close-only failures are separate work.
