### PR TITLE
Publish query cache to an explicit destination

### DIFF
--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -167,6 +167,12 @@ type queryExecution struct {
 	Metrics      *metrics.ExecutionMetrics
 	ValueFmtMode format.ValueFormatMode
 	Processor    RowProcessor // set by executeAndCollect after decideExecutionMode
+	// QueryCacheDest is the caller's LastResult.QueryCache slot. It is captured
+	// from the supplied settings before prepareFormatConfig can return a copy
+	// for SQL-export table-name auto-detection. Nil skips publication (DUMP's
+	// executeSQLWithFormatAndTxn path). Ownership is never inferred from
+	// pointer equality or display format.
+	QueryCacheDest **LastQueryCache
 }
 
 func (qe *queryExecution) outputWriter() io.Writer {
@@ -232,15 +238,16 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 	iter := txn.QueryWithOptions(ctx, stmt, opts)
 
 	return executeAndCollect(ctx, &queryExecution{
-		Session:      session,
-		Output:       out,
-		Iter:         iter,
-		ReadOnlyTxn:  txn,
-		FormatConfig: fc,
-		SQL:          sql,
-		SysVars:      sysVars,
-		Metrics:      m,
-		ValueFmtMode: vfm,
+		Session:        session,
+		Output:         out,
+		Iter:           iter,
+		ReadOnlyTxn:    txn,
+		FormatConfig:   fc,
+		SQL:            sql,
+		SysVars:        sysVars,
+		Metrics:        m,
+		ValueFmtMode:   vfm,
+		QueryCacheDest: nil, // DUMP / isolated format+txn execution must not replace the user's cache
 	})
 }
 
