### PR TITLE
build: migrate GoReleaser archive format keys

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ builds:
     ldflags: -s -w -X main.version={{.Version}} -X "main.installFrom=downloaded from release page"
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -37,7 +37,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 release:
   draft: true


### PR DESCRIPTION
## Summary

Replace the deprecated `archives.format` and `archives.format_overrides.format` keys with singleton `formats` lists, following the [GoReleaser migration guide](https://goreleaser.com/resources/deprecations/#archivesformat).

Keep tar.gz for Linux/macOS and zip for Windows. Build targets, archive names and members, hooks, draft-release policy and publishing workflows are unchanged. This does not add a slim artifact or depend on the broader release scaffold changes.

## Validation

- GoReleaser 2.18.0 configuration check passes without deprecation warnings; the previous configuration returned exit 2 for the deprecated properties.
- A non-publishing snapshot build with Go 1.26.8 successfully built and packaged all eight configured targets. Before hooks were skipped for this packaging check.
- All eight archive names match the previous release, each contains the expected license/README/platform binary, and every SHA-256 checksum verifies.
- Extracted macOS arm64 binary passes version/help smoke tests. Other target binaries were cross-compiled, not executed.
- `make check` passes, including the full test suite, lint and formatting checks.

This validates the configuration change and local snapshot packaging, not final tagged release assets. No tag or release was created.
