### PR TITLE
fix: load and validate complete protobuf descriptor graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1317,7 +1317,16 @@ spanner> SHOW VARIABLE CLI_PROTO_DESCRIPTOR_FILE;
 Empty set (0.00 sec)
 ```
 
-(EXPERIMENTAL) It also supports non-compiled `.proto` file.
+(EXPERIMENTAL) It also supports non-compiled `.proto` files, including their transitive imports and standard protobuf imports.
+
+Comma-separated inputs are merged into one descriptor graph before validation,
+both for `--proto-descriptor-file` and `SET CLI_PROTO_DESCRIPTOR_FILE`. Later
+inputs replace earlier descriptors with the same protobuf file name; file names
+must therefore identify the intended version, even if its package changes.
+The resulting graph must resolve all imports and symbols. Failed `SET` or `ADD`
+leaves both the previous descriptor graph and file list unchanged; split binary
+descriptor fragments must be supplied together in one `SET`, not as incomplete
+intermediate `ADD` operations.
 
 ```
 spanner> SET CLI_PROTO_DESCRIPTOR_FILE = "testdata/protos/order_protos.proto";

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -507,11 +507,13 @@ func applyStalenessOptions(sysVars *systemVariables, opts *spannerOptions) error
 }
 
 func applyProtoDescriptors(sysVars *systemVariables, opts *spannerOptions) error {
-	ss := lo.Ternary(opts.ProtoDescriptorFile != "", strings.Split(opts.ProtoDescriptorFile, ","), nil)
-	for _, s := range ss {
-		if err := sysVars.AddFromGoogleSQL("CLI_PROTO_DESCRIPTOR_FILE", strconv.Quote(s)); err != nil {
-			return fmt.Errorf("error on --proto-descriptor-file, file: %v: %w", s, err)
-		}
+	if opts.ProtoDescriptorFile == "" {
+		return nil
+	}
+	// Binary files can supply different parts of the same graph. Install the
+	// startup list as one candidate, just like a multi-input SQL SET.
+	if err := sysVars.SetFromSimple("CLI_PROTO_DESCRIPTOR_FILE", opts.ProtoDescriptorFile); err != nil {
+		return fmt.Errorf("error on --proto-descriptor-file, file: %v: %w", opts.ProtoDescriptorFile, err)
 	}
 	return nil
 }

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -38,7 +39,10 @@ import (
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
 	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
 
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/dynamicpb"
 
 	"cloud.google.com/go/spanner"
 	"github.com/google/go-cmp/cmp"
@@ -1449,6 +1453,56 @@ func TestProtoStatements(t *testing.T) {
 	}
 
 	runStatementTests(t, tests)
+}
+
+func TestImportedProtoStatements(t *testing.T) {
+	t.Parallel()
+	skipIfShortIntegration(t)
+	dir := t.TempDir()
+	child := writeProtoSource(t, filepath.Join(dir, "child.proto"), `syntax="proto3"; package imported; message Child { string value=1; }`)
+	root := writeProtoSource(t, filepath.Join(dir, "root.proto"), fmt.Sprintf(`syntax="proto3"; package imported; import %q; message Root { Child child=1; }`, child))
+	_, session := initializeWithRandomDB(t, nil, nil)
+	handler := NewSessionHandler(session)
+	execute := func(sql string) *Result {
+		t.Helper()
+		stmt, err := BuildStatementWithCommentsWithMode(sql, sql, enums.ParseModeNoMemefish)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := handler.ExecuteStatement(t.Context(), stmt)
+		if err != nil {
+			t.Fatalf("%s: %v", sql, err)
+		}
+		return result
+	}
+	execute(fmt.Sprintf("SET CLI_PROTO_DESCRIPTOR_FILE = %q", root))
+	execute("CREATE PROTO BUNDLE (`imported.Root`, `imported.Child`)")
+	execute("CREATE TABLE ProtoRows (Id INT64 NOT NULL, P imported.Root) PRIMARY KEY (Id)")
+	execute(`INSERT INTO ProtoRows (Id, P) VALUES (1, CAST('child { value: "kept" }' AS imported.Root))`)
+	result := execute("SELECT P FROM ProtoRows WHERE Id = 1")
+	if result.AffectedRows != 1 || result.Typed == nil || len(result.Typed.Rows) != 1 {
+		t.Fatalf("proto query returned no value: %+v", result)
+	}
+	rows, err := deriveDisplayRows(session.systemVariables, result.Typed)
+	if err != nil || len(rows) != 1 || len(rows[0]) != 1 {
+		t.Fatalf("CLI proto display rows = %v, err=%v", rows, err)
+	}
+	files := requireUsableDescriptor(t, session.systemVariables.Internal.ProtoDescriptor)
+	desc, err := files.FindDescriptorByName("imported.Root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := dynamicpb.NewMessage(desc.(protoreflect.MessageDescriptor))
+	// Parse the actual CLI decoder output, not only the SDK response or local
+	// descriptor registry. Text-format whitespace is not part of the contract.
+	decoded := rows[0][0].RawText()
+	if err := prototext.Unmarshal([]byte(decoded), message); err != nil {
+		t.Fatalf("decoded proto text = %q: %v", decoded, err)
+	}
+	childMessage := message.Get(message.Descriptor().Fields().ByName("child")).Message()
+	if got := childMessage.Get(childMessage.Descriptor().Fields().ByName("value")).String(); got != "kept" {
+		t.Fatalf("imported proto field = %q, want kept", got)
+	}
 }
 
 func TestAdminStatements(t *testing.T) {

--- a/internal/mycli/proto_descriptor_graph_test.go
+++ b/internal/mycli/proto_descriptor_graph_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func writeDescriptorSet(t *testing.T, path string, files ...*descriptorpb.FileDescriptorProto) string {
+	t.Helper()
+	b, err := proto.Marshal(&descriptorpb.FileDescriptorSet{File: files})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func descriptorFile(name, pkg string) *descriptorpb.FileDescriptorProto {
+	return &descriptorpb.FileDescriptorProto{
+		Name: proto.String(name), Package: proto.String(pkg), Syntax: proto.String("proto3"),
+		MessageType: []*descriptorpb.DescriptorProto{{Name: proto.String("Root")}},
+	}
+}
+
+func requireUsableDescriptor(t *testing.T, fds *descriptorpb.FileDescriptorSet) *protoregistry.Files {
+	t.Helper()
+	files, err := protodesc.NewFiles(fds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decoder.FormatConfigWithProto(fds, false); err != nil {
+		t.Fatalf("actual decoder rejected descriptors: %v", err)
+	}
+	return files
+}
+
+func writeProtoSource(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.ToSlash(path)
+}
+
+func TestProtoDescriptorDependencyClosure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dep := writeProtoSource(t, filepath.Join(dir, "dep.proto"), `syntax="proto3"; package graph; message Dep { string value=1; }`)
+	left := writeProtoSource(t, filepath.Join(dir, "left.proto"), fmt.Sprintf(`syntax="proto3"; package graph; import %q; message Left { Dep child=1; }`, dep))
+	right := writeProtoSource(t, filepath.Join(dir, "right.proto"), fmt.Sprintf(`syntax="proto3"; package graph; import %q; message Right { Dep child=1; }`, dep))
+	root := writeProtoSource(t, filepath.Join(dir, "root.proto"), fmt.Sprintf(`syntax="proto3"; package graph; import %q; import %q; message Root { Left left=1; Right right=2; }`, left, right))
+	wantNames := []string{dep, left, right, root}
+
+	fds, err := readFileDescriptorProtoFromFile(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, file := range fds.File {
+		names = append(names, file.GetName())
+	}
+	if diff := cmp.Diff(wantNames, names); diff != "" {
+		t.Fatalf("dependency-first diamond closure (-want +got):\n%s", diff)
+	}
+	files := requireUsableDescriptor(t, fds)
+	if _, err := files.FindDescriptorByName("graph.Dep"); err != nil {
+		t.Fatal(err)
+	}
+	again, err := readFileDescriptorProtoFromFile(root)
+	if err != nil || !proto.Equal(fds, again) {
+		t.Fatalf("repeated compilation changed graph: err=%v", err)
+	}
+
+	var sv systemVariables
+	if err := sv.SetFromSimple("CLI_PROTO_DESCRIPTOR_FILE", left+","+root); err != nil {
+		t.Fatal(err)
+	}
+	if len(sv.Internal.ProtoDescriptor.File) != 4 {
+		t.Fatalf("multiple roots duplicated shared dependencies: %v", sv.Internal.ProtoDescriptor)
+	}
+	requireUsableDescriptor(t, sv.Internal.ProtoDescriptor)
+}
+
+func TestProtoDescriptorStandardImport(t *testing.T) {
+	t.Parallel()
+	root := writeProtoSource(t, filepath.Join(t.TempDir(), "root.proto"), `syntax="proto3"; package standard; import "google/protobuf/timestamp.proto"; message Root { google.protobuf.Timestamp value=1; }`)
+	fds, err := readFileDescriptorProtoFromFile(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fds.File) != 2 || fds.File[0].GetName() != "google/protobuf/timestamp.proto" {
+		t.Fatalf("missing standard import: %v", fds)
+	}
+	requireUsableDescriptor(t, fds)
+}
+
+func TestProtoDescriptorInvalidGraphPreservesState(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"SET", "ADD"} {
+		for _, failure := range []string{"missing import", "duplicate symbol", "replaced dependency"} {
+			t.Run(operation+"/"+failure, func(t *testing.T) {
+				t.Parallel()
+				dir := t.TempDir()
+				good := descriptorFile("base.proto", "base")
+				goodFiles := []*descriptorpb.FileDescriptorProto{good}
+				bad := descriptorFile("broken.proto", "broken")
+				bad.Dependency = []string{"missing.proto"}
+				badFiles := []*descriptorpb.FileDescriptorProto{bad}
+				if failure == "duplicate symbol" {
+					bad = descriptorFile("duplicate.proto", "base")
+					badFiles = []*descriptorpb.FileDescriptorProto{good, bad}
+				}
+				if failure == "replaced dependency" {
+					consumer := descriptorFile("consumer.proto", "consumer")
+					consumer.Dependency = []string{"base.proto"}
+					consumer.MessageType[0].Field = []*descriptorpb.FieldDescriptorProto{{
+						Name: proto.String("child"), Number: proto.Int32(1),
+						Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+						Type:  descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(), TypeName: proto.String(".base.Root"),
+					}}
+					goodFiles = append(goodFiles, consumer)
+					bad = descriptorFile("base.proto", "renamed")
+					// This replacement is valid alone but invalidates an existing
+					// consumer; only whole-candidate validation detects that.
+					requireUsableDescriptor(t, &descriptorpb.FileDescriptorSet{File: []*descriptorpb.FileDescriptorProto{bad}})
+					badFiles = []*descriptorpb.FileDescriptorProto{bad, consumer}
+				}
+				goodPath := writeDescriptorSet(t, filepath.Join(dir, "good.pb"), goodFiles...)
+				badPath := writeDescriptorSet(t, filepath.Join(dir, "bad.pb"), badFiles...)
+				var sv systemVariables
+				if err := sv.SetFromSimple("CLI_PROTO_DESCRIPTOR_FILE", goodPath); err != nil {
+					t.Fatal(err)
+				}
+				before := proto.Clone(sv.Internal.ProtoDescriptor)
+				beforePaths := slices.Clone(sv.Internal.ProtoDescriptorFile)
+				var err error
+				if operation == "SET" {
+					err = sv.SetFromSimple("CLI_PROTO_DESCRIPTOR_FILE", badPath)
+				} else {
+					err = sv.AddFromSimple("CLI_PROTO_DESCRIPTOR_FILE", badPath)
+				}
+				if err == nil || !strings.Contains(err.Error(), "invalid proto descriptor set") {
+					t.Errorf("invalid graph error = %v", err)
+				}
+				if !proto.Equal(before, sv.Internal.ProtoDescriptor) || !slices.Equal(beforePaths, sv.Internal.ProtoDescriptorFile) {
+					t.Error("failed load changed descriptor or file list")
+				}
+				requireUsableDescriptor(t, sv.Internal.ProtoDescriptor)
+				if err := sv.AddFromSimple("CLI_PROTO_DESCRIPTOR_FILE", goodPath); err != nil || len(sv.Internal.ProtoDescriptorFile) != 1 {
+					t.Fatalf("duplicate ADD no longer a no-op: err=%v", err)
+				}
+				if err := sv.SetFromSimple("CLI_PROTO_DESCRIPTOR_FILE", ""); err != nil || sv.Internal.ProtoDescriptor != nil || len(sv.Internal.ProtoDescriptorFile) != 0 {
+					t.Fatalf("empty reset failed: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestProtoDescriptorFileIdentityReplacement(t *testing.T) {
+	t.Parallel()
+	for _, pkg := range []string{"old", "new"} {
+		t.Run(pkg, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			first := writeDescriptorSet(t, filepath.Join(dir, "first.pb"), descriptorFile("shared.proto", "old"))
+			replacement := descriptorFile("shared.proto", pkg)
+			replacement.MessageType = append(replacement.MessageType, &descriptorpb.DescriptorProto{Name: proto.String("Added")})
+			second := writeDescriptorSet(t, filepath.Join(dir, "second.pb"), replacement)
+			var sv systemVariables
+			if err := sv.SetFromSimple("CLI_PROTO_DESCRIPTOR_FILE", first+","+second); err != nil {
+				t.Fatal(err)
+			}
+			if len(sv.Internal.ProtoDescriptor.File) != 1 {
+				t.Fatalf("file identity duplicated: %v", sv.Internal.ProtoDescriptor)
+			}
+			files := requireUsableDescriptor(t, sv.Internal.ProtoDescriptor)
+			if _, err := files.FindDescriptorByName(protoreflect.FullName(pkg + ".Added")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestApplyProtoDescriptorsCombinedInputs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dep := descriptorFile("dep.proto", "dep")
+	root := descriptorFile("root.proto", "root")
+	root.Dependency = []string{"dep.proto"}
+	root.MessageType[0].Field = []*descriptorpb.FieldDescriptorProto{{
+		Name: proto.String("child"), Number: proto.Int32(1),
+		Label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		Type:  descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(), TypeName: proto.String(".dep.Root"),
+	}}
+	rootPath := writeDescriptorSet(t, filepath.Join(dir, "root.pb"), root)
+	depPath := writeDescriptorSet(t, filepath.Join(dir, "dep.pb"), dep)
+	for _, path := range []string{rootPath + "," + depPath, depPath + "," + rootPath} {
+		var sv systemVariables
+		if err := applyProtoDescriptors(&sv, &spannerOptions{ProtoDescriptorFile: path}); err != nil {
+			t.Fatal(err)
+		}
+		requireUsableDescriptor(t, sv.Internal.ProtoDescriptor)
+		if len(sv.Internal.ProtoDescriptorFile) != 2 {
+			t.Fatalf("startup file list = %v", sv.Internal.ProtoDescriptorFile)
+		}
+	}
+}

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bufbuild/protocompile"
 	"github.com/cloudspannerecosystem/memefish/ast"
 	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	"google.golang.org/protobuf/proto"
@@ -491,7 +492,10 @@ func mergeFDS(left, right *descriptorpb.FileDescriptorSet) *descriptorpb.FileDes
 	result := slices.Clone(left.GetFile())
 	for _, fd := range right.GetFile() {
 		idx := slices.IndexFunc(result, func(descriptorProto *descriptorpb.FileDescriptorProto) bool {
-			return descriptorProto.GetPackage() == fd.GetPackage() && descriptorProto.GetName() == fd.GetName()
+			// File names, not package/name pairs, identify protobuf files. Later
+			// inputs replace earlier versions; the complete graph is validated
+			// before installation, including references affected by replacement.
+			return descriptorProto.GetName() == fd.GetName()
 		})
 		if idx != -1 {
 			result[idx] = fd
@@ -532,9 +536,25 @@ func readFileDescriptorProtoFromFile(filename string) (*descriptorpb.FileDescrip
 			return nil, err
 		}
 
-		return &descriptorpb.FileDescriptorSet{
-			File: sliceOf(protodesc.ToFileDescriptorProto(files.FindFileByPath(filename))),
-		}, nil
+		// Compile returns roots with linked imports, not a flat descriptor set.
+		// Export each dependency once, in dependency-first declared import order,
+		// so both the decoder and the DDL request can resolve the same graph.
+		var result descriptorpb.FileDescriptorSet
+		seen := make(map[string]bool)
+		var visit func(protoreflect.FileDescriptor)
+		visit = func(file protoreflect.FileDescriptor) {
+			if seen[file.Path()] {
+				return
+			}
+			seen[file.Path()] = true
+			imports := file.Imports()
+			for i := range imports.Len() {
+				visit(imports.Get(i).FileDescriptor)
+			}
+			result.File = append(result.File, protodesc.ToFileDescriptorProto(file))
+		}
+		visit(files.FindFileByPath(filename))
+		return &result, nil
 	}
 
 	var b []byte

--- a/internal/mycli/var_custom_handlers.go
+++ b/internal/mycli/var_custom_handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/filesafety"
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -137,6 +138,11 @@ func (p *ProtoDescriptorVar) Set(value string) error {
 		}
 		fileDescriptorSet = mergeFDS(fileDescriptorSet, fds)
 	}
+	// Individual binary inputs may be fragments of one graph. Validate only
+	// after the complete candidate has been assembled, before changing state.
+	if _, err := protodesc.NewFiles(fileDescriptorSet); err != nil {
+		return fmt.Errorf("invalid proto descriptor set: %w", err)
+	}
 
 	*p.filesPtr = files
 	*p.descriptorPtr = fileDescriptorSet
@@ -156,8 +162,12 @@ func (p *ProtoDescriptorVar) Add(value string) error {
 		return err
 	}
 
+	candidate := mergeFDS(*p.descriptorPtr, fds)
+	if _, err := protodesc.NewFiles(candidate); err != nil {
+		return fmt.Errorf("invalid proto descriptor set: %w", err)
+	}
 	*p.filesPtr = append(*p.filesPtr, value)
-	*p.descriptorPtr = mergeFDS(*p.descriptorPtr, fds)
+	*p.descriptorPtr = candidate
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Include the full linked dependency graph when compiling a `.proto` input,
  including shared/transitive and standard imports, in deterministic
  dependency-first order.
- Validate the complete merged descriptor graph before installing it. Failed
  SET or ADD leaves the previous descriptor and file list unchanged. Later
  inputs replace earlier definitions of the same protobuf file name, with
  references checked after replacement.
- Load comma-separated startup inputs as one candidate so binary descriptor
  fragments can resolve each other's imports, just as with multi-input SET.
  Keep the existing startup error context and document the loading contract.

## Validation

- Full `make check` and `make check-race` on Go 1.26.8 / golangci-lint 2.13.2.
- Targeted graph/flag race tests, existing descriptor tests and original-source
  negative controls. Invalid imports, duplicate symbols and broken references
  after file replacement are rejected without changing the previous state.
- Actual local-emulator PROTO BUNDLE creation, table/insert/select and CLI
  decoding of a message whose child type comes from an imported `.proto` file.

This does not implement remote descriptor reconstruction, recursive nested-type
UPSERT or descriptor transport in DUMP, and does not change file/network limits
or compiler cancellation. Successful local graph validation is not a guarantee
that every protobuf feature is supported by the database.
