### PR TITLE
fix: shorten plain EXPLAIN headers for narrow plans

### DIFF
--- a/docs/query_plan.md
+++ b/docs/query_plan.md
@@ -485,6 +485,11 @@ Predicates(identified by ID):
 When you want to adjust the width, such as when displaying an execution plan on media where horizontal scrolling is not possible and content might be truncated or wrapped,
 you can use the `WIDTH=<width>` option to wrap the content of the `Operator` column at the specified width.
 
+Both `EXPLAIN` and `EXPLAIN ANALYZE` shorten the operator header to `Operator`
+when the effective wrap width is narrower than the full header. The effective
+width comes from `WIDTH` or, when omitted or zero, `CLI_EXPLAIN_WRAP_WIDTH`.
+This controls the operator column, not the total table width.
+
 For example, in the illustration below, by setting the width of the ASCII tree drawn in the Operator column to 39 characters,
 the entire output, including the ASCII table, can fit within 80 characters.
 

--- a/internal/mycli/explain_header_width_test.go
+++ b/internal/mycli/explain_header_width_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/olekukonko/tablewriter/tw"
+)
+
+func TestExplainResultHeaderWidth(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name                string
+		width, defaultWidth int64
+		want                string
+	}{
+		{"unlimited", 0, 0, operatorColumnName},
+		{"narrow", 20, 0, "Operator"},
+		{"below_boundary", operatorColumnNameLength - 1, 0, "Operator"},
+		{"at_boundary", operatorColumnNameLength, 0, operatorColumnName},
+		{"wide", 80, 0, operatorColumnName},
+		{"narrow_default", 0, 20, "Operator"},
+		{"wide_default", 0, 80, operatorColumnName},
+		{"narrow_override", 20, 80, "Operator"},
+		{"wide_override", 80, 20, operatorColumnName},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := newSystemVariablesWithDefaultsForTest()
+			vars.Display.ExplainWrapWidth = tt.defaultWidth
+			plan := &sppb.QueryPlan{PlanNodes: hangingIndentPlanNodes()}
+			plain, err := generateExplainResult(vars, plan, enums.ExplainFormatCurrent, tt.width, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			analyze, err := buildExplainAnalyzeResult(vars, plan, QueryStats{}, enums.ExplainFormatCurrent, tt.width, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for name, result := range map[string]*Result{"plain": plain, "analyze": analyze} {
+				got := result.TableHeader.Render(false)
+				if len(got) < 2 || !slices.Equal(got[:2], []string{"ID", tt.want}) {
+					t.Errorf("%s header = %v, want base [ID %s]", name, got, tt.want)
+				}
+				if len(result.Rows) != 3 {
+					t.Errorf("%s rows = %d, want 3", name, len(result.Rows))
+				}
+				if !slices.Equal(result.ColumnAlign[:2], explainColumnAlign) {
+					t.Errorf("%s alignment changed", name)
+				}
+			}
+		})
+	}
+}
+
+func TestExplainAnalyzeHeaderPreservesCustomColumns(t *testing.T) {
+	t.Parallel()
+	def := []columnRenderDef{{Name: "Elapsed", Alignment: tw.AlignCenter}}
+	for _, width := range []int64{0, 20, operatorColumnNameLength} {
+		names, aligns := explainAnalyzeHeader(def, width)
+		if len(names) != 3 || names[2] != "Elapsed" || !slices.Equal(aligns, []tw.Align{tw.AlignRight, tw.AlignLeft, tw.AlignCenter}) {
+			t.Errorf("width %d: names=%v aligns=%v", width, names, aligns)
+		}
+	}
+}
+
+func TestExplainNarrowHeaderRenderedTable(t *testing.T) {
+	t.Parallel()
+	vars := newSystemVariablesWithDefaultsForTest()
+	plan := &sppb.QueryPlan{PlanNodes: hangingIndentPlanNodes()}
+	result, err := generateExplainResult(vars, plan, enums.ExplainFormatCurrent, 20, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := printTableData(vars, 0, &out, result); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), operatorColumnName) || !strings.Contains(out.String(), "Operator") || !strings.Contains(out.String(), "Cross Apply") {
+		t.Fatalf("unexpected narrow plan table:\n%s", out.String())
+	}
+	// WIDTH limits the operator content, not ID, borders or cell padding.
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if len(line) > 30 {
+			t.Errorf("long header still widens WIDTH20 table: %q", line)
+		}
+	}
+}

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -427,7 +427,7 @@ func generateExplainResult(sysVars *systemVariables, queryPlan *sppb.QueryPlan, 
 	}
 
 	result := &Result{
-		TableHeader:  toTableHeader(explainColumnNames),
+		TableHeader:  toTableHeader(explainBaseColumnNames(width)),
 		ColumnAlign:  explainColumnAlign,
 		AffectedRows: len(rows),
 		Rows:         rows,
@@ -551,9 +551,14 @@ func buildExplainAnalyzeResult(sysVars *systemVariables, plan *sppb.QueryPlan, q
 	return result, nil
 }
 
+func explainBaseColumnNames(width int64) []string {
+	// Keep the header from widening a wrapped operator column in either mode.
+	return lo.Ternary(width == 0 || width >= operatorColumnNameLength, explainColumnNames, explainColumnNamesShort)
+}
+
 func explainAnalyzeHeader(def []columnRenderDef, width int64) ([]string, []tw.Align) {
 	// Start with the base columns and alignments for EXPLAIN output.
-	baseNames := lo.Ternary(width == 0 || width >= operatorColumnNameLength, explainColumnNames, explainColumnNamesShort)
+	baseNames := explainBaseColumnNames(width)
 	baseAlign := explainColumnAlign
 
 	// Extract the names and alignments from the custom column definitions.


### PR DESCRIPTION
## Summary

- Apply the existing EXPLAIN ANALYZE operator-header shortening rule to plain EXPLAIN, so a long header does not widen an otherwise narrow wrapped plan.
- Share the rule after resolving statement-level WIDTH versus CLI_EXPLAIN_WRAP_WIDTH. Unlimited and wide output retain the full header; custom ANALYZE columns and alignment are unchanged.
- Document that WIDTH controls operator content rather than total table width, and cover narrow/boundary/wide widths, inherited defaults, overrides, and rendered TABLE output.

Related to #765. This does not add configurable base-column labels or complete that feature request.

## Validation

- Targeted EXPLAIN header tests with `-short -race -count=1` passed.
- Replacing the production file with its original version via a Go overlay makes the narrow-header and rendered-table regressions fail; unlimited/wide/boundary and custom ANALYZE controls still pass.
- `make check check-race docs-update` passed with Go 1.26.8 and golangci-lint 2.13.2; generated documentation had no additional changes.

Rendering checks use a synthetic query plan and do not require a managed Spanner instance.
