### PR TITLE
refactor: share DUMP traversal through an explicit writer

### DIFF
--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -37,9 +37,10 @@ func effectiveQueryMode(userMode *sppb.ExecuteSqlRequest_QueryMode) sppb.Execute
 	}
 }
 
-// executeSQLWithFormatAndTxn executes SQL with specific format settings and within a given transaction.
-// This is for use within withReadOnlyTransaction callbacks where we already have a transaction.
-func executeSQLWithFormatAndTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, format enums.DisplayMode, streamingMode enums.StreamingMode, sqlTableName string) (*Result, error) {
+// executeSQLWithFormatAndTxn executes SQL with specific format settings and
+// within a given transaction. out, when non-nil, is the explicit destination
+// for streaming output instead of the session's statement-level destination.
+func executeSQLWithFormatAndTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, format enums.DisplayMode, streamingMode enums.StreamingMode, sqlTableName string, out io.Writer) (*Result, error) {
 	// Create a copy of the system variables for this specific execution
 	tempVars := *session.systemVariables
 
@@ -54,7 +55,7 @@ func executeSQLWithFormatAndTxn(ctx context.Context, session *Session, txn *span
 	tempVars.Display.EnableProgressBar = false
 
 	// Execute with the transaction directly
-	return executeSQLImplWithTxn(ctx, session, txn, sql, &tempVars)
+	return executeSQLImplWithTxn(ctx, session, txn, sql, &tempVars, out)
 }
 
 func executeSQL(ctx context.Context, session *Session, sql string) (*Result, error) {
@@ -157,6 +158,7 @@ func finalizeMetrics(m *metrics.ExecutionMetrics, sysVars *systemVariables) {
 // avoiding 9+ individual parameters through executeAndCollect and its downstream functions.
 type queryExecution struct {
 	Session      *Session
+	Output       io.Writer
 	Iter         *spanner.RowIterator
 	ReadOnlyTxn  *spanner.ReadOnlyTransaction
 	FormatConfig *spanvalue.FormatConfig
@@ -165,6 +167,13 @@ type queryExecution struct {
 	Metrics      *metrics.ExecutionMetrics
 	ValueFmtMode format.ValueFormatMode
 	Processor    RowProcessor // set by executeAndCollect after decideExecutionMode
+}
+
+func (qe *queryExecution) outputWriter() io.Writer {
+	if qe.Output != nil {
+		return qe.Output
+	}
+	return qe.Session.outputWriter()
 }
 
 // executeAndCollect runs the query iterator (streaming or buffered) and attaches metrics to the result.
@@ -201,7 +210,7 @@ func executeAndCollect(ctx context.Context, qe *queryExecution) (*Result, error)
 
 // executeSQLImplWithTxn executes SQL with specific system variables and within a given transaction.
 // This is for use when we have a specific transaction to use.
-func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, sysVars *systemVariables) (*Result, error) {
+func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, sysVars *systemVariables, out io.Writer) (*Result, error) {
 	m := newMetrics(sysVars)
 
 	fc, vfm, sysVars, err := prepareFormatConfig(sql, sysVars)
@@ -224,6 +233,7 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 
 	return executeAndCollect(ctx, &queryExecution{
 		Session:      session,
+		Output:       out,
 		Iter:         iter,
 		ReadOnlyTxn:  txn,
 		FormatConfig: fc,
@@ -321,9 +331,9 @@ func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql st
 // RowProcessor: executeStreamingSQLWithSpanvalueWriter creates and validates
 // the writer itself.
 func decideExecutionMode(qe *queryExecution) (bool, RowProcessor, error) {
-	// The per-statement output destination (respects tee/redirect settings
-	// and the MCP handler's capture buffer).
-	outStream := qe.Session.outputWriter()
+	// The explicit operation destination takes precedence over the statement
+	// destination, which respects tee/redirect settings and MCP capture.
+	outStream := qe.outputWriter()
 	if outStream == nil {
 		return false, nil, nil
 	}

--- a/internal/mycli/integration_dump_test.go
+++ b/internal/mycli/integration_dump_test.go
@@ -548,6 +548,17 @@ func TestDumpWithGeneratedColumns(t *testing.T) {
 	if diff := cmp.Diff(expectedOutput, dumpRenderedOutputForTest(t, result)); diff != "" {
 		t.Errorf("DUMP output mismatch (-want +got):\n%s", diff)
 	}
+
+	streamedResult, streamedOutput, err := executeSQLExportForTest(t, ctx, session, "DUMP TABLES Users")
+	if err != nil {
+		t.Fatalf("streamed DUMP TABLES failed: %v", err)
+	}
+	if !streamedResult.Streamed {
+		t.Fatal("expected streamed DUMP")
+	}
+	if diff := cmp.Diff(expectedOutput, streamedOutput); diff != "" {
+		t.Errorf("streamed DUMP output mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestDumpFloat32NegativeZeroReplay(t *testing.T) {

--- a/internal/mycli/spanvalue_streaming.go
+++ b/internal/mycli/spanvalue_streaming.go
@@ -111,7 +111,7 @@ func executeStreamingSQLWithSpanvalueProcessor(qe *queryExecution) (*Result, err
 }
 
 func newSpanvalueRowIteratorWriter(qe *queryExecution) (writer.RowIteratorWriter, bool, error) {
-	return newSpanvalueRowIteratorWriterFor(qe.Session.outputWriter(), qe.SysVars, qe.FormatConfig)
+	return newSpanvalueRowIteratorWriterFor(qe.outputWriter(), qe.SysVars, qe.FormatConfig)
 }
 
 // usesSpanvalueWriter reports whether mode is emitted by a spanvalue writer

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -272,88 +272,30 @@ func prepareDumpWithTxn(ctx context.Context, session *Session, mode dumpMode, sp
 
 func executeDumpBufferedWithTxn(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction) (*Result, error) {
 	var out bytes.Buffer
-	probed := false
-	probeOutput := func() {
-		if session.dumpReadTxnProbe != nil && !probed {
-			probed = true
-			session.dumpReadTxnProbe("output", txn)
-		}
-	}
-	if len(plan.DDL) > 0 {
-		probeOutput()
-		if _, err := out.Write(plan.DDL); err != nil {
-			return nil, fmt.Errorf("write DDL: %w", err)
-		}
-	}
-	if !mode.shouldExportData() {
-		return &Result{RenderedOutput: out.Bytes()}, nil
-	}
-	var affectedRows int
-	for _, unit := range plan.Data {
-		probeOutput()
-		if unit.Cyclic != nil {
-			if err := unit.Cyclic.writeTo(&out); err != nil {
-				return nil, fmt.Errorf("write cyclic data: %w", err)
-			}
-			affectedRows += len(unit.Cyclic.Statements)
-			continue
-		}
-		table := unit.Table
-		if len(table.Columns) == 0 {
-			fmt.Fprintf(&out, "-- Skipping table %s (no writable columns)\n", table.ID.FQN())
-			continue
-		}
-		if unit.Empty {
-			fmt.Fprintf(&out, "-- Data for table %s\n", table.ID.FQN())
-			continue
-		}
-		selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, table.Columns, table.ID)
-		dataResult, dumpOutput, err := executeDumpTableIntoBuffer(ctx, session, txn, selectQuery, table.ID.FQN())
-		if err != nil {
-			return nil, fmt.Errorf("export table %s: %w", table.ID.FQN(), err)
-		}
-		fmt.Fprintf(&out, "-- Data for table %s\n", table.ID.FQN())
-		if err := writeCapturedDumpOutput(&out, dumpOutput); err != nil {
-			return nil, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
-		}
-		if dataResult.AffectedRows > 0 {
-			fmt.Fprintln(&out)
-		}
-		affectedRows += dataResult.AffectedRows
+	affectedRows, err := writeDumpPlanTo(ctx, session, mode, plan, txn, &out)
+	if err != nil {
+		return nil, err
 	}
 	return &Result{AffectedRows: affectedRows, RenderedOutput: out.Bytes()}, nil
-}
-
-func writeCapturedDumpOutput(out io.Writer, output string) error {
-	if output == "" {
-		return nil
-	}
-	if _, err := io.WriteString(out, strings.TrimRight(output, "\n")); err != nil {
-		return err
-	}
-	_, err := io.WriteString(out, "\n")
-	return err
-}
-
-func executeDumpTableIntoBuffer(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, selectQuery, table string) (*Result, string, error) {
-	var buf bytes.Buffer
-	// SQL export is a non-table format and streams into the temporary
-	// per-statement output below; that capture is what makes this DUMP path
-	// buffered.
-	var result *Result
-	err := session.withOutput(outputContext{w: &buf}, func() error {
-		var err error
-		result, err = executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
-			enums.DisplayModeSQLInsert, enums.StreamingModeTrue, table)
-		return err
-	})
-	return result, buf.String(), err
 }
 
 // executeDumpStreamingWithTxn writes dump output directly to out.
 // Callers that export data must pass the same read-only transaction used
 // for catalog preflight. SCHEMA has no data txn.
 func executeDumpStreamingWithTxn(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, out io.Writer, txn *spanner.ReadOnlyTransaction) (*Result, error) {
+	affectedRows, err := writeDumpPlanTo(ctx, session, mode, plan, txn, out)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{AffectedRows: affectedRows, Streamed: true}, nil
+}
+
+// writeDumpPlanTo writes a prepared plan to out. Its caller chooses whether
+// out is an outer buffer, which withholds output on failure, or a streaming
+// destination, which may have received completed units before a later error.
+// Data queries use the same writer and read transaction as the surrounding
+// traversal, so catalog, cyclic planning, and exported values share a snapshot.
+func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, out io.Writer) (int, error) {
 	probed := false
 	probeOutput := func() {
 		if session.dumpReadTxnProbe != nil && !probed {
@@ -364,46 +306,52 @@ func executeDumpStreamingWithTxn(ctx context.Context, session *Session, mode dum
 	if len(plan.DDL) > 0 {
 		probeOutput()
 		if _, err := out.Write(plan.DDL); err != nil {
-			return nil, fmt.Errorf("failed to write DDL: %w", err)
+			return 0, fmt.Errorf("write DDL: %w", err)
 		}
 	}
 	if !mode.shouldExportData() {
-		return &Result{Streamed: true}, nil
+		return 0, nil
 	}
 	var totalAffectedRows int
 	for _, unit := range plan.Data {
 		probeOutput()
 		if unit.Cyclic != nil {
 			if err := unit.Cyclic.writeTo(out); err != nil {
-				return nil, fmt.Errorf("write cyclic data: %w", err)
+				return 0, fmt.Errorf("write cyclic data: %w", err)
 			}
 			totalAffectedRows += len(unit.Cyclic.Statements)
 			continue
 		}
 		table := unit.Table
 		if len(table.Columns) == 0 {
-			fmt.Fprintf(out, "-- Skipping table %s (no writable columns)\n", table.ID.FQN())
+			if _, err := fmt.Fprintf(out, "-- Skipping table %s (no writable columns)\n", table.ID.FQN()); err != nil {
+				return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
+			}
 			continue
 		}
 		if unit.Empty {
 			if _, err := fmt.Fprintf(out, "-- Data for table %s\n", table.ID.FQN()); err != nil {
-				return nil, err
+				return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
 			}
 			continue
 		}
 		selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, table.Columns, table.ID)
-		fmt.Fprintf(out, "-- Data for table %s\n", table.ID.FQN())
+		if _, err := fmt.Fprintf(out, "-- Data for table %s\n", table.ID.FQN()); err != nil {
+			return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
+		}
 		dataResult, err := executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
-			enums.DisplayModeSQLInsert, enums.StreamingModeTrue, table.ID.FQN())
+			enums.DisplayModeSQLInsert, enums.StreamingModeTrue, table.ID.FQN(), out)
 		if err != nil {
-			return nil, fmt.Errorf("failed to export table %s: %w", table.ID.FQN(), err)
+			return 0, fmt.Errorf("export table %s: %w", table.ID.FQN(), err)
 		}
 		totalAffectedRows += dataResult.AffectedRows
 		if dataResult.AffectedRows > 0 {
-			fmt.Fprintln(out, "")
+			if _, err := fmt.Fprintln(out); err != nil {
+				return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
+			}
 		}
 	}
-	return &Result{AffectedRows: totalAffectedRows, Streamed: true}, nil
+	return totalAffectedRows, nil
 }
 
 // exportDDL exports database DDL statements as pre-rendered text (kind (d)).

--- a/internal/mycli/statements_dump_test.go
+++ b/internal/mycli/statements_dump_test.go
@@ -46,21 +46,30 @@ func TestBuildSelectQueryWithColumns(t *testing.T) {
 	}
 }
 
-func TestExecuteDumpStreamingWithTxnPropagatesDDLWriteError(t *testing.T) {
+func TestExecuteDumpStreamingWithTxnPropagatesWriteError(t *testing.T) {
 	t.Parallel()
-
-	session := newDetachedTestSession(io.Discard)
-	t.Cleanup(session.Close)
-	want := errors.New("output failed")
-	result, err := executeDumpStreamingWithTxn(
-		t.Context(), session, dumpModeSchema,
-		&dumpPlan{DDL: []byte("CREATE TABLE T (Id INT64) PRIMARY KEY(Id);\n")},
-		dumpFailWriter{err: want}, nil,
-	)
-	if result != nil {
-		t.Fatalf("result = %#v, want nil", result)
-	}
-	if !errors.Is(err, want) {
-		t.Fatalf("error = %v, want wrapped %v", err, want)
+	for _, tt := range []struct {
+		name string
+		mode dumpMode
+		plan dumpPlan
+	}{
+		{name: "DDL", mode: dumpModeSchema, plan: dumpPlan{DDL: []byte("CREATE TABLE T (Id INT64) PRIMARY KEY(Id);\n")}},
+		{name: "no writable columns", mode: dumpModeTables, plan: dumpPlan{Data: []dumpDataPlan{{Table: dumpTablePlan{ID: tableID{Name: "T"}}}}}},
+		{name: "empty table", mode: dumpModeTables, plan: dumpPlan{Data: []dumpDataPlan{{Table: dumpTablePlan{ID: tableID{Name: "T"}, Columns: []string{"Id"}}, Empty: true}}}},
+		{name: "ordinary table header", mode: dumpModeTables, plan: dumpPlan{Data: []dumpDataPlan{{Table: dumpTablePlan{ID: tableID{Name: "T"}, Columns: []string{"Id"}}}}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			session := newDetachedTestSession(io.Discard)
+			t.Cleanup(session.Close)
+			want := errors.New("output failed")
+			// Header failures must stop before querying, so no data transaction is needed.
+			result, err := executeDumpStreamingWithTxn(t.Context(), session, tt.mode, &tt.plan, dumpFailWriter{err: want}, nil)
+			if result != nil {
+				t.Fatalf("result = %#v, want nil", result)
+			}
+			if !errors.Is(err, want) {
+				t.Fatalf("error = %v, want wrapped %v", err, want)
+			}
+		})
 	}
 }

--- a/internal/mycli/statements_dump_test.go
+++ b/internal/mycli/statements_dump_test.go
@@ -1,7 +1,8 @@
 package mycli
 
 import (
-	"bytes"
+	"errors"
+	"io"
 	"testing"
 
 	dbadminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
@@ -45,55 +46,21 @@ func TestBuildSelectQueryWithColumns(t *testing.T) {
 	}
 }
 
-func TestWriteCapturedDumpOutput(t *testing.T) {
+func TestExecuteDumpStreamingWithTxnPropagatesDDLWriteError(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name   string
-		output string
-		want   string
-	}{
-		{
-			name:   "empty output stays empty",
-			output: "",
-			want:   "",
-		},
-		{
-			name:   "missing trailing newline is added",
-			output: "INSERT INTO Singers VALUES (1)",
-			want:   "INSERT INTO Singers VALUES (1)\n",
-		},
-		{
-			name:   "single trailing newline is preserved",
-			output: "INSERT INTO Singers VALUES (1)\n",
-			want:   "INSERT INTO Singers VALUES (1)\n",
-		},
-		{
-			name:   "extra trailing newlines are collapsed",
-			output: "INSERT INTO Singers VALUES (1)\n\n",
-			want:   "INSERT INTO Singers VALUES (1)\n",
-		},
-		{
-			name:   "internal blank lines are preserved",
-			output: "INSERT INTO Singers VALUES (1)\n\nINSERT INTO Singers VALUES (2)\n",
-			want:   "INSERT INTO Singers VALUES (1)\n\nINSERT INTO Singers VALUES (2)\n",
-		},
-		{
-			name:   "only newlines collapse to one newline",
-			output: "\n\n",
-			want:   "\n",
-		},
+	session := newDetachedTestSession(io.Discard)
+	t.Cleanup(session.Close)
+	want := errors.New("output failed")
+	result, err := executeDumpStreamingWithTxn(
+		t.Context(), session, dumpModeSchema,
+		&dumpPlan{DDL: []byte("CREATE TABLE T (Id INT64) PRIMARY KEY(Id);\n")},
+		dumpFailWriter{err: want}, nil,
+	)
+	if result != nil {
+		t.Fatalf("result = %#v, want nil", result)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			if err := writeCapturedDumpOutput(&buf, tt.output); err != nil {
-				t.Fatalf("writeCapturedDumpOutput() error = %v", err)
-			}
-			if got := buf.String(); got != tt.want {
-				t.Fatalf("writeCapturedDumpOutput() = %q, want %q", got, tt.want)
-			}
-		})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want wrapped %v", err, want)
 	}
 }


### PR DESCRIPTION
DUMP now writes its prepared plan through one traversal with an explicit output destination. Buffered output uses one outer buffer; streaming writes directly to the caller. This removes the duplicated table loop, per-table buffers, and temporary Session output redirection while preserving the shared read snapshot and buffered publication only after success.

Streaming errors now use the same `write DDL:` and `export table:` prefixes as buffered errors, and header/separator write failures are propagated.

Validation: `make check`, focused DUMP/typed-row tests, and exact expected SQL comparison for buffered and streamed generated-column export. Existing replay tests cover cyclic groups, qualified tables, and FLOAT32 negative zero.
