### PR TITLE
Pass narrow export options to the shared row writer

### DIFF
--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -69,7 +69,7 @@ func streamPartitionedQuery(
 	fc *spanvalue.FormatConfig,
 	vfm format.ValueFormatMode,
 ) (*Result, bool, error) {
-	w, handled, err := newSpanvalueRowIteratorWriterFor(out, sysVars, fc)
+	w, handled, err := newSpanvalueRowIteratorWriterFor(out, exportWriterOptionsFrom(sysVars), fc)
 	if err != nil || !handled {
 		return nil, handled, err
 	}

--- a/internal/mycli/spancodec_bridge.go
+++ b/internal/mycli/spancodec_bridge.go
@@ -105,7 +105,7 @@ func streamStructRows[T any](enc *spancodec.RowEncoder[T], items []T, sysVars *s
 	if err != nil {
 		return nil, false, err
 	}
-	w, handled, err := newSpanvalueRowIteratorWriterFor(out, sysVars, fc)
+	w, handled, err := newSpanvalueRowIteratorWriterFor(out, exportWriterOptionsFrom(sysVars), fc)
 	if err != nil || !handled {
 		return nil, handled, err
 	}

--- a/internal/mycli/spanvalue_streaming.go
+++ b/internal/mycli/spanvalue_streaming.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/format"
@@ -111,7 +112,32 @@ func executeStreamingSQLWithSpanvalueProcessor(qe *queryExecution) (*Result, err
 }
 
 func newSpanvalueRowIteratorWriter(qe *queryExecution) (writer.RowIteratorWriter, bool, error) {
-	return newSpanvalueRowIteratorWriterFor(qe.outputWriter(), qe.SysVars, qe.FormatConfig)
+	return newSpanvalueRowIteratorWriterFor(qe.outputWriter(), exportWriterOptionsFrom(qe.SysVars), qe.FormatConfig)
+}
+
+// exportWriterOptions is the subset of live settings consumed by the shared
+// CSV/JSONL/SQL spanvalue writers. Callers pass io.Writer and FormatConfig
+// separately so this value never carries Registry, callbacks, LastResult,
+// StreamManager, or mutable settings maps.
+type exportWriterOptions struct {
+	CLIFormat       enums.DisplayMode
+	SkipColumnNames bool
+	SQLTableName    string
+	SQLBatchSize    int64
+	DatabaseDialect databasepb.DatabaseDialect
+}
+
+func exportWriterOptionsFrom(sysVars *systemVariables) exportWriterOptions {
+	if sysVars == nil {
+		return exportWriterOptions{}
+	}
+	return exportWriterOptions{
+		CLIFormat:       sysVars.Display.CLIFormat,
+		SkipColumnNames: sysVars.Display.SkipColumnNames,
+		SQLTableName:    sysVars.Display.SQLTableName,
+		SQLBatchSize:    sysVars.Display.SQLBatchSize,
+		DatabaseDialect: sysVars.Feature.DatabaseDialect,
+	}
 }
 
 // usesSpanvalueWriter reports whether mode is emitted by a spanvalue writer
@@ -134,17 +160,17 @@ func usesSpanvalueWriter(mode enums.DisplayMode) bool {
 // the current CLI_FORMAT writing to out, shared by the query streaming path
 // and the client-side virtual result set path (streamStructRows). A nil out
 // requests the buffered fallback.
-func newSpanvalueRowIteratorWriterFor(out io.Writer, sysVars *systemVariables, fc *spanvalue.FormatConfig) (writer.RowIteratorWriter, bool, error) {
+func newSpanvalueRowIteratorWriterFor(out io.Writer, opts exportWriterOptions, fc *spanvalue.FormatConfig) (writer.RowIteratorWriter, bool, error) {
 	if out == nil {
 		return nil, false, nil
 	}
 
-	switch sysVars.Display.CLIFormat {
+	switch opts.CLIFormat {
 	case enums.DisplayModeCSV:
 		w, err := writer.NewCSVWriter(
 			out,
 			writer.WithFormatter(fc),
-			writer.WithHeader(!sysVars.Display.SkipColumnNames),
+			writer.WithHeader(!opts.SkipColumnNames),
 			writer.WithUnnamedFieldNamer(nil),
 			writer.WithFlushEachRow(),
 		)
@@ -163,24 +189,24 @@ func newSpanvalueRowIteratorWriterFor(out io.Writer, sysVars *systemVariables, f
 		}
 		return w, true, nil
 	case enums.DisplayModeSQLInsert, enums.DisplayModeSQLInsertOrIgnore, enums.DisplayModeSQLInsertOrUpdate:
-		if sysVars.Display.SQLTableName == "" {
+		if opts.SQLTableName == "" {
 			return nil, true, fmt.Errorf("SQL export requires a table name. Auto-detection failed (query may be too complex).\n" +
 				"Options:\n" +
 				"  1. Use DUMP TABLE for full table exports\n" +
 				"  2. Set CLI_SQL_TABLE_NAME explicitly for complex queries\n" +
 				"  3. Ensure your query matches: SELECT * FROM table_name [WHERE/ORDER BY/LIMIT]")
 		}
-		batchSize, err := spanvalueSQLBatchSize(sysVars.Display.SQLBatchSize)
+		batchSize, err := spanvalueSQLBatchSize(opts.SQLBatchSize)
 		if err != nil {
 			return nil, true, err
 		}
 		w, err := writer.NewSQLInsertWriter(
 			out,
-			sysVars.Display.SQLTableName,
+			opts.SQLTableName,
 			writer.WithFormatter(fc),
 			writer.WithSQLBatchSize(batchSize),
-			writer.WithSQLDialect(sysVars.Feature.DatabaseDialect),
-			writer.WithSQLInsertKind(spanvalueSQLInsertKind(sysVars.Display.CLIFormat)),
+			writer.WithSQLDialect(opts.DatabaseDialect),
+			writer.WithSQLInsertKind(spanvalueSQLInsertKind(opts.CLIFormat)),
 		)
 		if err != nil {
 			return nil, true, err

--- a/internal/mycli/spanvalue_streaming_test.go
+++ b/internal/mycli/spanvalue_streaming_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"bytes"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spancodec"
+	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/decoder"
+	"github.com/apstndb/spanvalue"
+	"github.com/apstndb/spanvalue/writer"
+	"github.com/google/go-cmp/cmp"
+)
+
+type exportIdentRow struct {
+	ID   int64  `spanner:"id"`
+	Name string `spanner:"name"`
+}
+
+const sqlExportMissingTableNameErr = "SQL export requires a table name. Auto-detection failed (query may be too complex).\n" +
+	"Options:\n" +
+	"  1. Use DUMP TABLE for full table exports\n" +
+	"  2. Set CLI_SQL_TABLE_NAME explicitly for complex queries\n" +
+	"  3. Ensure your query matches: SELECT * FROM table_name [WHERE/ORDER BY/LIMIT]"
+
+func TestNewSpanvalueRowIteratorWriterForContract(t *testing.T) {
+	t.Parallel()
+
+	fc, err := decoder.FormatConfigWithProto(nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("nil destination is unhandled buffered fallback", func(t *testing.T) {
+		t.Parallel()
+		w, handled, err := newSpanvalueRowIteratorWriterFor(nil, exportWriterOptions{CLIFormat: enums.DisplayModeCSV}, fc)
+		if w != nil || handled || err != nil {
+			t.Fatalf("got writer=%v handled=%v err=%v, want nil, false, nil", w, handled, err)
+		}
+	})
+
+	t.Run("unsupported format is unhandled", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w, handled, err := newSpanvalueRowIteratorWriterFor(&buf, exportWriterOptions{CLIFormat: enums.DisplayModeTable}, fc)
+		if w != nil || handled || err != nil {
+			t.Fatalf("got writer=%v handled=%v err=%v, want nil, false, nil", w, handled, err)
+		}
+	})
+
+	t.Run("SQL export missing table name is handled with exact error text", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w, handled, err := newSpanvalueRowIteratorWriterFor(&buf, exportWriterOptions{CLIFormat: enums.DisplayModeSQLInsert}, sqlLiteralFormatConfig())
+		if w != nil || !handled {
+			t.Fatalf("got writer=%v handled=%v, want nil, true", w, handled)
+		}
+		if err == nil || err.Error() != sqlExportMissingTableNameErr {
+			t.Fatalf("error mismatch (-want +got):\n%s", cmp.Diff(sqlExportMissingTableNameErr, errString(err)))
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("writer wrote %q before failing", buf.String())
+		}
+	})
+
+	t.Run("negative SQL batch size is handled with error", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		_, handled, err := newSpanvalueRowIteratorWriterFor(&buf, exportWriterOptions{
+			CLIFormat:    enums.DisplayModeSQLInsert,
+			SQLTableName: "Items",
+			SQLBatchSize: -1,
+		}, sqlLiteralFormatConfig())
+		if !handled {
+			t.Fatal("negative batch size should be handled")
+		}
+		want := "CLI_SQL_BATCH_SIZE cannot be negative: -1"
+		if err == nil || err.Error() != want {
+			t.Fatalf("error mismatch (-want +got):\n%s", cmp.Diff(want, errString(err)))
+		}
+	})
+
+	t.Run("SQL batch size above maximum is handled with error", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		_, handled, err := newSpanvalueRowIteratorWriterFor(&buf, exportWriterOptions{
+			CLIFormat:    enums.DisplayModeSQLInsert,
+			SQLTableName: "Items",
+			SQLBatchSize: 10001,
+		}, sqlLiteralFormatConfig())
+		if !handled {
+			t.Fatal("oversized batch size should be handled")
+		}
+		want := "CLI_SQL_BATCH_SIZE 10001 exceeds maximum supported value of 10000 (limited for Spanner mutation constraints)"
+		if err == nil || err.Error() != want {
+			t.Fatalf("error mismatch (-want +got):\n%s", cmp.Diff(want, errString(err)))
+		}
+	})
+}
+
+func TestNewSpanvalueRowIteratorWriterForOutput(t *testing.T) {
+	t.Parallel()
+
+	md, rows := mustExportIdentRows(t, []exportIdentRow{
+		{ID: 1, Name: "Alice"},
+		{ID: 2, Name: "Bob"},
+		{ID: 3, Name: "Carol"},
+	})
+
+	tests := []struct {
+		name string
+		opts exportWriterOptions
+		fc   *spanvalue.FormatConfig
+		want string
+	}{
+		{
+			name: "CSV includes headers",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeCSV},
+			want: "id,name\n1,Alice\n2,Bob\n3,Carol\n",
+		},
+		{
+			name: "CSV skip column names",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeCSV, SkipColumnNames: true},
+			want: "1,Alice\n2,Bob\n3,Carol\n",
+		},
+		{
+			name: "JSONL values",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeJSONL},
+			want: "{\"id\":1,\"name\":\"Alice\"}\n{\"id\":2,\"name\":\"Bob\"}\n{\"id\":3,\"name\":\"Carol\"}\n",
+		},
+		{
+			name: "SQL INSERT uses table name and GoogleSQL string quotes",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeSQLInsert, SQLTableName: "Items"},
+			fc:   sqlLiteralFormatConfig(),
+			want: "INSERT INTO `Items` (`id`, `name`) VALUES (1, \"Alice\");\nINSERT INTO `Items` (`id`, `name`) VALUES (2, \"Bob\");\nINSERT INTO `Items` (`id`, `name`) VALUES (3, \"Carol\");\n",
+		},
+		{
+			name: "SQL INSERT OR IGNORE",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeSQLInsertOrIgnore, SQLTableName: "Items"},
+			fc:   sqlLiteralFormatConfig(),
+			want: "INSERT OR IGNORE INTO `Items` (`id`, `name`) VALUES (1, \"Alice\");\nINSERT OR IGNORE INTO `Items` (`id`, `name`) VALUES (2, \"Bob\");\nINSERT OR IGNORE INTO `Items` (`id`, `name`) VALUES (3, \"Carol\");\n",
+		},
+		{
+			name: "SQL INSERT OR UPDATE",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeSQLInsertOrUpdate, SQLTableName: "Items"},
+			fc:   sqlLiteralFormatConfig(),
+			want: "INSERT OR UPDATE INTO `Items` (`id`, `name`) VALUES (1, \"Alice\");\nINSERT OR UPDATE INTO `Items` (`id`, `name`) VALUES (2, \"Bob\");\nINSERT OR UPDATE INTO `Items` (`id`, `name`) VALUES (3, \"Carol\");\n",
+		},
+		{
+			name: "SQL batch size groups VALUES lists",
+			opts: exportWriterOptions{CLIFormat: enums.DisplayModeSQLInsert, SQLTableName: "Items", SQLBatchSize: 2},
+			fc:   sqlLiteralFormatConfig(),
+			want: "INSERT INTO `Items` (`id`, `name`) VALUES\n  (1, \"Alice\"),\n  (2, \"Bob\");\nINSERT INTO `Items` (`id`, `name`) VALUES\n  (3, \"Carol\");\n",
+		},
+		{
+			name: "PostgreSQL dialect quotes identifiers",
+			opts: exportWriterOptions{
+				CLIFormat:       enums.DisplayModeSQLInsert,
+				SQLTableName:    "Items",
+				DatabaseDialect: databasepb.DatabaseDialect_POSTGRESQL,
+			},
+			fc:   sqlLiteralFormatConfig(),
+			want: "INSERT INTO \"Items\" (\"id\", \"name\") VALUES (1, \"Alice\");\nINSERT INTO \"Items\" (\"id\", \"name\") VALUES (2, \"Bob\");\nINSERT INTO \"Items\" (\"id\", \"name\") VALUES (3, \"Carol\");\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fc := tt.fc
+			if fc == nil {
+				var err error
+				if tt.opts.CLIFormat == enums.DisplayModeJSONL {
+					fc = decoder.JSONFormatConfig()
+				} else {
+					fc, err = decoder.FormatConfigWithProto(nil, false)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			var buf bytes.Buffer
+			w, handled, err := newSpanvalueRowIteratorWriterFor(&buf, tt.opts, fc)
+			if err != nil || !handled {
+				t.Fatalf("newSpanvalueRowIteratorWriterFor: handled=%v err=%v", handled, err)
+			}
+			if _, err := writer.WriteRowSeq(md, writer.RowSeq(rows...), w); err != nil {
+				t.Fatalf("WriteRowSeq: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, buf.String()); diff != "" {
+				t.Errorf("output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func mustExportIdentRows(t *testing.T, items []exportIdentRow) (*sppb.ResultSetMetadata, []*spanner.Row) {
+	t.Helper()
+	enc := spancodec.MustNewRowEncoder[exportIdentRow]()
+	md, err := enc.ResultSetMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows []*spanner.Row
+	for row, err := range enc.Rows(items) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, row)
+	}
+	return md, rows
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/mycli/typed_rows.go
+++ b/internal/mycli/typed_rows.go
@@ -56,16 +56,14 @@ func writeTypedRows(out io.Writer, sysVars *systemVariables, result *Result) err
 		return err
 	}
 
+	opts := exportWriterOptionsFrom(sysVars)
 	// Apply the per-query auto-detected table name (Result.SQLTableNameForExport)
-	// for SQL export without mutating the caller's systemVariables.
-	sv := sysVars
-	if n := result.SQLTableNameForExport; n != "" && sv.Display.SQLTableName != n {
-		tmp := *sv
-		tmp.Display.SQLTableName = n
-		sv = &tmp
+	// for SQL export without copying or mutating the caller's systemVariables.
+	if n := result.SQLTableNameForExport; n != "" {
+		opts.SQLTableName = n
 	}
 
-	w, handled, err := newSpanvalueRowIteratorWriterFor(out, sv, fc)
+	w, handled, err := newSpanvalueRowIteratorWriterFor(out, opts, fc)
 	if err != nil {
 		return err
 	}
@@ -74,7 +72,7 @@ func writeTypedRows(out io.Writer, sysVars *systemVariables, result *Result) err
 		// formats with a non-nil out, so newSpanvalueRowIteratorWriterFor must
 		// handle them. Fail loudly rather than silently drop rows if the two
 		// format sets ever diverge.
-		return fmt.Errorf("no spanvalue writer for typed replay in format %v", sv.Display.CLIFormat)
+		return fmt.Errorf("no spanvalue writer for typed replay in format %v", opts.CLIFormat)
 	}
 	if _, err := writer.WriteRowSeq(result.Typed.Metadata, writer.RowSeq(result.Typed.Rows...), w); err != nil {
 		return normalizeSpanvalueWriterError(err)

--- a/internal/mycli/typed_rows_test.go
+++ b/internal/mycli/typed_rows_test.go
@@ -94,7 +94,7 @@ func TestTypedRowsByteIdentity(t *testing.T) {
 			var wantBuf bytes.Buffer
 			if usesSpanvalueWriter(mode) {
 				// Export formats stream through this writer for live queries.
-				w, handled, err := newSpanvalueRowIteratorWriterFor(&wantBuf, sv2, fc)
+				w, handled, err := newSpanvalueRowIteratorWriterFor(&wantBuf, exportWriterOptionsFrom(sv2), fc)
 				if err != nil || !handled {
 					t.Fatalf("newSpanvalueRowIteratorWriterFor: handled=%v err=%v", handled, err)
 				}
@@ -161,6 +161,77 @@ func bodyPayloadCount(r *Result) int {
 		n++
 	}
 	return n
+}
+
+// TestWriteTypedRowsCapturedTableName verifies that typed replay honors
+// Result.SQLTableNameForExport without copying or mutating live settings.
+func TestWriteTypedRowsCapturedTableName(t *testing.T) {
+	t.Parallel()
+
+	enc := spancodec.MustNewRowEncoder[identRow]()
+	md, err := enc.ResultSetMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rawRows []*spanner.Row
+	for row, err := range enc.Rows([]identRow{{N: 1, S: "Alice", B: true, F: 1.5}}) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		rawRows = append(rawRows, row)
+	}
+
+	tests := []struct {
+		name       string
+		liveTable  string
+		exportName string
+		wantSubstr string
+	}{
+		{
+			name:       "captured name overrides a different live table name",
+			liveTable:  "Live",
+			exportName: "Captured",
+			wantSubstr: "INSERT INTO `Captured`",
+		},
+		{
+			name:       "empty captured name keeps the live table name",
+			liveTable:  "Live",
+			exportName: "",
+			wantSubstr: "INSERT INTO `Live`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sv := newSystemVariablesWithDefaults()
+			sv.Display.CLIFormat = enums.DisplayModeSQLInsert
+			sv.Display.SQLTableName = tt.liveTable
+			sv.LastResult.QueryCache = &LastQueryCache{QueryStats: map[string]any{"seed": "A"}}
+
+			result := &Result{
+				Typed:                 &TypedRows{Metadata: md, Rows: rawRows, SQLExportAllowed: true},
+				SQLTableNameForExport: tt.exportName,
+			}
+
+			var buf bytes.Buffer
+			if err := writeTypedRows(&buf, &sv, result); err != nil {
+				t.Fatalf("writeTypedRows: %v", err)
+			}
+			if sv.Display.SQLTableName != tt.liveTable {
+				t.Errorf("live SQLTableName mutated: got %q, want %q", sv.Display.SQLTableName, tt.liveTable)
+			}
+			if sv.LastResult.QueryCache == nil || sv.LastResult.QueryCache.QueryStats["seed"] != "A" {
+				t.Error("live QueryCache must remain untouched")
+			}
+			if !bytes.Contains(buf.Bytes(), []byte(tt.wantSubstr)) {
+				t.Errorf("output %q does not contain %q", buf.String(), tt.wantSubstr)
+			}
+			if tt.exportName != "" && bytes.Contains(buf.Bytes(), []byte("INSERT INTO `Live`")) {
+				t.Errorf("output used live table name despite captured export name: %q", buf.String())
+			}
+		})
+	}
 }
 
 // TestResultBodyPayloadExclusive verifies the at-most-one-body-payload


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #913. Tracking: #911.

The shared CSV/JSONL/SQL writer consumed only a few settings but accepted the whole live `systemVariables`. `writeTypedRows` copied that object solely to override the SQL export table name.

This PR introduces a private `exportWriterOptions` value with display mode, skip-column-names, SQL table name, SQL batch size, and database dialect. Streamed, partitioned, struct-row, and typed-replay paths build those options at the writer callers. Typed replay overrides only the captured `Result.SQLTableNameForExport` and no longer copies `systemVariables`. `io.Writer` and `*spanvalue.FormatConfig` stay separate arguments.

## Behavior

- CSV headers, JSONL values, SQL dialect/insert kind/batch limits, and the exact SQL table-name error text are unchanged.
- Typed replay honors its captured export table name without mutating live settings; presentation tables retain SQL-export eligibility/fallback.
- Every CSV/JSONL/SQL route still uses `newSpanvalueRowIteratorWriterFor` as the single emitter factory.
- A nil destination remains unhandled buffered fallback; a supported format with invalid options is handled with an error.

## Validation

```sh
go test -short ./internal/mycli/... -run 'Typed|Spanvalue|StructRows|SQLExport|Partitioned'
go test -short ./...
go test -short -race ./...
golangci-lint run --timeout=5m
make fmt-check
```

Full `make check` (`go test ./...` plus lint/fmt) was not completed locally because this environment has no Docker/emulator. CI should run the required emulator suite.

## Changed files

- `internal/mycli/spanvalue_streaming.go` — `exportWriterOptions`; writer constructor no longer takes `*systemVariables`
- `internal/mycli/typed_rows.go` — override only the options table name
- `internal/mycli/spancodec_bridge.go` — struct-row path builds options at the caller
- `internal/mycli/execute_partitioned.go` — partitioned path builds options at the caller
- tests for writer contract, SQL dialect/insert kind/batch limits, and captured table-name replay

Deleted: the whole-`systemVariables` copy in `writeTypedRows`.

No QueryCache publication change, typed BIGQUERY contract, new formats, dependency upgrades, or unrelated cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a82143a4-546a-52f8-8352-86e4dd74c417?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a82143a4-546a-52f8-8352-86e4dd74c417&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