@@ -282,6 +289,11 @@ type queryWithStatsRunner func(context.Context, spanner.Statement, bool, sppb.Ex
 func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql string, sysVars *systemVariables, run queryWithStatsRunner, rollbackActiveTransactionOnAbort bool) (*Result, error) {
 	m := newMetrics(sysVars)
 
+	// Capture the caller's cache slot before prepareFormatConfig can copy
+	// sysVars when SQL export auto-detects a table name. Publishing through
+	// that copy would leave the live plan/stats cache stale.
+	queryCacheDest := &sysVars.LastResult.QueryCache
+
 	fc, vfm, sysVars, err := prepareFormatConfig(sql, sysVars)
 	if err != nil {
 		return nil, err
@@ -298,14 +310,15 @@ func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql st
 	}
 
 	result, err := executeAndCollect(ctx, &queryExecution{
-		Session:      session,
-		Iter:         iter,
-		ReadOnlyTxn:  roTxn,
-		FormatConfig: fc,
-		SQL:          sql,
-		SysVars:      sysVars,
-		Metrics:      m,
-		ValueFmtMode: vfm,
+		Session:        session,
+		Iter:           iter,
+		ReadOnlyTxn:    roTxn,
+		FormatConfig:   fc,
+		SQL:            sql,
+		SysVars:        sysVars,
+		Metrics:        m,
+		ValueFmtMode:   vfm,
+		QueryCacheDest: queryCacheDest,
 	})
 	if err == nil && session != nil && session.txn != nil {
 		err = session.txn.invokeQueryAfterCollectHook()
@@ -383,18 +396,24 @@ func executeWithStreaming(ctx context.Context, qe *queryExecution) (*Result, err
 	return executeStreamingSQL(ctx, qe)
 }
 
-// finalizeQueryResult parses query stats, extracts the read timestamp, and updates the query cache.
-func finalizeQueryResult(result *Result, stats map[string]any, roTxn *spanner.ReadOnlyTransaction, plan *sppb.QueryPlan, sysVars *systemVariables, m *metrics.ExecutionMetrics) error {
+// finalizeQueryResult parses query stats, extracts the read timestamp, and
+// publishes the query cache. Publication uses QueryCacheDest, not SysVars:
+// SQL-export auto-detection may have replaced SysVars with a copy. Timing is
+// after query-stat parsing and read-timestamp collection and before appendix
+// rendering; a later appendix or after-collect hook failure does not clear an
+// already published cache. Iterator or parse failure never reaches here, so
+// the previous cache remains.
+func (qe *queryExecution) finalizeQueryResult(result *Result, stats map[string]any, plan *sppb.QueryPlan) error {
 	queryStats, err := parseQueryStats(stats)
 	if err != nil {
 		return err
 	}
 	result.Stats = queryStats
-	m.ServerElapsedTime = queryStats.ElapsedTime
-	m.ServerCPUTime = queryStats.CPUTime
+	qe.Metrics.ServerElapsedTime = queryStats.ElapsedTime
+	qe.Metrics.ServerCPUTime = queryStats.CPUTime
 
-	if roTxn != nil {
-		ts, err := roTxn.Timestamp()
+	if qe.ReadOnlyTxn != nil {
+		ts, err := qe.ReadOnlyTxn.Timestamp()
 		if err != nil {
 			slog.Warn("failed to get read-only transaction timestamp", "err", err)
 		} else {
@@ -402,13 +421,15 @@ func finalizeQueryResult(result *Result, stats map[string]any, roTxn *spanner.Re
 		}
 	}
 
-	sysVars.LastResult.QueryCache = &LastQueryCache{
-		QueryPlan:     plan,
-		QueryStats:    stats,
-		ReadTimestamp: result.ReadTimestamp,
+	if qe.QueryCacheDest != nil {
+		*qe.QueryCacheDest = &LastQueryCache{
+			QueryPlan:     plan,
+			QueryStats:    stats,
+			ReadTimestamp: result.ReadTimestamp,
+		}
 	}
 
-	return applyQueryModeStatsRendering(result, plan, sysVars)
+	return applyQueryModeStatsRendering(result, plan, qe.SysVars)
 }
 
 // applyQueryModeStatsRendering reflects the user-specified stats query modes
@@ -467,7 +488,7 @@ func executeWithBuffering(ctx context.Context, qe *queryExecution) (*Result, err
 		AffectedRows: len(rows),
 	}
 
-	if err := finalizeQueryResult(result, stats, qe.ReadOnlyTxn, plan, qe.SysVars, qe.Metrics); err != nil {
+	if err := qe.finalizeQueryResult(result, stats, plan); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/internal/mycli/query_cache_test.go
+++ b/internal/mycli/query_cache_test.go
@@ -15,92 +15,83 @@
 package mycli
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"strings"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/spanner"
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spanner-mycli/enums"
-	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
+	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const sqlExportSelectUsers = "SELECT * FROM Users"
 
+var queryCacheFixedReadTS = timestamppb.New(time.Date(2026, 9, 12, 8, 0, 0, 0, time.UTC))
+
 func TestQueryCachePublicationSQLExportNames(t *testing.T) {
 	t.Parallel()
 
-	statsB := map[string]any{"elapsed_time": "2 msec", "query": "B"}
 	planB := testQueryPlan(t)
-	readTS := time.Date(2026, 9, 12, 8, 0, 0, 0, time.UTC)
+	statsB := map[string]any{"elapsed_time": "2 msec", "query": "B"}
 
 	for _, tt := range []struct {
-		name           string
-		sqlTableName   string
-		wantCopiedVars bool
+		name         string
+		sqlTableName string
 	}{
-		{
-			name:           "auto-detected SQL table name",
-			wantCopiedVars: true,
-		},
-		{
-			name:           "explicit SQL table name",
-			sqlTableName:   "Users",
-			wantCopiedVars: false,
-		},
+		{name: "auto-detected SQL table name"},
+		{name: "explicit SQL table name", sqlTableName: "Users"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			live := newSQLExportQueryVars(t, tt.sqlTableName)
+			session, live := newQueryCacheRPCSession(t, planB, statsB, nil)
+			live.Display.CLIFormat = enums.DisplayModeSQLInsert
+			live.Display.SQLTableName = tt.sqlTableName
 			seed := seedQueryCacheA()
 			live.LastResult.QueryCache = seed
 
-			formatted, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, planB, readTS, &live.LastResult.QueryCache)
-			if err != nil {
-				t.Fatalf("finalizeQueryResult: %v", err)
-			}
-			if (formatted != live) != tt.wantCopiedVars {
-				t.Fatalf("prepareFormatConfig copy = %v, want copy=%v", formatted != live, tt.wantCopiedVars)
+			if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true); err != nil {
+				t.Fatalf("executeSQLImplWithQueryRunner: %v", err)
 			}
 			if live.Display.SQLTableName != tt.sqlTableName {
 				t.Errorf("live SQLTableName = %q, want %q (auto-detect must not persist)", live.Display.SQLTableName, tt.sqlTableName)
 			}
-			if tt.wantCopiedVars && formatted.LastResult.QueryCache != seed {
-				t.Fatal("auto-detect copy received the publication; live cache would stay stale")
-			}
-
-			got := live.LastResult.QueryCache
-			if got == nil || got == seed {
-				t.Fatal("live QueryCache was not replaced")
-			}
-			if diff := cmp.Diff(planB, got.QueryPlan, protocmp.Transform()); diff != "" {
-				t.Errorf("QueryPlan mismatch (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(statsB, got.QueryStats); diff != "" {
-				t.Errorf("QueryStats mismatch (-want +got):\n%s", diff)
-			}
-			if !got.ReadTimestamp.Equal(readTS) {
-				t.Errorf("ReadTimestamp = %v, want %v", got.ReadTimestamp, readTS)
-			}
+			assertLiveQueryCacheReplaced(t, live, seed, planB, statsB)
 		})
 	}
 
-	// Subtests run in parallel, so compare after they complete via t.Cleanup
-	// is racy. Re-run the two modes sequentially here for equality.
-	t.Run("detected and explicit publish equal plan/stats/timestamp", func(t *testing.T) {
+	t.Run("detected and explicit publish equal plan/stats", func(t *testing.T) {
 		t.Parallel()
 		var published [2]*LastQueryCache
 		for i, sqlTableName := range []string{"", "Users"} {
-			live := newSQLExportQueryVars(t, sqlTableName)
+			session, live := newQueryCacheRPCSession(t, planB, statsB, nil)
+			live.Display.CLIFormat = enums.DisplayModeSQLInsert
+			live.Display.SQLTableName = sqlTableName
 			live.LastResult.QueryCache = seedQueryCacheA()
-			if _, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, planB, readTS, &live.LastResult.QueryCache); err != nil {
+			if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true); err != nil {
 				t.Fatalf("sqlTableName=%q: %v", sqlTableName, err)
 			}
 			published[i] = live.LastResult.QueryCache
 		}
-		if diff := cmp.Diff(published[0], published[1], protocmp.Transform()); diff != "" {
+		if diff := cmp.Diff(published[0], published[1], protocmp.Transform(), cmpopts.IgnoreFields(LastQueryCache{}, "ReadTimestamp")); diff != "" {
 			t.Errorf("detected vs explicit cache mismatch (-detected +explicit):\n%s", diff)
 		}
 	})
@@ -109,34 +100,56 @@ func TestQueryCachePublicationSQLExportNames(t *testing.T) {
 func TestQueryCachePublicationBufferedAndStreamingEmitters(t *testing.T) {
 	t.Parallel()
 
-	// Buffered executeWithBuffering and both streaming emitters
-	// (spanvalue writer and spanvalue processor) share queryExecution.finalizeQueryResult.
-	statsB := map[string]any{"elapsed_time": "3 msec"}
 	planB := testQueryPlan(t)
-	readTS := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	statsB := map[string]any{"elapsed_time": "3 msec", "query": "B"}
 
-	for _, route := range []string{"buffered", "spanvalue writer", "spanvalue processor"} {
-		t.Run(route, func(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		format       enums.DisplayMode
+		sqlTableName string
+		streaming    bool
+		wantStreamed bool
+	}{
+		{
+			name:         "buffered SQL export auto-detect",
+			format:       enums.DisplayModeSQLInsert,
+			wantStreamed: false,
+		},
+		{
+			name:         "spanvalue writer SQL export auto-detect",
+			format:       enums.DisplayModeSQLInsert,
+			streaming:    true,
+			wantStreamed: true,
+		},
+		{
+			// TAB streams through the RowProcessor stack. SQL auto-detect
+			// does not copy settings here; the dest still comes from the runner.
+			name:         "spanvalue processor",
+			format:       enums.DisplayModeTab,
+			streaming:    true,
+			wantStreamed: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			live := newSQLExportQueryVars(t, "")
+			session, live := newQueryCacheRPCSession(t, planB, statsB, nil)
+			live.Display.CLIFormat = tt.format
+			live.Display.SQLTableName = tt.sqlTableName
+			if tt.streaming {
+				var buf bytes.Buffer
+				live.StreamManager = streamio.NewStreamManager(io.NopCloser(strings.NewReader("")), &buf, io.Discard)
+			}
 			seed := seedQueryCacheA()
 			live.LastResult.QueryCache = seed
-			if _, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, planB, readTS, &live.LastResult.QueryCache); err != nil {
-				t.Fatalf("%s: %v", route, err)
+
+			result, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true)
+			if err != nil {
+				t.Fatalf("executeSQLImplWithQueryRunner: %v", err)
 			}
-			got := live.LastResult.QueryCache
-			if got == nil || got == seed {
-				t.Fatalf("%s did not replace the live cache", route)
+			if result.Streamed != tt.wantStreamed {
+				t.Fatalf("Streamed = %v, want %v (wrong emitter route)", result.Streamed, tt.wantStreamed)
 			}
-			if diff := cmp.Diff(planB, got.QueryPlan, protocmp.Transform()); diff != "" {
-				t.Errorf("%s QueryPlan mismatch (-want +got):\n%s", route, diff)
-			}
-			if diff := cmp.Diff(statsB, got.QueryStats); diff != "" {
-				t.Errorf("%s QueryStats mismatch (-want +got):\n%s", route, diff)
-			}
-			if !got.ReadTimestamp.Equal(readTS) {
-				t.Errorf("%s ReadTimestamp = %v, want %v", route, got.ReadTimestamp, readTS)
-			}
+			assertLiveQueryCacheReplaced(t, live, seed, planB, statsB)
 		})
 	}
 }
@@ -144,106 +157,67 @@ func TestQueryCachePublicationBufferedAndStreamingEmitters(t *testing.T) {
 func TestQueryCachePublicationNilDestinationLeavesLiveCache(t *testing.T) {
 	t.Parallel()
 
-	live := newSQLExportQueryVars(t, "")
+	planB := testQueryPlan(t)
+	session, live := newQueryCacheRPCSession(t, planB, map[string]any{"query": "DUMP"}, nil)
 	seed := seedQueryCacheA()
 	live.LastResult.QueryCache = seed
 
-	// DUMP's executeSQLWithFormatAndTxn path passes a nil destination even
-	// when SQL export auto-detects a table name and copies settings.
-	formatted, err := publishCompletedQuery(t, live, sqlExportSelectUsers, map[string]any{"query": "DUMP"}, testQueryPlan(t), time.Time{}, nil)
-	if err != nil {
-		t.Fatalf("finalizeQueryResult: %v", err)
-	}
-	if formatted == live {
-		t.Fatal("expected auto-detect copy so this covers DUMP-like isolated settings")
+	var buf bytes.Buffer
+	txn := session.client.ReadOnlyTransaction()
+	t.Cleanup(txn.Close)
+	if _, err := executeSQLWithFormatAndTxn(t.Context(), session, txn, sqlExportSelectUsers,
+		enums.DisplayModeSQLInsert, enums.StreamingModeTrue, "Users", &buf); err != nil {
+		t.Fatalf("executeSQLWithFormatAndTxn: %v", err)
 	}
 	if live.LastResult.QueryCache != seed {
-		t.Fatal("nil destination replaced the user's last-query cache")
-	}
-	if formatted.LastResult.QueryCache != seed {
-		t.Fatal("nil destination must not publish onto the settings copy either")
-	}
-}
-
-func TestQueryCachePublicationDoesNotInferFromPointerEquality(t *testing.T) {
-	t.Parallel()
-
-	live := newSQLExportQueryVars(t, "Users")
-	seed := seedQueryCacheA()
-	live.LastResult.QueryCache = seed
-
-	var isolated *LastQueryCache
-	formatted, err := publishCompletedQuery(t, live, sqlExportSelectUsers, map[string]any{"query": "B"}, testQueryPlan(t), time.Time{}, &isolated)
-	if err != nil {
-		t.Fatalf("finalizeQueryResult: %v", err)
-	}
-	if formatted != live {
-		t.Fatal("explicit table name should keep the caller's settings pointer")
-	}
-	if live.LastResult.QueryCache != seed {
-		t.Fatal("publication inferred the sysVars pointer as the destination")
-	}
-	if isolated == nil || isolated.QueryStats["query"] != "B" {
-		t.Fatal("explicit destination was not published")
+		t.Fatal("DUMP replaced the user's last-query cache")
 	}
 }
 
 func TestQueryCachePublicationParseFailureLeavesOldCache(t *testing.T) {
 	t.Parallel()
 
-	live := newSQLExportQueryVars(t, "Users")
+	session, live := newQueryCacheRPCSession(t, testQueryPlan(t), map[string]any{"query": "B"}, status.Error(codes.Internal, "iterator failed"))
+	live.Display.CLIFormat = enums.DisplayModeSQLInsert
 	seed := seedQueryCacheA()
 	live.LastResult.QueryCache = seed
 
-	// Iterator and parse failures return before finalizeQueryResult. A
-	// destination is captured, but publication must not run.
-	dest := &live.LastResult.QueryCache
-	if _, _, _, err := prepareFormatConfig(sqlExportSelectUsers, live); err != nil {
-		t.Fatal(err)
-	}
-	if dest == nil || *dest != seed {
-		t.Fatal("capturing the slot must not replace the cache")
+	_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true)
+	if err == nil {
+		t.Fatal("executeSQLImplWithQueryRunner error = nil, want iterator failure")
 	}
 	if live.LastResult.QueryCache != seed {
-		t.Fatal("skipped finalization replaced the live cache")
+		t.Fatal("iterator failure replaced the live cache")
 	}
 }
 
 func TestQueryCachePublicationAppendixFailureKeepsPublishedCache(t *testing.T) {
 	t.Parallel()
 
-	live := newSQLExportQueryVars(t, "Users")
-	seed := seedQueryCacheA()
-	live.LastResult.QueryCache = seed
-
-	// Index 5 at slice position 0 is rejected by spannerplan.New during appendix
-	// rendering, after the cache has already been replaced.
 	brokenPlan := &sppb.QueryPlan{
 		PlanNodes: []*sppb.PlanNode{{Index: 5, DisplayName: "Scan", Kind: sppb.PlanNode_RELATIONAL}},
 	}
 	statsB := map[string]any{"elapsed_time": "9 msec", "query": "B"}
+	session, live := newQueryCacheRPCSession(t, brokenPlan, statsB, nil)
+	live.Display.CLIFormat = enums.DisplayModeSQLInsert
 	live.Query.QueryMode = sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum()
+	seed := seedQueryCacheA()
+	live.LastResult.QueryCache = seed
 
-	_, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, brokenPlan, time.Time{}, &live.LastResult.QueryCache)
+	_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true)
 	if err == nil {
-		t.Fatal("finalizeQueryResult error = nil, want appendix rendering failure")
+		t.Fatal("executeSQLImplWithQueryRunner error = nil, want appendix rendering failure")
 	}
-	got := live.LastResult.QueryCache
-	if got == nil || got == seed {
-		t.Fatal("appendix failure cleared or skipped the already published cache")
-	}
-	if diff := cmp.Diff(brokenPlan, got.QueryPlan, protocmp.Transform()); diff != "" {
-		t.Errorf("published QueryPlan mismatch (-want +got):\n%s", diff)
-	}
-	if diff := cmp.Diff(statsB, got.QueryStats); diff != "" {
-		t.Errorf("published QueryStats mismatch (-want +got):\n%s", diff)
-	}
+	assertLiveQueryCacheReplaced(t, live, seed, brokenPlan, statsB)
 }
 
 func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 	t.Parallel()
 
-	live := newSQLExportQueryVars(t, "")
+	planB := testQueryPlan(t)
+	statsB := map[string]any{"elapsed_time": "2 msec", "query": "B"}
+	session, live := newQueryCacheRPCSession(t, planB, statsB, nil)
+	live.Display.CLIFormat = enums.DisplayModeSQLInsert
 	seed := &LastQueryCache{
 		QueryPlan: &sppb.QueryPlan{PlanNodes: []*sppb.PlanNode{
 			{Index: 0, Kind: sppb.PlanNode_RELATIONAL, DisplayName: "OldScan"},
@@ -252,14 +226,10 @@ func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 	}
 	live.LastResult.QueryCache = seed
 
-	planB := testQueryPlan(t)
-	statsB := map[string]any{"elapsed_time": "2 msec", "query": "B"}
-	result := &Result{Rows: []Row{toRow("should not persist")}}
-	if _, err := publishCompletedQueryResult(t, live, sqlExportSelectUsers, result, statsB, planB, time.Time{}, &live.LastResult.QueryCache); err != nil {
-		t.Fatalf("finalizeQueryResult: %v", err)
+	if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true); err != nil {
+		t.Fatalf("executeSQLImplWithQueryRunner: %v", err)
 	}
 
-	session := &Session{systemVariables: live}
 	explain, err := (&ExplainLastQueryStatement{}).Execute(t.Context(), session)
 	if err != nil {
 		t.Fatalf("EXPLAIN LAST QUERY: %v", err)
@@ -267,7 +237,7 @@ func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 	if explain == nil || len(explain.Rows) == 0 {
 		t.Fatal("EXPLAIN LAST QUERY returned no plan rows")
 	}
-	var sawNewPlan, sawOldPlan, sawDataRow bool
+	var sawNewPlan, sawOldPlan bool
 	for _, row := range explain.Rows {
 		joined := rowText(row)
 		if strings.Contains(joined, "Serialize Result") {
@@ -276,18 +246,12 @@ func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 		if strings.Contains(joined, "OldScan") {
 			sawOldPlan = true
 		}
-		if strings.Contains(joined, "should not persist") {
-			sawDataRow = true
-		}
 	}
 	if !sawNewPlan {
 		t.Errorf("EXPLAIN LAST QUERY did not see the newly published plan; rows=%v", explain.Rows)
 	}
 	if sawOldPlan {
 		t.Errorf("EXPLAIN LAST QUERY still showed the seed plan; rows=%v", explain.Rows)
-	}
-	if sawDataRow {
-		t.Fatal("query result rows were retained in the published cache")
 	}
 
 	show, err := (&ShowPlanNodeStatement{NodeID: 1}).Execute(t.Context(), session)
@@ -308,12 +272,20 @@ func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 	}
 }
 
-func newSQLExportQueryVars(t *testing.T, sqlTableName string) *systemVariables {
+func assertLiveQueryCacheReplaced(t *testing.T, live *systemVariables, seed *LastQueryCache, plan *sppb.QueryPlan, stats map[string]any) {
 	t.Helper()
-	sv := newSystemVariablesWithDefaultsForTest()
-	sv.Display.CLIFormat = enums.DisplayModeSQLInsert
-	sv.Display.SQLTableName = sqlTableName
-	return sv
+	got := live.LastResult.QueryCache
+	if got == nil || got == seed {
+		t.Fatal("live QueryCache was not replaced")
+	}
+	if diff := cmp.Diff(plan, got.QueryPlan, protocmp.Transform()); diff != "" {
+		t.Errorf("QueryPlan mismatch (-want +got):\n%s", diff)
+	}
+	for k, want := range stats {
+		if got.QueryStats[k] != want {
+			t.Errorf("QueryStats[%q] = %v, want %v (full=%v)", k, got.QueryStats[k], want, got.QueryStats)
+		}
+	}
 }
 
 func seedQueryCacheA() *LastQueryCache {
@@ -326,30 +298,119 @@ func seedQueryCacheA() *LastQueryCache {
 	}
 }
 
-func publishCompletedQuery(t *testing.T, live *systemVariables, sql string, stats map[string]any, plan *sppb.QueryPlan, readTS time.Time, dest **LastQueryCache) (*systemVariables, error) {
-	t.Helper()
-	return publishCompletedQueryResult(t, live, sql, &Result{}, stats, plan, readTS, dest)
-}
-
-func publishCompletedQueryResult(t *testing.T, live *systemVariables, sql string, result *Result, stats map[string]any, plan *sppb.QueryPlan, readTS time.Time, dest **LastQueryCache) (*systemVariables, error) {
-	t.Helper()
-	_, _, formatted, err := prepareFormatConfig(sql, live)
-	if err != nil {
-		return nil, err
-	}
-	result.ReadTimestamp = readTS
-	qe := &queryExecution{
-		SysVars:        formatted,
-		Metrics:        &metrics.ExecutionMetrics{},
-		QueryCacheDest: dest,
-	}
-	return formatted, qe.finalizeQueryResult(result, stats, plan)
-}
-
 func rowText(row Row) string {
 	parts := make([]string, len(row))
 	for i, cell := range row {
 		parts[i] = cell.RawText()
 	}
 	return strings.Join(parts, " ")
+}
+
+type queryCacheRPCServer struct {
+	sppb.UnimplementedSpannerServer
+	plan    *sppb.QueryPlan
+	stats   *structpb.Struct
+	execErr error
+}
+
+func (s *queryCacheRPCServer) CreateSession(_ context.Context, r *sppb.CreateSessionRequest) (*sppb.Session, error) {
+	return &sppb.Session{Name: r.Database + "/sessions/qcache", Multiplexed: true, CreateTime: queryCacheFixedReadTS}, nil
+}
+
+func (s *queryCacheRPCServer) BatchCreateSessions(_ context.Context, r *sppb.BatchCreateSessionsRequest) (*sppb.BatchCreateSessionsResponse, error) {
+	n := int(r.SessionCount)
+	if n <= 0 {
+		n = 1
+	}
+	sessions := make([]*sppb.Session, n)
+	for i := range n {
+		sessions[i] = &sppb.Session{Name: fmt.Sprintf("%s/sessions/%d", r.Database, i), CreateTime: timestamppb.Now()}
+	}
+	return &sppb.BatchCreateSessionsResponse{Session: sessions}, nil
+}
+
+func (s *queryCacheRPCServer) GetSession(_ context.Context, r *sppb.GetSessionRequest) (*sppb.Session, error) {
+	return &sppb.Session{Name: r.Name, Multiplexed: true, CreateTime: timestamppb.Now()}, nil
+}
+
+func (s *queryCacheRPCServer) DeleteSession(context.Context, *sppb.DeleteSessionRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (s *queryCacheRPCServer) BeginTransaction(context.Context, *sppb.BeginTransactionRequest) (*sppb.Transaction, error) {
+	return &sppb.Transaction{Id: []byte("qcache-ro"), ReadTimestamp: queryCacheFixedReadTS}, nil
+}
+
+func (s *queryCacheRPCServer) ExecuteSql(context.Context, *sppb.ExecuteSqlRequest) (*sppb.ResultSet, error) {
+	return s.resultSet(), nil
+}
+
+func (s *queryCacheRPCServer) ExecuteStreamingSql(_ *sppb.ExecuteSqlRequest, stream sppb.Spanner_ExecuteStreamingSqlServer) error {
+	if s.execErr != nil {
+		return s.execErr
+	}
+	return stream.Send(&sppb.PartialResultSet{
+		Metadata: s.resultSet().Metadata,
+		Values:   []*structpb.Value{structpb.NewStringValue("1")},
+		Stats:    s.resultSet().Stats,
+	})
+}
+
+func (s *queryCacheRPCServer) resultSet() *sppb.ResultSet {
+	return &sppb.ResultSet{
+		Metadata: &sppb.ResultSetMetadata{
+			RowType: &sppb.StructType{Fields: []*sppb.StructType_Field{
+				{Name: "id", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
+			}},
+			Transaction: &sppb.Transaction{Id: []byte("qcache-ro"), ReadTimestamp: queryCacheFixedReadTS},
+		},
+		Stats: &sppb.ResultSetStats{
+			QueryPlan:  s.plan,
+			QueryStats: s.stats,
+		},
+	}
+}
+
+func newQueryCacheRPCSession(t *testing.T, plan *sppb.QueryPlan, stats map[string]any, execErr error) (*Session, *systemVariables) {
+	t.Helper()
+	listener := bufconn.Listen(1 << 20)
+	grpcServer := grpc.NewServer()
+	sppb.RegisterSpannerServer(grpcServer, &queryCacheRPCServer{
+		plan:    plan,
+		stats:   mustNewStruct(stats),
+		execErr: execErr,
+	})
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Errorf("serve: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
+	conn, err := grpc.NewClient("passthrough:///qcache",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return listener.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	client, err := spanner.NewClientWithConfig(t.Context(), "projects/test/instances/test/databases/test",
+		spanner.ClientConfig{DisableNativeMetrics: true}, option.WithGRPCConn(conn))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Close)
+
+	live := newSystemVariablesWithDefaultsForTest()
+	session := &Session{
+		mode:            DatabaseConnected,
+		client:          client,
+		systemVariables: live,
+		txn:             NewTransactionManager(client, live, spanner.ClientConfig{DisableNativeMetrics: true}),
+	}
+	live.inTransaction = session.txn.InTransaction
+	return session, live
 }

--- a/internal/mycli/query_cache_test.go
+++ b/internal/mycli/query_cache_test.go
@@ -1,0 +1,355 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/metrics"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+const sqlExportSelectUsers = "SELECT * FROM Users"
+
+func TestQueryCachePublicationSQLExportNames(t *testing.T) {
+	t.Parallel()
+
+	statsB := map[string]any{"elapsed_time": "2 msec", "query": "B"}
+	planB := testQueryPlan(t)
+	readTS := time.Date(2026, 9, 12, 8, 0, 0, 0, time.UTC)
+
+	for _, tt := range []struct {
+		name           string
+		sqlTableName   string
+		wantCopiedVars bool
+	}{
+		{
+			name:           "auto-detected SQL table name",
+			wantCopiedVars: true,
+		},
+		{
+			name:           "explicit SQL table name",
+			sqlTableName:   "Users",
+			wantCopiedVars: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			live := newSQLExportQueryVars(t, tt.sqlTableName)
+			seed := seedQueryCacheA()
+			live.LastResult.QueryCache = seed
+
+			formatted, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, planB, readTS, &live.LastResult.QueryCache)
+			if err != nil {
+				t.Fatalf("finalizeQueryResult: %v", err)
+			}
+			if (formatted != live) != tt.wantCopiedVars {
+				t.Fatalf("prepareFormatConfig copy = %v, want copy=%v", formatted != live, tt.wantCopiedVars)
+			}
+			if live.Display.SQLTableName != tt.sqlTableName {
+				t.Errorf("live SQLTableName = %q, want %q (auto-detect must not persist)", live.Display.SQLTableName, tt.sqlTableName)
+			}
+			if tt.wantCopiedVars && formatted.LastResult.QueryCache != seed {
+				t.Fatal("auto-detect copy received the publication; live cache would stay stale")
+			}
+
+			got := live.LastResult.QueryCache
+			if got == nil || got == seed {
+				t.Fatal("live QueryCache was not replaced")
+			}
+			if diff := cmp.Diff(planB, got.QueryPlan, protocmp.Transform()); diff != "" {
+				t.Errorf("QueryPlan mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(statsB, got.QueryStats); diff != "" {
+				t.Errorf("QueryStats mismatch (-want +got):\n%s", diff)
+			}
+			if !got.ReadTimestamp.Equal(readTS) {
+				t.Errorf("ReadTimestamp = %v, want %v", got.ReadTimestamp, readTS)
+			}
+		})
+	}
+
+	// Subtests run in parallel, so compare after they complete via t.Cleanup
+	// is racy. Re-run the two modes sequentially here for equality.
+	t.Run("detected and explicit publish equal plan/stats/timestamp", func(t *testing.T) {
+		t.Parallel()
+		var published [2]*LastQueryCache
+		for i, sqlTableName := range []string{"", "Users"} {
+			live := newSQLExportQueryVars(t, sqlTableName)
+			live.LastResult.QueryCache = seedQueryCacheA()
+			if _, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, planB, readTS, &live.LastResult.QueryCache); err != nil {
+				t.Fatalf("sqlTableName=%q: %v", sqlTableName, err)
+			}
+			published[i] = live.LastResult.QueryCache
+		}
+		if diff := cmp.Diff(published[0], published[1], protocmp.Transform()); diff != "" {
+			t.Errorf("detected vs explicit cache mismatch (-detected +explicit):\n%s", diff)
+		}
+	})
+}
+
+func TestQueryCachePublicationBufferedAndStreamingEmitters(t *testing.T) {
+	t.Parallel()
+
+	// Buffered executeWithBuffering and both streaming emitters
+	// (spanvalue writer and spanvalue processor) share queryExecution.finalizeQueryResult.
+	statsB := map[string]any{"elapsed_time": "3 msec"}
+	planB := testQueryPlan(t)
+	readTS := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	for _, route := range []string{"buffered", "spanvalue writer", "spanvalue processor"} {
+		t.Run(route, func(t *testing.T) {
+			t.Parallel()
+			live := newSQLExportQueryVars(t, "")
+			seed := seedQueryCacheA()
+			live.LastResult.QueryCache = seed
+			if _, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, planB, readTS, &live.LastResult.QueryCache); err != nil {
+				t.Fatalf("%s: %v", route, err)
+			}
+			got := live.LastResult.QueryCache
+			if got == nil || got == seed {
+				t.Fatalf("%s did not replace the live cache", route)
+			}
+			if diff := cmp.Diff(planB, got.QueryPlan, protocmp.Transform()); diff != "" {
+				t.Errorf("%s QueryPlan mismatch (-want +got):\n%s", route, diff)
+			}
+			if diff := cmp.Diff(statsB, got.QueryStats); diff != "" {
+				t.Errorf("%s QueryStats mismatch (-want +got):\n%s", route, diff)
+			}
+			if !got.ReadTimestamp.Equal(readTS) {
+				t.Errorf("%s ReadTimestamp = %v, want %v", route, got.ReadTimestamp, readTS)
+			}
+		})
+	}
+}
+
+func TestQueryCachePublicationNilDestinationLeavesLiveCache(t *testing.T) {
+	t.Parallel()
+
+	live := newSQLExportQueryVars(t, "")
+	seed := seedQueryCacheA()
+	live.LastResult.QueryCache = seed
+
+	// DUMP's executeSQLWithFormatAndTxn path passes a nil destination even
+	// when SQL export auto-detects a table name and copies settings.
+	formatted, err := publishCompletedQuery(t, live, sqlExportSelectUsers, map[string]any{"query": "DUMP"}, testQueryPlan(t), time.Time{}, nil)
+	if err != nil {
+		t.Fatalf("finalizeQueryResult: %v", err)
+	}
+	if formatted == live {
+		t.Fatal("expected auto-detect copy so this covers DUMP-like isolated settings")
+	}
+	if live.LastResult.QueryCache != seed {
+		t.Fatal("nil destination replaced the user's last-query cache")
+	}
+	if formatted.LastResult.QueryCache != seed {
+		t.Fatal("nil destination must not publish onto the settings copy either")
+	}
+}
+
+func TestQueryCachePublicationDoesNotInferFromPointerEquality(t *testing.T) {
+	t.Parallel()
+
+	live := newSQLExportQueryVars(t, "Users")
+	seed := seedQueryCacheA()
+	live.LastResult.QueryCache = seed
+
+	var isolated *LastQueryCache
+	formatted, err := publishCompletedQuery(t, live, sqlExportSelectUsers, map[string]any{"query": "B"}, testQueryPlan(t), time.Time{}, &isolated)
+	if err != nil {
+		t.Fatalf("finalizeQueryResult: %v", err)
+	}
+	if formatted != live {
+		t.Fatal("explicit table name should keep the caller's settings pointer")
+	}
+	if live.LastResult.QueryCache != seed {
+		t.Fatal("publication inferred the sysVars pointer as the destination")
+	}
+	if isolated == nil || isolated.QueryStats["query"] != "B" {
+		t.Fatal("explicit destination was not published")
+	}
+}
+
+func TestQueryCachePublicationParseFailureLeavesOldCache(t *testing.T) {
+	t.Parallel()
+
+	live := newSQLExportQueryVars(t, "Users")
+	seed := seedQueryCacheA()
+	live.LastResult.QueryCache = seed
+
+	// Iterator and parse failures return before finalizeQueryResult. A
+	// destination is captured, but publication must not run.
+	dest := &live.LastResult.QueryCache
+	if _, _, _, err := prepareFormatConfig(sqlExportSelectUsers, live); err != nil {
+		t.Fatal(err)
+	}
+	if dest == nil || *dest != seed {
+		t.Fatal("capturing the slot must not replace the cache")
+	}
+	if live.LastResult.QueryCache != seed {
+		t.Fatal("skipped finalization replaced the live cache")
+	}
+}
+
+func TestQueryCachePublicationAppendixFailureKeepsPublishedCache(t *testing.T) {
+	t.Parallel()
+
+	live := newSQLExportQueryVars(t, "Users")
+	seed := seedQueryCacheA()
+	live.LastResult.QueryCache = seed
+
+	// Index 5 at slice position 0 is rejected by spannerplan.New during appendix
+	// rendering, after the cache has already been replaced.
+	brokenPlan := &sppb.QueryPlan{
+		PlanNodes: []*sppb.PlanNode{{Index: 5, DisplayName: "Scan", Kind: sppb.PlanNode_RELATIONAL}},
+	}
+	statsB := map[string]any{"elapsed_time": "9 msec", "query": "B"}
+	live.Query.QueryMode = sppb.ExecuteSqlRequest_WITH_PLAN_AND_STATS.Enum()
+
+	_, err := publishCompletedQuery(t, live, sqlExportSelectUsers, statsB, brokenPlan, time.Time{}, &live.LastResult.QueryCache)
+	if err == nil {
+		t.Fatal("finalizeQueryResult error = nil, want appendix rendering failure")
+	}
+	got := live.LastResult.QueryCache
+	if got == nil || got == seed {
+		t.Fatal("appendix failure cleared or skipped the already published cache")
+	}
+	if diff := cmp.Diff(brokenPlan, got.QueryPlan, protocmp.Transform()); diff != "" {
+		t.Errorf("published QueryPlan mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(statsB, got.QueryStats); diff != "" {
+		t.Errorf("published QueryStats mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
+	t.Parallel()
+
+	live := newSQLExportQueryVars(t, "")
+	seed := &LastQueryCache{
+		QueryPlan: &sppb.QueryPlan{PlanNodes: []*sppb.PlanNode{
+			{Index: 0, Kind: sppb.PlanNode_RELATIONAL, DisplayName: "OldScan"},
+		}},
+		QueryStats: map[string]any{"query": "A"},
+	}
+	live.LastResult.QueryCache = seed
+
+	planB := testQueryPlan(t)
+	statsB := map[string]any{"elapsed_time": "2 msec", "query": "B"}
+	result := &Result{Rows: []Row{toRow("should not persist")}}
+	if _, err := publishCompletedQueryResult(t, live, sqlExportSelectUsers, result, statsB, planB, time.Time{}, &live.LastResult.QueryCache); err != nil {
+		t.Fatalf("finalizeQueryResult: %v", err)
+	}
+
+	session := &Session{systemVariables: live}
+	explain, err := (&ExplainLastQueryStatement{}).Execute(t.Context(), session)
+	if err != nil {
+		t.Fatalf("EXPLAIN LAST QUERY: %v", err)
+	}
+	if explain == nil || len(explain.Rows) == 0 {
+		t.Fatal("EXPLAIN LAST QUERY returned no plan rows")
+	}
+	var sawNewPlan, sawOldPlan, sawDataRow bool
+	for _, row := range explain.Rows {
+		joined := rowText(row)
+		if strings.Contains(joined, "Serialize Result") {
+			sawNewPlan = true
+		}
+		if strings.Contains(joined, "OldScan") {
+			sawOldPlan = true
+		}
+		if strings.Contains(joined, "should not persist") {
+			sawDataRow = true
+		}
+	}
+	if !sawNewPlan {
+		t.Errorf("EXPLAIN LAST QUERY did not see the newly published plan; rows=%v", explain.Rows)
+	}
+	if sawOldPlan {
+		t.Errorf("EXPLAIN LAST QUERY still showed the seed plan; rows=%v", explain.Rows)
+	}
+	if sawDataRow {
+		t.Fatal("query result rows were retained in the published cache")
+	}
+
+	show, err := (&ShowPlanNodeStatement{NodeID: 1}).Execute(t.Context(), session)
+	if err != nil {
+		t.Fatalf("SHOW PLAN NODE 1: %v", err)
+	}
+	if show == nil || len(show.Rows) == 0 || !strings.Contains(show.Rows[0][0].RawText(), "Scan") {
+		t.Errorf("SHOW PLAN NODE 1 = %v, want cached Scan node from the new plan", show)
+	}
+
+	f := &fuzzyFinderCommand{cli: &Cli{SystemVariables: live}}
+	got, err := f.resolveCandidates(t.Context(), fuzzyCompletePlanNode, "")
+	if err != nil {
+		t.Fatalf("plan-node completion: %v", err)
+	}
+	if len(got) != 2 || got[0].Value != "0" || got[1].Value != "1" {
+		t.Fatalf("plan-node completion = %v, want the newly published two-node plan", got)
+	}
+}
+
+func newSQLExportQueryVars(t *testing.T, sqlTableName string) *systemVariables {
+	t.Helper()
+	sv := newSystemVariablesWithDefaultsForTest()
+	sv.Display.CLIFormat = enums.DisplayModeSQLInsert
+	sv.Display.SQLTableName = sqlTableName
+	return sv
+}
+
+func seedQueryCacheA() *LastQueryCache {
+	return &LastQueryCache{
+		QueryPlan: &sppb.QueryPlan{PlanNodes: []*sppb.PlanNode{
+			{Index: 0, Kind: sppb.PlanNode_RELATIONAL, DisplayName: "OldScan"},
+		}},
+		QueryStats:    map[string]any{"query": "A", "elapsed_time": "1 msec"},
+		ReadTimestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func publishCompletedQuery(t *testing.T, live *systemVariables, sql string, stats map[string]any, plan *sppb.QueryPlan, readTS time.Time, dest **LastQueryCache) (*systemVariables, error) {
+	t.Helper()
+	return publishCompletedQueryResult(t, live, sql, &Result{}, stats, plan, readTS, dest)
+}
+
+func publishCompletedQueryResult(t *testing.T, live *systemVariables, sql string, result *Result, stats map[string]any, plan *sppb.QueryPlan, readTS time.Time, dest **LastQueryCache) (*systemVariables, error) {
+	t.Helper()
+	_, _, formatted, err := prepareFormatConfig(sql, live)
+	if err != nil {
+		return nil, err
+	}
+	result.ReadTimestamp = readTS
+	qe := &queryExecution{
+		SysVars:        formatted,
+		Metrics:        &metrics.ExecutionMetrics{},
+		QueryCacheDest: dest,
+	}
+	return formatted, qe.finalizeQueryResult(result, stats, plan)
+}
+
+func rowText(row Row) string {
+	parts := make([]string, len(row))
+	for i, cell := range row {
+		parts[i] = cell.RawText()
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/mycli/query_mode_test.go
+++ b/internal/mycli/query_mode_test.go
@@ -346,7 +346,12 @@ func TestFinalizeQueryResultQueryModeRendering(t *testing.T) {
 			sysVars.Query.QueryMode = tt.userMode
 
 			result := &Result{}
-			if err := finalizeQueryResult(result, stats, nil, plan, sysVars, &metrics.ExecutionMetrics{}); err != nil {
+			qe := &queryExecution{
+				SysVars:        sysVars,
+				Metrics:        &metrics.ExecutionMetrics{},
+				QueryCacheDest: &sysVars.LastResult.QueryCache,
+			}
+			if err := qe.finalizeQueryResult(result, stats, plan); err != nil {
 				t.Fatalf("finalizeQueryResult() error = %v, want nil", err)
 			}
 

--- a/internal/mycli/spanvalue_streaming.go
+++ b/internal/mycli/spanvalue_streaming.go
@@ -54,14 +54,7 @@ func executeStreamingSQLWithSpanvalueWriter(qe *queryExecution) (*Result, bool, 
 		SQLExportAllowed: qe.ValueFmtMode == format.SQLLiteralValues,
 	}
 
-	if err := finalizeQueryResult(
-		result,
-		queryStats,
-		qe.ReadOnlyTxn,
-		queryPlan,
-		qe.SysVars,
-		qe.Metrics,
-	); err != nil {
+	if err := qe.finalizeQueryResult(result, queryStats, queryPlan); err != nil {
 		return nil, true, err
 	}
 	return result, true, nil
@@ -97,14 +90,7 @@ func executeStreamingSQLWithSpanvalueProcessor(qe *queryExecution) (*Result, err
 		SQLExportAllowed: qe.ValueFmtMode == format.SQLLiteralValues,
 	}
 
-	if err := finalizeQueryResult(
-		result,
-		queryStats,
-		qe.ReadOnlyTxn,
-		queryPlan,
-		qe.SysVars,
-		qe.Metrics,
-	); err != nil {
+	if err := qe.finalizeQueryResult(result, queryStats, queryPlan); err != nil {
 		return nil, err
 	}
 	return result, nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #914. Tracking: #911.

`prepareFormatConfig` copies `systemVariables` when SQL export auto-detects a table name so the detected name stays per-query. `finalizeQueryResult` then wrote `LastResult.QueryCache` on that copy. A completed SQL-export query with an auto-detected name therefore left the live plan/stats cache stale, while the same query with `CLI_SQL_TABLE_NAME` set updated it. That is an observable bug, not a mechanical refactor: `EXPLAIN LAST QUERY` and plan-node completion could miss the query the user just ran.

This PR captures a nullable pointer to the caller's `LastResult.QueryCache` slot **before** `prepareFormatConfig` can return a copy, and publishes only through that destination. Nil means no publication. Ownership is never inferred from pointer equality or display format. Settings copies stay in place for the later cleanup (#915).

## Behavior

- Normal and isolated-single-use query-runner paths (`executeSQL` / `EXPORT DATA`) publish to the captured caller slot, including auto-detected SQL export. Buffered output and both streaming emitters (`executeWithBuffering`, spanvalue writer, spanvalue processor) share `queryExecution.finalizeQueryResult`.
- DUMP's `executeSQLWithFormatAndTxn` path passes a nil destination so per-table reads do not replace the user's last-query cache.
- Iterator or query-stat parsing failure never reaches finalization, so the previous cache remains. Appendix rendering and the after-collect hook run after publication and do not clear it.
- `EXPLAIN LAST QUERY` and plan-node completion read the newly published plan/stats/timestamp. Result rows are not stored in the cache.

## Tests

`TestQueryCachePublication*` now drives `executeSQLImplWithQueryRunner` against a fake Spanner RPC session. The runner chooses `QueryCacheDest`. Cases seed cache A, run query B with an auto-detected table name, and assert the live cache is replaced for buffered SQL export, the SQL writer, and the TAB processor path. DUMP uses `executeSQLWithFormatAndTxn` and leaves the live cache unchanged. Moving the production capture below `prepareFormatConfig` fails the auto-detect cases.

## Validation

```sh
go test -short ./internal/mycli/... -run 'QueryMode|QueryCache|Fuzzy|SQLExport|Dump'
go test -short ./...
go test -short -race ./...
golangci-lint run --timeout=5m
make fmt-check
```

Full `make check` (`go test ./...` plus lint/fmt) was not completed locally because this environment has no Docker/emulator. CI should run the required emulator suite.

## Changed files

- `internal/mycli/execute_sql.go` — capture the cache slot; nil destination on the explicit-txn/DUMP path; `finalizeQueryResult` is a method on `queryExecution`
- `internal/mycli/spanvalue_streaming.go` — both streaming emitters call `qe.finalizeQueryResult` (same publication as buffered). This is only the finalize call sites; it does not change `newSpanvalueRowIteratorWriterFor` (#926)
- `internal/mycli/query_cache_test.go` — execution-path tests through the runner (fake RPC), including processor path, DUMP nil destination, appendix-failure timing, EXPLAIN LAST QUERY / plan-node completion
- `internal/mycli/query_mode_test.go` — rendering tests pass the explicit destination

Deleted: publishing through `sysVars.LastResult.QueryCache` after a possible auto-detect copy.

No DML cache policy change, streaming-output rollback, table-name persistence into user settings, whole-settings clone deletion, dependency upgrades, or unrelated cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd6d5b0c-97e4-5d76-8e6c-27b13658d5fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd6d5b0c-97e4-5d76-8e6c-27b13658d5fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

