### PR TITLE
Replace TransitTransaction with a direct pending transition

### DIFF
--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -114,7 +114,6 @@ type TransactionManager struct {
 	// Direct access to tc is managed through withTransactionContextWithLock base method.
 	// Helper functions that work with transaction context:
 	// - withTransactionContextWithLock: Base method for all tc manipulation (acquires write lock)
-	// - TransitTransaction: Atomic state transitions with cleanup
 	// - withReadWriteTransaction, withReadWriteTransactionContext, withReadOnlyTransaction: Type-safe transaction access
 	// - clearTransactionContext, TransactionAttrsWithLock: Safe context management
 	// All transaction context access MUST go through these helpers.
@@ -204,28 +203,6 @@ func (tm *TransactionManager) withTransactionContextWithLock(fn func(tc **transa
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 	return fn(&tm.tc)
-}
-
-// TransitTransaction implements a functional state transition pattern for transaction management.
-// It atomically transitions from one transaction state to another, handling cleanup of the old state.
-// The transition function receives the current context and returns the new context.
-// If an error occurs during transition, the original state is preserved.
-func (tm *TransactionManager) TransitTransaction(ctx context.Context, fn func(tc *transactionContext) (*transactionContext, error)) error {
-	return tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
-		oldTc := *tcPtr
-		newTc, err := fn(oldTc)
-		if err != nil {
-			return err
-		}
-
-		// Cleanup old transaction context if it's being replaced
-		if oldTc != nil && oldTc != newTc {
-			oldTc.Close()
-		}
-
-		*tcPtr = newTc
-		return nil
-	})
 }
 
 // withTransactionLocked is a generic helper that executes fn while holding the transaction mutex.
@@ -544,21 +521,19 @@ func (tm *TransactionManager) BeginPendingTransaction(ctx context.Context, isola
 	resolvedIsolationLevel := tm.resolveTransactionIsolationLevel(isolationLevel)
 	resolvedPriority := tm.resolveTransactionPriority(priority)
 
-	return tm.TransitTransaction(ctx, func(tc *transactionContext) (*transactionContext, error) {
-		// Check for any type of existing transaction (including pending)
-		if tc != nil {
-			return nil, fmt.Errorf("%s transaction is already running", tc.attrs.mode)
-		}
-
-		// Return new pending transaction context
-		return &transactionContext{
-			attrs: transactionAttributes{
-				mode:           transactionModePending,
-				priority:       resolvedPriority,
-				isolationLevel: resolvedIsolationLevel,
-			},
-		}, nil
-	})
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if tm.tc != nil {
+		return fmt.Errorf("%s transaction is already running", tm.tc.attrs.mode)
+	}
+	tm.tc = &transactionContext{
+		attrs: transactionAttributes{
+			mode:           transactionModePending,
+			priority:       resolvedPriority,
+			isolationLevel: resolvedIsolationLevel,
+		},
+	}
+	return nil
 }
 
 // DetermineTransactionLocked determines the type of transaction to start based on the pending transaction

--- a/internal/mycli/transaction_manager_test.go
+++ b/internal/mycli/transaction_manager_test.go
@@ -1,8 +1,8 @@
 package mycli
 
 import (
-	"context"
-	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -344,67 +344,128 @@ func TestTransactionHelperErrorHandling(t *testing.T) {
 	}
 }
 
