### PR TITLE
fix: preserve ANSI-aware table width and wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,12 @@ is unchanged. It does not change when plans are cached or cleared (plain
 > - Set to empty string to disable all type styling.
 > - See [docs/system_variables.md](docs/system_variables.md) for full reference.
 
+Table width calculation and wrapping account for 7-bit ANSI escape sequences
+already present in values or headers, independently of CLI-added type styling.
+SGR color/style sequences are preserved across wrapped lines. Disabling CLI
+styling does not sanitize escape sequences in the input; CSV, JSONL and SQL
+export behavior is unchanged.
+
 ### Batch statements
 
 #### DDL batching

--- a/internal/mycli/format/ansi_width_test.go
+++ b/internal/mycli/format/ansi_width_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/apstndb/spanner-mycli/enums"
+)
+
+// Remove only complete sequences used by these fixtures and tab markers. A
+// split escape must remain in the output and fail the exact layout comparison.
+var ansiWidthFixtureStrip = strings.NewReplacer(
+	"\x1b[31m", "", "\x1b[32m", "", "\x1b[0m", "",
+	"\x1b[2m", "", "\x1b[22m", "",
+)
+
+func TestTableANSIWidthCondition(t *testing.T) {
+	f := &TableStreamingFormatter{config: FormatConfig{TabWidth: 8}}
+	cond := f.newCondition()
+	if got := cond.StringWidth("\x1b[31mred\x1b[0m\tx"); got != 9 {
+		t.Fatalf("visible width = %d, want 9", got)
+	}
+	wc := &widthCalculator{Condition: cond}
+	plain := wc.adjustByHeader([]string{"first", "second"}, 15)
+	colored := wc.adjustByHeader([]string{"first", "\x1b[31msecond\x1b[0m"}, 15)
+	if !reflect.DeepEqual(plain, colored) {
+		t.Fatalf("header allocation plain=%v colored=%v", plain, colored)
+	}
+	wrapped := cond.Wrap("\x1b[31mabcdef\x1b[0m", 3)
+	if want := "\x1b[31mabc\x1b[0m\n\x1b[31mdef\x1b[0m"; wrapped != want {
+		t.Fatalf("SGR carry-over = %q, want %q", wrapped, want)
+	}
+}
+
+func TestTableANSILayout(t *testing.T) {
+	for _, strategy := range enums.WidthStrategyValues() {
+		for _, styled := range []bool{false, true} {
+			for _, streaming := range []bool{false, true} {
+				for _, visualize := range []bool{false, true} {
+					for _, width := range []int{20, 40, 80} {
+						t.Run(fmt.Sprintf("%s/styled%v/stream%v/tabs%v/width%d", strategy, styled, streaming, visualize, width), func(t *testing.T) {
+							config := FormatConfig{WidthStrategy: strategy, Styled: styled, TabVisualize: visualize, TabWidth: 4}
+							for _, coloredHeader := range []bool{false, true} {
+								render := func(color bool) ([]int, string) {
+									headers := []string{"first", "second"}
+									values := []string{"abcdefghijklmnop", "界e\u0301\tx"}
+									if color {
+										if coloredHeader {
+											headers[1] = "\x1b[31m" + headers[1] + "\x1b[0m"
+										} else {
+											for i := range values {
+												values[i] = "\x1b[31m" + values[i] + "\x1b[0m"
+											}
+										}
+									}
+									rows := []Row{StringsToRow(values...)}
+									// Exercise the same raw text with CLI-added styles independently.
+									rows[0][0] = StyledCell{Text: values[0], Style: "\x1b[32m"}
+									var out bytes.Buffer
+									var f *TableStreamingFormatter
+									if streaming {
+										f = NewTableStreamingFormatter(&out, config, width, 1, ModeTable)
+									} else {
+										f = NewTableFormatterForBuffered(&out, config, width, ModeTable, TableParams{})
+									}
+									if err := ExecuteWithFormatter(f, rows, headers, config); err != nil {
+										t.Fatal(err)
+									}
+									return f.widths, out.String()
+								}
+								plainWidths, plain := render(false)
+								coloredWidths, colored := render(true)
+								if !reflect.DeepEqual(plainWidths, coloredWidths) {
+									t.Errorf("header%v widths plain=%v colored=%v", coloredHeader, plainWidths, coloredWidths)
+								}
+								if ansiWidthFixtureStrip.Replace(colored) != ansiWidthFixtureStrip.Replace(plain) {
+									t.Errorf("header%v layout mismatch:\nplain=%q\ncolored=%q", coloredHeader, plain, colored)
+								}
+								if !strings.Contains(colored, "\x1b[31m") || !strings.Contains(colored, "\x1b[0m") {
+									t.Errorf("input color lost: %q", colored)
+								}
+								if !styled && strings.Contains(colored, "\x1b[32m") {
+									t.Errorf("disabled CLI style was emitted: %q", colored)
+								}
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/mycli/format/streaming_table.go
+++ b/internal/mycli/format/streaming_table.go
@@ -231,7 +231,10 @@ func (f *TableStreamingFormatter) FinishFormat() error {
 
 // newCondition creates a tabwrap.Condition from the formatter's config.
 func (f *TableStreamingFormatter) newCondition() *tabwrap.Condition {
-	return &tabwrap.Condition{TabWidth: cmp.Or(f.config.TabWidth, 4)}
+	// Styled controls whether the CLI adds styles, not whether input text can
+	// already contain ANSI escapes. Use the same visible-width rules for raw
+	// cells, headers, tab expansion and wrapping, even with CLI styling disabled.
+	return &tabwrap.Condition{TabWidth: cmp.Or(f.config.TabWidth, 4), ControlSequences: true}
 }
 
 // calculateWidths calculates optimal column widths based on preview rows.

--- a/internal/mycli/format/width.go
+++ b/internal/mycli/format/width.go
@@ -257,8 +257,8 @@ func (wc WidthCount) Length() int { return wc.width }
 // Count returns the frequency count.
 func (wc WidthCount) Count() int { return wc.count }
 
-func adjustByHeader(headers []string, availableWidth int) []int {
-	nameWidths := slices.Collect(loi.Map(slices.Values(headers), tabwrap.StringWidth))
+func (wc *widthCalculator) adjustByHeader(headers []string, availableWidth int) []int {
+	nameWidths := slices.Collect(loi.Map(slices.Values(headers), wc.StringWidth))
 
 	adjustWidths, _ := adjustToSum(availableWidth, nameWidths)
 

--- a/internal/mycli/format/width_strategy_greedy.go
+++ b/internal/mycli/format/width_strategy_greedy.go
@@ -46,7 +46,7 @@ func (GreedyFrequencyStrategy) CalculateWidths(wc *widthCalculator, availableWid
 		return fmt.Sprintf("remaining %v, adjustedWidths: %v", remainsWidth-sumWidths(adjustedWidths), adjustedWidths)
 	}
 
-	adjustedWidths := adjustByHeader(headers, availableWidth)
+	adjustedWidths := wc.adjustByHeader(headers, availableWidth)
 
 	applyColumnFloors(adjustedWidths, hints, availableWidth)
 

--- a/internal/mycli/format/width_strategy_marginal.go
+++ b/internal/mycli/format/width_strategy_marginal.go
@@ -46,7 +46,7 @@ func (MarginalCostStrategy) CalculateWidths(wc *widthCalculator, availableWidth 
 	}
 
 	// Start with header-proportional allocation + preferred/min width floor.
-	adjustedWidths := adjustByHeader(headers, availableWidth)
+	adjustedWidths := wc.adjustByHeader(headers, availableWidth)
 	applyColumnFloors(adjustedWidths, hints, availableWidth)
 
 	remaining := availableWidth - lo.Sum(adjustedWidths)

--- a/internal/mycli/format/width_strategy_proportional.go
+++ b/internal/mycli/format/width_strategy_proportional.go
@@ -46,7 +46,7 @@ func (ProportionalStrategy) CalculateWidths(wc *widthCalculator, availableWidth 
 	}
 
 	// Start with header-proportional allocation + preferred/min width floor.
-	adjustedWidths := adjustByHeader(headers, availableWidth)
+	adjustedWidths := wc.adjustByHeader(headers, availableWidth)
 	applyColumnFloors(adjustedWidths, hints, availableWidth)
 
 	// Compute deficit per column: how much more each column wants.

--- a/internal/mycli/format/width_test.go
+++ b/internal/mycli/format/width_test.go
@@ -221,7 +221,7 @@ func TestAdjustByHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := adjustByHeader(tt.headers, tt.availableWidth)
+			got := newTestWidthCalculator().adjustByHeader(tt.headers, tt.availableWidth)
 			if len(got) != tt.wantLen {
 				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
 			}


### PR DESCRIPTION
## Summary

- Use the existing ANSI-aware table-width condition for raw cell text, headers,
  tab expansion and wrapping, independently of whether the CLI adds styles.
- Initialize header widths through the same configured calculator in all three
  width strategies, so ANSI codes do not distort initial allocation.
- Preserve SGR sequences and their wrap-boundary reset/replay behavior. Keep
  styling disabled when requested; this does not sanitize ANSI already present
  in input. CSV, JSONL and SQL exports are unchanged.

## Validation

- `make check`, `make check-race`, `make docs-update` using Go 1.26.8 and
  golangci-lint 2.13.2.
- Format-package race tests covering three width strategies and screen widths,
  streaming/buffered paths, raw and CLI-added styles, headers/cells, tabs and
  combining/CJK text. Compare visible layouts and assert complete input escapes
  survive; verify SGR carry-over and configured tab widths directly.
- The original table formatter overlaid on the final tests fails visible-width
  and layout assertions; the candidate passes. No dependencies were changed.

Fixes #763.
