### PR TITLE
Preserve original SQL fragments for SOURCE and batch echo

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -241,7 +241,7 @@ func (c *Cli) handleSpecialStatements(ctx context.Context, stmt Statement) (exit
 
 // executeStatementInteractive executes the statement and displays the result.
 func (c *Cli) executeStatementInteractive(ctx context.Context, stmt Statement, input *inputStatement) (string, error) {
-	preInput, err := c.executeStatement(ctx, stmt, true, input.statement, c.GetWriter())
+	preInput, err := c.executeStatement(ctx, stmt, true, interactiveEchoText(input.statement), c.GetWriter())
 	if err != nil {
 		return "", err
 	}
@@ -275,35 +275,26 @@ func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 		return err
 	}
 
-	// Parse the contents using buildCommands (same as batch mode)
+	// Parse the entire file before executing any statement (same as batch mode).
 	// IMPORTANT: buildCommands explicitly rejects meta-commands (including \.) with the error
 	// "meta commands are not supported in batch mode". This means nested sourcing
 	// (i.e., having \. commands within a sourced file) is not possible by design.
 	// Meta-commands are only processed in the interactive mode's main loop.
-	stmts, err := buildCommands(string(contents), c.SystemVariables.Query.BuildStatementMode)
+	cmds, err := buildCommands(string(contents), c.SystemVariables.Query.BuildStatementMode)
 	if err != nil {
 		return fmt.Errorf("failed to parse SQL from file %s: %w", filePath, err)
 	}
 
 	// Execute each statement sequentially
-	for i, fileStmt := range stmts {
-		// Skip ExitStatement in source files (exit should only end the file, not the session)
-		if _, ok := fileStmt.(*ExitStatement); ok {
+	for i, cmd := range cmds {
+		// SOURCE continues past EXIT without closing the session. Batch mode
+		// treats EXIT as the end of execution (see RunBatch).
+		if _, ok := cmd.stmt.(*ExitStatement); ok {
 			continue
 		}
 
-		// Extract SQL text for ECHO support
-		// TODO: Currently we reconstruct the SQL text using Statement.String() method.
-		// Ideally, buildCommands() should return the original text from the file
-		// to echo exactly what was written in the source file.
-		// See: https://github.com/apstndb/spanner-mycli/issues/380
-		sqlText := ""
-		if stringer, ok := fileStmt.(fmt.Stringer); ok {
-			sqlText = stringer.String()
-		}
-
 		// Execute the statement in interactive mode to get proper output formatting
-		_, err = c.executeStatement(ctx, fileStmt, true, sqlText, c.GetWriter())
+		_, err = c.executeStatement(ctx, cmd.stmt, true, cmd.echoText(), c.GetWriter())
 		if err != nil {
 			return fmt.Errorf("error executing statement %d from file %s: %w", i+1, filePath, err)
 		}
@@ -313,7 +304,7 @@ func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 }
 
 func (c *Cli) RunBatch(ctx context.Context, input string) error {
-	stmts, err := buildCommands(input, c.SystemVariables.Query.BuildStatementMode)
+	cmds, err := buildCommands(input, c.SystemVariables.Query.BuildStatementMode)
 	if err != nil {
 		c.PrintBatchError(err)
 		return NewExitCodeError(exitCodeError)
@@ -323,12 +314,12 @@ func (c *Cli) RunBatch(ctx context.Context, input string) error {
 	defer cancel()
 	go handleInterrupt(ctx, cancel)
 
-	for _, stmt := range stmts {
-		if _, ok := stmt.(*ExitStatement); ok {
+	for _, cmd := range cmds {
+		if _, ok := cmd.stmt.(*ExitStatement); ok {
 			return NewExitCodeError(c.handleExit())
 		}
 
-		_, err = c.executeStatement(ctx, stmt, false, input, c.GetWriter())
+		_, err = c.executeStatement(ctx, cmd.stmt, false, cmd.echoText(), c.GetWriter())
 		if err != nil {
 			c.PrintBatchError(err)
 			return NewExitCodeError(exitCodeError)

--- a/internal/mycli/cli_mcp.go
+++ b/internal/mycli/cli_mcp.go
@@ -133,7 +133,7 @@ func executeStatementHandler(cli *Cli) func(context.Context, *mcp.CallToolReques
 		output := newMCPOutputCapture(mcpMaxOutputBytes)
 
 		// Execute the statement with the capped capture as the output
-		_, err = cli.executeStatement(ctx, stmt, false, statement, output)
+		_, err = cli.executeStatement(ctx, stmt, false, interactiveEchoText(statement), output)
 		if err != nil {
 			slog.Debug("MCP execution failed",
 				"error", err.Error(),

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"text/template"
@@ -152,15 +153,121 @@ func TestBuildCommands(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
 			got, err := buildCommands(test.Input, enums.ParseModeFallback)
-			if test.ExpectError && err == nil {
-				t.Errorf("expect error but not error, input: %v", test.Input)
+			if test.ExpectError {
+				if err == nil {
+					t.Errorf("expect error but not error, input: %v", test.Input)
+				}
+				return
 			}
-			if !test.ExpectError && err != nil {
+			if err != nil {
 				t.Errorf("err: %v, input: %v", err, test.Input)
+				return
 			}
 
-			if !cmp.Equal(got, test.Expected) {
-				t.Errorf("invalid result: %v", cmp.Diff(test.Expected, got))
+			gotStmts := statementsOf(got)
+			if !cmp.Equal(gotStmts, test.Expected) {
+				t.Errorf("invalid result: %v", cmp.Diff(test.Expected, gotStmts))
+			}
+		})
+	}
+}
+
+func statementsOf(cmds []command) []Statement {
+	stmts := make([]Statement, len(cmds))
+	for i, cmd := range cmds {
+		stmts[i] = cmd.stmt
+	}
+	return stmts
+}
+
+func TestBuildCommands_preservesSourceFragments(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc     string
+		input    string
+		wantEcho []string
+		wantStmt []Statement
+	}{
+		{
+			desc:     "unterminated last statement",
+			input:    "SHOW VARIABLES",
+			wantEcho: []string{"SHOW VARIABLES"},
+			wantStmt: []Statement{&ShowVariablesStatement{}},
+		},
+		{
+			desc:     "quoted semicolon",
+			input:    `SET CLI_PROMPT = 'a;b';`,
+			wantEcho: []string{`SET CLI_PROMPT = 'a;b';`},
+			wantStmt: []Statement{&SetStatement{VarName: "CLI_PROMPT", Value: "'a;b'"}},
+		},
+		{
+			desc:     "mixed case and unusual spacing",
+			input:    "show   VARIABLES;",
+			wantEcho: []string{"show   VARIABLES;"},
+			wantStmt: []Statement{&ShowVariablesStatement{}},
+		},
+		{
+			desc:     "multiline comment and CRLF inside fragment",
+			input:    "/* keep\r\nme */ SHOW VARIABLES;",
+			wantEcho: []string{"/* keep\r\nme */ SHOW VARIABLES;"},
+			wantStmt: []Statement{&ShowVariablesStatement{}},
+		},
+		{
+			desc:     "hint retained on query",
+			input:    "@{rpc_priority=PRIORITY_HIGH} SELECT 1;",
+			wantEcho: []string{"@{rpc_priority=PRIORITY_HIGH} SELECT 1;"},
+			wantStmt: []Statement{&SelectStatement{Query: "@{rpc_priority=PRIORITY_HIGH} SELECT 1"}},
+		},
+		{
+			desc:  "consecutive DDL grouped with ordered source",
+			input: "CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64;",
+			wantEcho: []string{
+				"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);ALTER TABLE t1 ADD COLUMN col INT64;",
+			},
+			wantStmt: []Statement{&BulkDdlStatement{[]string{
+				"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)",
+				"ALTER TABLE t1 ADD COLUMN col INT64",
+			}}},
+		},
+		{
+			desc: "DDL before and after an ordinary statement",
+			input: `CREATE TABLE t1 (pk INT64) PRIMARY KEY(pk);
+SELECT * FROM t1;
+DROP TABLE t1;`,
+			wantEcho: []string{
+				"CREATE TABLE t1 (pk INT64) PRIMARY KEY(pk);",
+				"SELECT * FROM t1;",
+				"DROP TABLE t1;",
+			},
+			wantStmt: []Statement{
+				&BulkDdlStatement{[]string{"CREATE TABLE t1 (pk INT64) PRIMARY KEY(pk)"}},
+				&SelectStatement{"SELECT * FROM t1"},
+				&BulkDdlStatement{[]string{"DROP TABLE t1"}},
+			},
+		},
+		{
+			desc:     "comment-only trailing input ignored",
+			input:    "SHOW VARIABLES; /* trailing */",
+			wantEcho: []string{"SHOW VARIABLES;"},
+			wantStmt: []Statement{&ShowVariablesStatement{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := buildCommands(tt.input, enums.ParseModeFallback)
+			if err != nil {
+				t.Fatalf("buildCommands() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.wantStmt, statementsOf(got)); diff != "" {
+				t.Errorf("statements mismatch (-want +got):\n%s", diff)
+			}
+			var gotEcho []string
+			for _, cmd := range got {
+				gotEcho = append(gotEcho, cmd.echoText())
+			}
+			if diff := cmp.Diff(tt.wantEcho, gotEcho); diff != "" {
+				t.Errorf("echo text mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -231,7 +338,7 @@ func TestPrintResult(t *testing.T) {
 					},
 					Feature: FeatureVars{EchoInput: true},
 				},
-				input: "SELECT foo, bar\nFROM input",
+				input: "SELECT foo, bar\nFROM input;",
 				result: &Result{
 					TableHeader: toTableHeader("foo", "bar"),
 					Rows: []Row{
@@ -1790,5 +1897,144 @@ func TestCli_PrintResult_invalidPagerCommand(t *testing.T) {
 	err := cli.PrintResult(80, result, false, "", outBuf)
 	if err == nil || !strings.Contains(err.Error(), "invalid pager command") {
 		t.Fatalf("error = %v, want invalid pager command error", err)
+	}
+}
+
+func writeTempSQL(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "source.sql")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func newDetachedEchoCli(t *testing.T, out io.Writer) *Cli {
+	t.Helper()
+	session := newDetachedTestSession(out)
+	t.Cleanup(session.Close)
+	session.systemVariables.Query.BuildStatementMode = enums.ParseModeFallback
+	session.systemVariables.Feature.EchoInput = true
+	session.systemVariables.Display.CLIFormat = enums.DisplayModeTab
+	return &Cli{
+		SessionHandler:  NewSessionHandler(session),
+		SystemVariables: session.systemVariables,
+	}
+}
+
+func TestCli_executeSourceFile_echoRawSQL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		content    string
+		wantEcho   []string
+		wantPrompt string
+	}{
+		{
+			name: "comments, quoted semicolon, mixed case, unusual spacing, unterminated last",
+			content: "/* keep me */ SHOW VARIABLE CLI_PROMPT;\n" +
+				"SET CLI_PROMPT = 'a;b';\n" +
+				"show   VARIABLE CLI_PROMPT",
+			wantEcho: []string{
+				"/* keep me */ SHOW VARIABLE CLI_PROMPT;",
+				"SET CLI_PROMPT = 'a;b';",
+				"show   VARIABLE CLI_PROMPT",
+			},
+			wantPrompt: "a;b",
+		},
+		{
+			name:       "CRLF line endings",
+			content:    "SET CLI_PROMPT = 'crlf';\r\nSHOW VARIABLE CLI_PROMPT",
+			wantEcho:   []string{"SET CLI_PROMPT = 'crlf';", "SHOW VARIABLE CLI_PROMPT"},
+			wantPrompt: "crlf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			cli := newDetachedEchoCli(t, &out)
+			if err := cli.executeSourceFile(context.Background(), writeTempSQL(t, tt.content)); err != nil {
+				t.Fatalf("executeSourceFile: %v", err)
+			}
+			got := out.String()
+			for _, echo := range tt.wantEcho {
+				if strings.Count(got, echo+"\n") != 1 && strings.Count(got, echo) != 1 {
+					t.Errorf("echo %q not found exactly once in output:\n%s", echo, got)
+				}
+			}
+			if strings.Count(got, tt.content) != 0 {
+				t.Errorf("whole-script echo present in output:\n%s", got)
+			}
+			if cli.SystemVariables.Display.Prompt != tt.wantPrompt {
+				t.Errorf("CLI_PROMPT = %q, want %q", cli.SystemVariables.Display.Prompt, tt.wantPrompt)
+			}
+		})
+	}
+}
+
+func TestCli_RunBatch_echoRawSQL(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newDetachedEchoCli(t, &out)
+	input := "SHOW VARIABLE CLI_PROMPT;\nSET CLI_PROMPT = 'batch';"
+	if err := cli.RunBatch(context.Background(), input); err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+	got := out.String()
+	if strings.Count(got, "SHOW VARIABLE CLI_PROMPT;\n") != 1 {
+		t.Errorf("SHOW echo count mismatch in output:\n%s", got)
+	}
+	if strings.Count(got, "SET CLI_PROMPT = 'batch';\n") != 1 {
+		t.Errorf("SET echo count mismatch in output:\n%s", got)
+	}
+	if strings.Contains(got, input) {
+		t.Errorf("whole-script echo present in output:\n%s", got)
+	}
+	if cli.SystemVariables.Display.Prompt != "batch" {
+		t.Errorf("CLI_PROMPT = %q, want batch", cli.SystemVariables.Display.Prompt)
+	}
+}
+
+func TestCli_executeSourceFile_continuesPastExit(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newDetachedEchoCli(t, &out)
+	content := "SET CLI_PROMPT = 'before';\nEXIT;\nSET CLI_PROMPT = 'after';"
+	if err := cli.executeSourceFile(context.Background(), writeTempSQL(t, content)); err != nil {
+		t.Fatalf("executeSourceFile: %v", err)
+	}
+	if cli.SystemVariables.Display.Prompt != "after" {
+		t.Errorf("CLI_PROMPT = %q, want after (SOURCE continues past EXIT)", cli.SystemVariables.Display.Prompt)
+	}
+}
+
+func TestCli_RunBatch_exitEndsExecution(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newDetachedEchoCli(t, &out)
+	err := cli.RunBatch(context.Background(), "SET CLI_PROMPT = 'before';\nEXIT;\nSET CLI_PROMPT = 'after';")
+	if GetExitCode(err) != exitCodeSuccess {
+		t.Fatalf("RunBatch EXIT error = %v, want success exit code", err)
+	}
+	if cli.SystemVariables.Display.Prompt != "before" {
+		t.Errorf("CLI_PROMPT = %q, want before (batch EXIT ends execution)", cli.SystemVariables.Display.Prompt)
+	}
+}
+
+func TestCli_executeSourceFile_parseFailureBeforeExecution(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newDetachedEchoCli(t, &out)
+	err := cli.executeSourceFile(context.Background(), writeTempSQL(t, "SET CLI_PROMPT = 'changed';\nINVALID SYNTAX;"))
+	if err == nil || !strings.Contains(err.Error(), "failed to parse SQL from file") {
+		t.Fatalf("error = %v, want parse failure", err)
+	}
+	if cli.SystemVariables.Display.Prompt != defaultPrompt {
+		t.Errorf("CLI_PROMPT = %q, want %q (parse failure must run before execution)", cli.SystemVariables.Display.Prompt, defaultPrompt)
+	}
+	if out.Len() != 0 {
+		t.Errorf("parse failure produced output: %q", out.String())
 	}
 }

--- a/internal/mycli/dump_proto_replay_test.go
+++ b/internal/mycli/dump_proto_replay_test.go
@@ -45,7 +45,7 @@ func TestDumpProtoDescriptorReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, cmd := range cmds {
-		if _, err := source.ExecuteStatement(t.Context(), cmd); err != nil {
+		if _, err := source.ExecuteStatement(t.Context(), cmd.stmt); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -94,12 +94,12 @@ func TestDumpProtoDescriptorReplay(t *testing.T) {
 					if len(commands) == 0 {
 						t.Fatal("no replay commands")
 					}
-					if _, ok := commands[0].(*SetStatement); !ok {
-						t.Fatalf("first command = %T, want SET", commands[0])
+					if _, ok := commands[0].stmt.(*SetStatement); !ok {
+						t.Fatalf("first command = %T, want SET", commands[0].stmt)
 					}
 					_, target := initializeWithRandomDB(t, nil, nil)
 					for _, command := range commands {
-						if _, err := target.ExecuteStatement(t.Context(), command); err != nil {
+						if _, err := target.ExecuteStatement(t.Context(), command.stmt); err != nil {
 							t.Fatalf("unassisted replay: %v", err)
 						}
 					}
@@ -128,7 +128,7 @@ func TestDumpProtoDescriptorImportedNestedReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, cmd := range cmds {
-		if _, err := source.ExecuteStatement(t.Context(), cmd); err != nil {
+		if _, err := source.ExecuteStatement(t.Context(), cmd.stmt); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -180,7 +180,7 @@ func TestDumpProtoReplayWithoutPreamble(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, cmd := range cmds {
-		if _, err := source.ExecuteStatement(t.Context(), cmd); err != nil {
+		if _, err := source.ExecuteStatement(t.Context(), cmd.stmt); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -195,14 +195,14 @@ func TestDumpProtoReplayWithoutPreamble(t *testing.T) {
 	if len(commands) < 2 {
 		t.Fatalf("replay commands = %d, want SET plus DDL/data", len(commands))
 	}
-	if _, ok := commands[0].(*SetStatement); !ok {
-		t.Fatalf("first command = %T, want SET", commands[0])
+	if _, ok := commands[0].stmt.(*SetStatement); !ok {
+		t.Fatalf("first command = %T, want SET", commands[0].stmt)
 	}
 
 	_, stripped := initializeWithRandomDB(t, nil, nil)
 	var strippedErr error
 	for _, command := range commands[1:] {
-		if _, strippedErr = stripped.ExecuteStatement(t.Context(), command); strippedErr != nil {
+		if _, strippedErr = stripped.ExecuteStatement(t.Context(), command.stmt); strippedErr != nil {
 			break
 		}
 	}
@@ -215,7 +215,7 @@ func TestDumpProtoReplayWithoutPreamble(t *testing.T) {
 
 	_, control := initializeWithRandomDB(t, nil, nil)
 	for _, command := range commands {
-		if _, err := control.ExecuteStatement(t.Context(), command); err != nil {
+		if _, err := control.ExecuteStatement(t.Context(), command.stmt); err != nil {
 			t.Fatalf("descriptor-supplied control: %v", err)
 		}
 	}
@@ -344,11 +344,11 @@ func replayCommands(t *testing.T, target *Session, sql string) {
 	if len(commands) == 0 {
 		t.Fatal("no replay commands")
 	}
-	if _, ok := commands[0].(*SetStatement); !ok {
-		t.Fatalf("first command = %T, want SET", commands[0])
+	if _, ok := commands[0].stmt.(*SetStatement); !ok {
+		t.Fatalf("first command = %T, want SET", commands[0].stmt)
 	}
 	for _, command := range commands {
-		if _, err := target.ExecuteStatement(t.Context(), command); err != nil {
+		if _, err := target.ExecuteStatement(t.Context(), command.stmt); err != nil {
 			t.Fatalf("unassisted replay: %v", err)
 		}
 	}

--- a/internal/mycli/result_sink.go
+++ b/internal/mycli/result_sink.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 
 	"github.com/kballard/go-shellquote"
@@ -49,7 +50,7 @@ type resultSink struct {
 	c     *Cli
 	ctx   context.Context // statement context; PrintResult uses Background
 	dst   io.Writer       // caller-provided destination
-	input string          // raw statement text for CLI_ECHO_INPUT
+	input string          // already prepared CLI_ECHO_INPUT text; no extra semicolon is appended
 
 	out       io.Writer    // active destination once started (pager pipe or dst)
 	startErr  error        // sticky pager start failure
@@ -58,9 +59,12 @@ type resultSink struct {
 	done      bool
 }
 
-// newResultSink returns a sink writing to dst. input is echoed when
-// CLI_ECHO_INPUT is enabled. ctx bounds the pager child only; it cannot
-// interrupt an independently blocking dst (unpaged output).
+// newResultSink returns a sink writing to dst. input is already prepared echo
+// text: the sink writes it as-is when CLI_ECHO_INPUT is enabled and does not
+// append another semicolon. A display newline is added only when the text
+// does not already end with one, so subsequent output stays separated.
+// ctx bounds the pager child only; it cannot interrupt an independently
+// blocking dst (unpaged output).
 func (c *Cli) newResultSink(ctx context.Context, dst io.Writer, input string) *resultSink {
 	if ctx == nil {
 		ctx = context.Background()
@@ -113,12 +117,28 @@ func (s *resultSink) start() error {
 	// is captured in tee files, providing complete context in logs showing
 	// which queries produced which results.
 	if s.c.SystemVariables.Feature.EchoInput && s.input != "" {
-		if _, err := fmt.Fprintln(out, s.input+";"); err != nil {
+		if _, err := io.WriteString(out, s.input); err != nil {
 			s.startErr = s.wrapPagerWrite(err)
 			return s.startErr
 		}
+		if !strings.HasSuffix(s.input, "\n") {
+			if _, err := fmt.Fprint(out, "\n"); err != nil {
+				s.startErr = s.wrapPagerWrite(err)
+				return s.startErr
+			}
+		}
 	}
 	return nil
+}
+
+// interactiveEchoText prepares CLI_ECHO_INPUT text for interactive and MCP
+// callers using the historical convention: the statement with a semicolon
+// terminator. Empty input stays empty so the sink skips the echo.
+func interactiveEchoText(statement string) string {
+	if statement == "" {
+		return ""
+	}
+	return statement + delimiterHorizontal
 }
 
 func (s *resultSink) Write(p []byte) (int, error) {

--- a/internal/mycli/result_sink_test.go
+++ b/internal/mycli/result_sink_test.go
@@ -48,7 +48,7 @@ func TestExecuteStatement_decorationsPrecedeStreamedRows(t *testing.T) {
 	cli.SystemVariables.Feature.EchoInput = true
 
 	var buf bytes.Buffer
-	if _, err := cli.executeStatement(context.Background(), &ShowVariablesStatement{}, false, "SHOW VARIABLES", &buf); err != nil {
+	if _, err := cli.executeStatement(context.Background(), &ShowVariablesStatement{}, false, "SHOW VARIABLES;", &buf); err != nil {
 		t.Fatalf("executeStatement: %v", err)
 	}
 
@@ -115,7 +115,7 @@ func TestExecuteStatement_errorBeforeOutputEmitsNoDecorations(t *testing.T) {
 	var buf bytes.Buffer
 	// SELECT requires a database connection; the detached session rejects it
 	// before producing any output.
-	_, err := cli.executeStatement(context.Background(), &SelectStatement{Query: "SELECT 1"}, false, "SELECT 1", &buf)
+	_, err := cli.executeStatement(context.Background(), &SelectStatement{Query: "SELECT 1"}, false, "SELECT 1;", &buf)
 	if err == nil {
 		t.Fatal("executeStatement succeeded, want detached-mode rejection")
 	}
@@ -138,7 +138,7 @@ func TestExecuteStatement_setMarkdownDecoratesOwnResult(t *testing.T) {
 
 	var buf bytes.Buffer
 	stmt := &SetStatement{VarName: "CLI_MARKDOWN_CODEBLOCK", Value: "TRUE"}
-	if _, err := cli.executeStatement(context.Background(), stmt, true, "SET CLI_MARKDOWN_CODEBLOCK = TRUE", &buf); err != nil {
+	if _, err := cli.executeStatement(context.Background(), stmt, true, "SET CLI_MARKDOWN_CODEBLOCK = TRUE;", &buf); err != nil {
 		t.Fatalf("executeStatement: %v", err)
 	}
 

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -625,11 +625,41 @@ func parseDumpTableIDList(input string) ([]tableID, error) {
 	}
 }
 
+// command is the SOURCE/batch envelope: a named Statement plus the ordered
+// original inputStatement fragments used for echo. It does not embed Statement
+// and does not implement Statement or its marker interfaces.
+type command struct {
+	stmt      Statement
+	fragments []inputStatement
+}
+
+func (c command) echoText() string {
+	var b strings.Builder
+	for _, frag := range c.fragments {
+		b.WriteString(frag.statement)
+		b.WriteString(frag.delim)
+	}
+	return b.String()
+}
+
 // buildCommands parses the input and builds a list of commands for batch execution.
 // It can compose BulkDdlStatement from consecutive DDL statements.
-func buildCommands(input string, mode enums.ParseMode) ([]Statement, error) {
-	var cmds []Statement
+func buildCommands(input string, mode enums.ParseMode) ([]command, error) {
+	var cmds []command
 	var pendingDdls []string
+	var pendingFrags []inputStatement
+
+	flushPendingDdls := func() {
+		if len(pendingDdls) == 0 {
+			return
+		}
+		cmds = append(cmds, command{
+			stmt:      &BulkDdlStatement{pendingDdls},
+			fragments: pendingFrags,
+		})
+		pendingDdls = nil
+		pendingFrags = nil
+	}
 
 	// Check if input starts with a meta command.
 	// This check must be performed before separateInput() because meta-commands
@@ -660,22 +690,17 @@ func buildCommands(input string, mode enums.ParseMode) ([]Statement, error) {
 		}
 		if ddl, ok := stmt.(*DdlStatement); ok {
 			pendingDdls = append(pendingDdls, ddl.Ddl)
+			pendingFrags = append(pendingFrags, separated)
 			continue
 		}
 
-		// Flush pending DDLs
-		if len(pendingDdls) > 0 {
-			cmds = append(cmds, &BulkDdlStatement{pendingDdls})
-			pendingDdls = nil
-		}
-
-		cmds = append(cmds, stmt)
+		flushPendingDdls()
+		cmds = append(cmds, command{
+			stmt:      stmt,
+			fragments: []inputStatement{separated},
+		})
 	}
 
-	// Flush pending DDLs
-	if len(pendingDdls) > 0 {
-		cmds = append(cmds, &BulkDdlStatement{pendingDdls})
-	}
-
+	flushPendingDdls()
 	return cmds, nil
 }

--- a/internal/mycli/statements_stringer_test.go
+++ b/internal/mycli/statements_stringer_test.go
@@ -69,39 +69,6 @@ func TestStatementStringer(t *testing.T) {
 	}
 }
 
-// TestSourceFileEchoIntegration tests that ECHO works correctly with sourced files
-func TestSourceFileEchoIntegration(t *testing.T) {
-	t.Parallel()
-	// This is a conceptual test showing what we want to verify
-	// In a real integration test, this would:
-	// 1. Create a SQL file with various statement types
-	// 2. Execute it with CLI_ECHO_INPUT = TRUE
-	// 3. Verify that all statements are echoed correctly
-
-	stmts := []Statement{
-		&SelectStatement{Query: "SELECT 1"},
-		&DmlStatement{Dml: "UPDATE t SET x = 1"},
-		&DdlStatement{Ddl: "CREATE TABLE t (id INT64) PRIMARY KEY (id)"},
-		&ExplainStatement{Explain: "SELECT * FROM t"},
-		&DescribeStatement{Statement: "SELECT * FROM t"},
-	}
-
-	// Verify all can produce String() output
-	for _, stmt := range stmts {
-		stringer, ok := stmt.(interface{ String() string })
-		if !ok {
-			t.Errorf("%T should implement String() for ECHO support in source files", stmt)
-			continue
-		}
-
-		// Verify String() returns non-empty result
-		str := stringer.String()
-		if str == "" {
-			t.Errorf("%T.String() returned empty string", stmt)
-		}
-	}
-}
-
 // TestStatementStringerConsistency verifies that String() output can be parsed back
 func TestStatementStringerConsistency(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #380. Tracking: #911.

SOURCE echoed reconstructed `Statement.String()` text, and batch execution passed the entire script as the echo input for every command. `buildCommands` already split original fragments via `separateInput`, then discarded them.

This PR returns a private command envelope from `buildCommands` with a named underlying `Statement` plus the ordered original fragments. SOURCE and batch dispatch that statement and echo concatenated fragment text plus each recorded terminator. Interactive and MCP callers still prepare echo with the historical semicolon convention; `resultSink` writes already prepared echo text and does not append another semicolon.

## Behavior

- SOURCE and batch echo the corresponding raw SQL, including comments, hints, unusual spacing, quoted semicolons, mixed case, CRLF inside fragments, and an unterminated last statement.
- Consecutive DDL still executes as one `BulkDdlStatement` and echoes its ordered source.
- SOURCE continues past `EXIT` without closing the session; batch `EXIT` still ends execution. The SOURCE comment now describes that continue behavior.
- Interactive/MCP echo and existing decoration/pager ordering stay on the previous convention.
- Comment-only trailing input remains ignored.

## Validation

```sh
go test -short ./internal/mycli/... -run 'BuildCommands|SeparateInput|executeSourceFile|ResultSink|ExecuteStatement|ReadOnlyGuard|RunBatch|PrintResult'
go test -short ./...
go test -short -race ./...
golangci-lint run --timeout=5m
make fmt-check
```

Full `make check` (`go test ./...` plus lint/fmt) was not completed locally because this environment has no Docker/emulator. CI should run the required emulator suite.

## Changed files

- `internal/mycli/statement_processing.go` — command envelope; `buildCommands` flush helper
- `internal/mycli/cli.go` — SOURCE/batch dispatch and echo; SOURCE EXIT comment
- `internal/mycli/result_sink.go` — prepared echo text; no extra semicolon
- `internal/mycli/cli_mcp.go` — interactive/MCP echo preparation
- tests for `buildCommands` fragments, SOURCE/batch echo, EXIT, parse-before-execute
- dump replay call sites updated to `command.stmt`

Deleted: SOURCE `Statement.String()` reconstruction and the conceptual `TestSourceFileEchoIntegration` Stringer-echo placeholder.

No dependency upgrades or unrelated cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a472e6b-50a9-530e-b001-f2f59ec20d5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a472e6b-50a9-530e-b001-f2f59ec20d5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

