### PR TITLE
fix: isolate EXPLAIN template execution errors

### DIFF
--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -663,7 +663,9 @@ func templateMapFunc(tmplName, tmplText string) (func(row plantree.RowWithPredic
 
 	return func(row plantree.RowWithPredicates) (string, error) {
 		var sb strings.Builder
-		if err = tmpl.Execute(&sb, row.ExecutionStats); err != nil {
+		// Use a per-call error so concurrent EXPLAIN/ANALYZE renders do not
+		// race on the Parse error from the enclosing function.
+		if err := tmpl.Execute(&sb, row.ExecutionStats); err != nil {
 			return "", err
 		}
 

--- a/internal/mycli/statements_explain_describe_test.go
+++ b/internal/mycli/statements_explain_describe_test.go
@@ -27,6 +27,34 @@ import (
 
 // Test helpers for explain/describe statements
 
+func TestTemplateMapFuncConcurrent(t *testing.T) {
+	t.Parallel()
+	render, err := templateMapFunc("concurrent", `{{if eq .Rows.Total "bad"}}{{index .Rows.Histogram 0}}{{else}}{{.Rows.Total}}{{end}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 32 {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			want := fmt.Sprint(i)
+			if i%2 == 0 {
+				want = "bad"
+			}
+			row := plantree.RowWithPredicates{ExecutionStats: stats.ExecutionStats{Rows: stats.ExecutionStatsValue{Total: want}}}
+			for range 20 {
+				got, err := render(row)
+				if want == "bad" {
+					if err == nil || got != "" {
+						t.Fatalf("failed template: got %q, error %v", got, err)
+					}
+				} else if err != nil || got != want {
+					t.Fatalf("got %q, error %v; want %q", got, err, want)
+				}
+			}
+		})
+	}
+}
+
 func mustNewStruct(m map[string]interface{}) *structpb.Struct {
 	if s, err := structpb.NewStruct(m); err != nil {
 		panic(err)


### PR DESCRIPTION
Concurrent EXPLAIN renderers can race on the `err` captured from template parsing. A failing render may overwrite another call's error and turn a successful result into an empty string. Keep the Execute error local to each invocation, alongside its existing local output builder.

Add a concurrent regression sharing one renderer across successful and failing template inputs. The original-source overlay reports data races and incorrect empty output; the corrected implementation passes.

Validation: `make check check-race` passed, including the full emulator-backed suite and the unit race suite.