-func TestTransactionValidation(t *testing.T) {
+func TestBeginPendingTransactionRejectsExistingContext(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		name    string
-		setupTC func() *transactionContext
-		wantErr bool
+		setupTC func(closed *bool) *transactionContext
+		wantErr string
 	}{
 		{
-			name:    "no transaction",
-			setupTC: func() *transactionContext { return nil },
-			wantErr: false,
+			name:    "idle to pending succeeds",
+			setupTC: func(*bool) *transactionContext { return nil },
 		},
 		{
-			name: "pending transaction",
-			setupTC: func() *transactionContext {
+			name: "pending to pending fails without replacing",
+			setupTC: func(closed *bool) *transactionContext {
 				return &transactionContext{
-					attrs: transactionAttributes{mode: transactionModePending},
+					attrs: transactionAttributes{
+						mode:           transactionModePending,
+						tag:            "pending-tag",
+						priority:       sppb.RequestOptions_PRIORITY_LOW,
+						isolationLevel: sppb.TransactionOptions_REPEATABLE_READ,
+					},
+					heartbeatCancel: func() { *closed = true },
 				}
 			},
-			wantErr: false, // Pending transactions are allowed for new transactions
+			wantErr: "pending transaction is already running",
 		},
 		{
-			name: "read-write transaction",
-			setupTC: func() *transactionContext {
+			name: "read-write to pending fails without replacing or closing",
+			setupTC: func(closed *bool) *transactionContext {
 				return &transactionContext{
-					attrs: transactionAttributes{mode: transactionModeReadWrite},
+					attrs: transactionAttributes{
+						mode:           transactionModeReadWrite,
+						tag:            "rw-tag",
+						priority:       sppb.RequestOptions_PRIORITY_HIGH,
+						isolationLevel: sppb.TransactionOptions_SERIALIZABLE,
+					},
+					heartbeatCancel: func() { *closed = true },
 				}
 			},
-			wantErr: true,
+			wantErr: "read-write transaction is already running",
 		},
 		{
-			name: "read-only transaction",
-			setupTC: func() *transactionContext {
+			name: "read-only to pending fails without replacing or closing",
+			setupTC: func(closed *bool) *transactionContext {
 				return &transactionContext{
-					attrs: transactionAttributes{mode: transactionModeReadOnly},
+					attrs: transactionAttributes{
+						mode:           transactionModeReadOnly,
+						tag:            "ro-tag",
+						priority:       sppb.RequestOptions_PRIORITY_MEDIUM,
+						isolationLevel: sppb.TransactionOptions_SERIALIZABLE,
+					},
+					heartbeatCancel: func() { *closed = true },
 				}
 			},
-			wantErr: true,
+			wantErr: "read-only transaction is already running",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tm := &TransactionManager{
-				tc: tt.setupTC(),
-			}
-
-			// Test validation through TransitTransaction which now handles validation
-			err := tm.TransitTransaction(context.Background(), func(tc *transactionContext) (*transactionContext, error) {
-				// Check if we can start a new transaction
-				if tc != nil && (tc.attrs.mode == transactionModeReadWrite || tc.attrs.mode == transactionModeReadOnly) {
-					return nil, fmt.Errorf("%s transaction is already running", tc.attrs.mode)
+			t.Parallel()
+			var closed bool
+			existing := tt.setupTC(&closed)
+			tm := &TransactionManager{tc: existing}
+			err := tm.BeginPendingTransaction(t.Context(), sppb.TransactionOptions_SERIALIZABLE, sppb.RequestOptions_PRIORITY_HIGH)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("BeginPendingTransaction() error = %v", err)
 				}
-				// Return existing context (no actual transition for this test)
-				return tc, nil
-			})
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TransitTransaction validation error = %v, wantErr %v", err, tt.wantErr)
+				attrs := tm.TransactionAttrsWithLock()
+				if attrs.mode != transactionModePending {
+					t.Errorf("mode = %q, want pending", attrs.mode)
+				}
+				if attrs.priority != sppb.RequestOptions_PRIORITY_HIGH {
+					t.Errorf("priority = %v, want HIGH", attrs.priority)
+				}
+				if attrs.isolationLevel != sppb.TransactionOptions_SERIALIZABLE {
+					t.Errorf("isolation = %v, want SERIALIZABLE", attrs.isolationLevel)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+			if tm.tc != existing {
+				t.Fatal("existing transaction context was replaced")
+			}
+			if closed {
+				t.Error("existing transaction context was closed")
+			}
+			if existing != nil {
+				if tm.tc.attrs.tag != existing.attrs.tag ||
+					tm.tc.attrs.priority != existing.attrs.priority ||
+					tm.tc.attrs.isolationLevel != existing.attrs.isolationLevel ||
+					tm.tc.attrs.mode != existing.attrs.mode {
+					t.Errorf("existing options/tags changed: %+v", tm.tc.attrs)
+				}
 			}
 		})
+	}
+}
+
+func TestBeginPendingTransactionConcurrent(t *testing.T) {
+	t.Parallel()
+
+	tm := &TransactionManager{}
+	var success atomic.Int32
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			if err := tm.BeginPendingTransaction(t.Context(), sppb.TransactionOptions_SERIALIZABLE, sppb.RequestOptions_PRIORITY_HIGH); err == nil {
+				success.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+	if got := success.Load(); got != 1 {
+		t.Fatalf("concurrent BEGIN published %d contexts, want 1", got)
+	}
+	if attrs := tm.TransactionAttrsWithLock(); attrs.mode != transactionModePending {
+		t.Errorf("mode = %q, want pending", attrs.mode)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #921. Tracking: #911.

`TransitTransaction` was a generic context-replacement/cleanup callback used only by `BeginPendingTransaction`. That caller rejects every existing context, so the generic old-context replacement machinery was unnecessary.

This PR resolves priority and isolation defaults at the same point as today, then acquires `tm.mu` directly, rejects `tm.tc != nil` with the existing error text, and assigns the pending `transactionContext` directly. `TransitTransaction` and comments asserting it is the foundation of all state changes are deleted. `withTransactionContextWithLock` and other multi-use locking helpers are unchanged.

## Behavior

- Idle to pending succeeds.
- Pending, read-only, and read-write to pending fail without replacing or closing the existing context or changing options/tags.
- Explicit arguments and lazy fallback priority/isolation match the #910 regression cases, including nil settings when overrides suffice.
- Two concurrent BEGIN attempts cannot both publish a context.

## Validation

```sh
go test -short ./internal/mycli/... -run 'Pending|TransactionOptions|TransactionHelpers|TransactionState|BeginPending'
go test -short ./...
go test -short -race ./...
golangci-lint run --timeout=5m
make fmt-check
```

Full `make check` (`go test ./...` plus lint/fmt) was not completed locally because this environment has no Docker/emulator. CI should run the required emulator suite.

## Changed files

- `internal/mycli/transaction_manager.go` — direct pending assignment; delete `TransitTransaction`
- `internal/mycli/transaction_manager_test.go` — pending rejection/concurrency through `BeginPendingTransaction`

Deleted: `TransitTransaction` and the wrapper-only validation test that did not match production pending rejection.

No transaction lifetime redesign, generic helper purge, option-builder reintroduction, or lock-scope changes around commit/query callbacks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a82143a4-546a-52f8-8352-86e4dd74c417?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a82143a4-546a-52f8-8352-86e4dd74c417&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

