### PR TITLE
refactor: consolidate completion caches by kind

### DIFF
--- a/internal/mycli/fuzzy_finder.go
+++ b/internal/mycli/fuzzy_finder.go
@@ -93,15 +93,9 @@ type fuzzyFinderCommand struct {
 	editor *multiline.Editor
 	cli    *Cli
 
-	// Caches for network-dependent candidates.
-	databaseCache     *fuzzyCacheEntry
-	tableCache        *fuzzyCacheEntry
-	viewCache         *fuzzyCacheEntry
-	indexCache        *fuzzyCacheEntry
-	changeStreamCache *fuzzyCacheEntry
-	sequenceCache     *fuzzyCacheEntry
-	modelCache        *fuzzyCacheEntry
-	schemaCache       *fuzzyCacheEntry
+	// Cache only database and schema-object candidates; other network-backed
+	// completions (roles and operations) depend on context or change rapidly.
+	cache map[fuzzyCompletionType]*fuzzyCacheEntry
 }
 
 func (f *fuzzyFinderCommand) String() string {
@@ -652,73 +646,33 @@ func unwrapCustomVar(v Variable) Variable {
 
 // getCachedCandidates returns cached candidates if the cache is valid, or nil.
 func (f *fuzzyFinderCommand) getCachedCandidates(ct fuzzyCompletionType) []fzfItem {
-	session := f.cli.SessionHandler.GetSession()
-	switch ct {
-	case fuzzyCompleteDatabase:
-		if f.databaseCache.valid(session, false) {
-			return f.databaseCache.candidates
-		}
-	case fuzzyCompleteTable:
-		if f.tableCache.valid(session, true) {
-			return f.tableCache.candidates
-		}
-	case fuzzyCompleteView:
-		if f.viewCache.valid(session, true) {
-			return f.viewCache.candidates
-		}
-	case fuzzyCompleteIndex:
-		if f.indexCache.valid(session, true) {
-			return f.indexCache.candidates
-		}
-	case fuzzyCompleteChangeStream:
-		if f.changeStreamCache.valid(session, true) {
-			return f.changeStreamCache.candidates
-		}
-	case fuzzyCompleteSequence:
-		if f.sequenceCache.valid(session, true) {
-			return f.sequenceCache.candidates
-		}
-	case fuzzyCompleteModel:
-		if f.modelCache.valid(session, true) {
-			return f.modelCache.candidates
-		}
-	case fuzzyCompleteSchema:
-		if f.schemaCache.valid(session, true) {
-			return f.schemaCache.candidates
-		}
+	entry := f.cache[ct]
+	if entry.valid(f.cli.SessionHandler.GetSession(), ct != fuzzyCompleteDatabase) {
+		return entry.candidates
 	}
 	return nil
 }
 
-// setCachedCandidates stores candidates in the appropriate cache.
+// setCachedCandidates stores candidates for database and schema-object completion.
 func (f *fuzzyFinderCommand) setCachedCandidates(ct fuzzyCompletionType, candidates []fzfItem) {
+	switch ct {
+	case fuzzyCompleteDatabase, fuzzyCompleteTable, fuzzyCompleteView, fuzzyCompleteIndex,
+		fuzzyCompleteChangeStream, fuzzyCompleteSequence, fuzzyCompleteModel, fuzzyCompleteSchema:
+	default:
+		return
+	}
 	session := f.cli.SessionHandler.GetSession()
 	if session == nil {
 		return
 	}
-	entry := &fuzzyCacheEntry{
+	if f.cache == nil {
+		f.cache = make(map[fuzzyCompletionType]*fuzzyCacheEntry)
+	}
+	f.cache[ct] = &fuzzyCacheEntry{
 		candidates:       candidates,
 		expiresAt:        time.Now().Add(fuzzyCacheTTL),
 		session:          session,
 		schemaGeneration: session.SchemaGeneration(),
-	}
-	switch ct {
-	case fuzzyCompleteDatabase:
-		f.databaseCache = entry
-	case fuzzyCompleteTable:
-		f.tableCache = entry
-	case fuzzyCompleteView:
-		f.viewCache = entry
-	case fuzzyCompleteIndex:
-		f.indexCache = entry
-	case fuzzyCompleteChangeStream:
-		f.changeStreamCache = entry
-	case fuzzyCompleteSequence:
-		f.sequenceCache = entry
-	case fuzzyCompleteModel:
-		f.modelCache = entry
-	case fuzzyCompleteSchema:
-		f.schemaCache = entry
 	}
 }
 

--- a/internal/mycli/fuzzy_finder_test.go
+++ b/internal/mycli/fuzzy_finder_test.go
@@ -1264,3 +1264,39 @@ func TestFuzzyCacheEntryValid(t *testing.T) {
 		})
 	}
 }
+
+func TestFuzzyCandidateCacheScope(t *testing.T) {
+	t.Parallel()
+	handler := &SessionHandler{Session: &Session{}}
+	f := &fuzzyFinderCommand{cli: &Cli{SessionHandler: handler}}
+	cached := []fuzzyCompletionType{
+		fuzzyCompleteDatabase, fuzzyCompleteTable, fuzzyCompleteView,
+		fuzzyCompleteIndex, fuzzyCompleteChangeStream, fuzzyCompleteSequence, fuzzyCompleteModel, fuzzyCompleteSchema,
+	}
+	for _, ct := range cached {
+		assert.Nil(t, f.getCachedCandidates(ct))
+		f.setCachedCandidates(ct, []fzfItem{{Value: ct.String()}})
+	}
+	for _, ct := range cached {
+		assert.Equal(t, []fzfItem{{Value: ct.String()}}, f.getCachedCandidates(ct))
+	}
+	for _, ct := range []fuzzyCompletionType{fuzzyCompleteRole, fuzzyCompleteOperation, fuzzyCompleteVariable, fuzzyCompleteParam} {
+		f.setCachedCandidates(ct, []fzfItem{{Value: "must not be cached"}})
+		assert.Nil(t, f.getCachedCandidates(ct))
+	}
+
+	// DDL invalidates schema objects but not the database list.
+	handler.schemaGeneration++
+	for _, ct := range cached {
+		if ct == fuzzyCompleteDatabase {
+			assert.Equal(t, []fzfItem{{Value: ct.String()}}, f.getCachedCandidates(ct))
+		} else {
+			assert.Nil(t, f.getCachedCandidates(ct))
+		}
+	}
+	// USE invalidates every kind, even when the schema generations match.
+	handler.Session = &Session{}
+	for _, ct := range cached {
+		assert.Nil(t, f.getCachedCandidates(ct))
+	}
+}


### PR DESCRIPTION
Store database and schema-object completion candidates in one map keyed by completion kind. This removes parallel cache fields and duplicated lookup/write branches while retaining session, schema-generation, and TTL invalidation. Role and operation candidates remain uncached.

Validation: focused cache-scope and invalidation tests, and `make check`.
