### PR TITLE
Give each Session a fixed connection identity

### DIFF
--- a/internal/mycli/feature.go
+++ b/internal/mycli/feature.go
@@ -202,8 +202,8 @@ func NewTableHeader(names ...string) TableHeader { return toTableHeader(names...
 // argument. Exported wrapper over unquoteString for feature packages.
 func UnquoteString(s string) string { return unquoteString(s) }
 
-// ProjectID returns the configured Spanner project for the session.
-func (s *Session) ProjectID() string { return s.systemVariables.Connection.Project }
+// ProjectID returns the session's construction-time Spanner project.
+func (s *Session) ProjectID() string { return s.connection.Project }
 
 // CredentialBytes returns a defensive copy of the raw --credential bytes stored
 // on the durable startup config. Feature packages that build their own

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -128,6 +128,11 @@ type Session struct {
 	clientOpts      []option.ClientOption
 	txn             *TransactionManager // transaction lifecycle + query execution
 	systemVariables *systemVariables
+	// connection is the construction identity (project, instance, database,
+	// role). Client creation, Session.DatabasePath, and per-session
+	// administrative resource paths use this copy, not the live registry
+	// Connection on systemVariables.
+	connection ConnectionVars
 
 	batch BatchManager
 
@@ -222,18 +227,7 @@ func (h *SessionHandler) createSessionWithOpts(ctx context.Context, sysVars *sys
 		opts = current.clientOpts
 	}
 
-	// Create admin-only session if no database is specified
-	var session *Session
-	var err error
-	if sysVars.Connection.Database == "" {
-		session, err = NewAdminSession(ctx, sysVars, opts...)
-	} else {
-		session, err = NewSession(ctx, sysVars, opts...)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return session, nil
+	return createSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
 }
 
 // validateSessionSwitch rejects USE/DETACH while a transaction or batch is
@@ -353,9 +347,25 @@ func logGrpcClientOptions() []option.ClientOption {
 }
 
 func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
+	return newSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+}
+
+// createSessionWithIdentity constructs a Session for identity while sharing
+// sysVars for registry, query/transaction settings, runtime logging,
+// StreamManager and feature variables. Public constructors capture the live
+// Connection values instead of taking identity explicitly.
+func createSessionWithIdentity(ctx context.Context, sysVars *systemVariables, identity ConnectionVars, opts ...option.ClientOption) (*Session, error) {
+	if identity.Database == "" {
+		return newAdminSessionWithIdentity(ctx, sysVars, identity, opts...)
+	}
+	return newSessionWithIdentity(ctx, sysVars, identity, opts...)
+}
+
+func newSessionWithIdentity(ctx context.Context, sysVars *systemVariables, identity ConnectionVars, opts ...option.ClientOption) (*Session, error) {
 	return newSessionWithFactories(
 		ctx,
 		sysVars,
+		identity,
 		spanner.NewClientWithConfig,
 		adminapi.NewDatabaseAdminClient,
 		func(client *spanner.Client) { client.Close() },
@@ -363,29 +373,58 @@ func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.Cl
 	)
 }
 
+func clientConfigForIdentity(sysVars *systemVariables, identity ConnectionVars) spanner.ClientConfig {
+	clientConfig := clientConfigForSystemVariables(sysVars)
+	clientConfig.DatabaseRole = identity.Role
+	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
+	return clientConfig
+}
+
+func appendSessionClientOptions(sysVars *systemVariables, opts []option.ClientOption) []option.ClientOption {
+	if sysVars.Config.Insecure && len(sysVars.Config.EmbeddedClientOptions) == 0 {
+		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
+	}
+	if sysVars.Config.LogGrpc {
+		opts = append(opts, logGrpcClientOptions()...)
+	}
+	return append(opts, defaultClientOpts...)
+}
+
+func bindConstructedSession(
+	mode SessionMode,
+	client *spanner.Client,
+	adminClient *adminapi.DatabaseAdminClient,
+	clientConfig spanner.ClientConfig,
+	opts []option.ClientOption,
+	sysVars *systemVariables,
+	identity ConnectionVars,
+) *Session {
+	session := &Session{
+		mode:            mode,
+		client:          client,
+		clientConfig:    clientConfig,
+		clientOpts:      opts,
+		adminClient:     adminClient,
+		txn:             NewTransactionManager(client, sysVars, clientConfig),
+		systemVariables: sysVars,
+		connection:      identity,
+	}
+	sysVars.inTransaction = session.txn.InTransaction
+	return session
+}
+
 func newSessionWithFactories(
 	ctx context.Context,
 	sysVars *systemVariables,
+	identity ConnectionVars,
 	clientFactory func(context.Context, string, spanner.ClientConfig, ...option.ClientOption) (*spanner.Client, error),
 	adminClientFactory func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error),
 	closeClient func(*spanner.Client),
 	opts ...option.ClientOption,
 ) (*Session, error) {
-	dbPath := sysVars.DatabasePath()
-	clientConfig := clientConfigForSystemVariables(sysVars)
-	clientConfig.DatabaseRole = sysVars.Connection.Role
-	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
-
-	if sysVars.Config.Insecure && len(sysVars.Config.EmbeddedClientOptions) == 0 {
-		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
-	}
-
-	if sysVars.Config.LogGrpc {
-		opts = append(opts, logGrpcClientOptions()...)
-	}
-
-	opts = append(opts, defaultClientOpts...)
-	client, err := clientFactory(ctx, dbPath, clientConfig, opts...)
+	clientConfig := clientConfigForIdentity(sysVars, identity)
+	opts = appendSessionClientOptions(sysVars, opts)
+	client, err := clientFactory(ctx, identity.DatabasePath(), clientConfig, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -396,52 +435,19 @@ func newSessionWithFactories(
 		return nil, err
 	}
 
-	session := &Session{
-		mode:            DatabaseConnected,
-		client:          client,
-		clientConfig:    clientConfig,
-		clientOpts:      opts,
-		adminClient:     adminClient,
-		txn:             NewTransactionManager(client, sysVars, clientConfig),
-		systemVariables: sysVars,
-	}
-	sysVars.inTransaction = session.txn.InTransaction
-
-	return session, nil
+	return bindConstructedSession(DatabaseConnected, client, adminClient, clientConfig, opts, sysVars, identity), nil
 }
 
 func NewAdminSession(ctx context.Context, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
-	clientConfig := clientConfigForSystemVariables(sysVars)
-	clientConfig.DatabaseRole = sysVars.Connection.Role
-	clientConfig.DirectedReadOptions = sysVars.Query.DirectedRead
+	return newAdminSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+}
 
-	if sysVars.Config.Insecure && len(sysVars.Config.EmbeddedClientOptions) == 0 {
-		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
-	}
-
-	if sysVars.Config.LogGrpc {
-		opts = append(opts, logGrpcClientOptions()...)
-	}
-
-	opts = append(opts, defaultClientOpts...)
-
-	adminClient, err := adminapi.NewDatabaseAdminClient(ctx, opts...)
+func newAdminSessionWithIdentity(ctx context.Context, sysVars *systemVariables, identity ConnectionVars, opts ...option.ClientOption) (*Session, error) {
+	session, err := newAdminSessionWithFactories(ctx, sysVars, identity, adminapi.NewDatabaseAdminClient, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	session := &Session{
-		mode:            Detached,
-		client:          nil, // no database client in detached mode
-		clientConfig:    clientConfig,
-		clientOpts:      opts,
-		adminClient:     adminClient,
-		txn:             NewTransactionManager(nil, sysVars, clientConfig),
-		systemVariables: sysVars,
-	}
-	sysVars.inTransaction = session.txn.InTransaction
-
-	// Validate instance exists
 	exists, err := session.InstanceExists(ctx)
 	if err != nil {
 		session.Close()
@@ -449,10 +455,27 @@ func NewAdminSession(ctx context.Context, sysVars *systemVariables, opts ...opti
 	}
 	if !exists {
 		session.Close()
-		return nil, fmt.Errorf("unknown instance %q", sysVars.Connection.Instance)
+		return nil, fmt.Errorf("unknown instance %q", identity.Instance)
 	}
 
 	return session, nil
+}
+
+func newAdminSessionWithFactories(
+	ctx context.Context,
+	sysVars *systemVariables,
+	identity ConnectionVars,
+	adminClientFactory func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error),
+	opts ...option.ClientOption,
+) (*Session, error) {
+	clientConfig := clientConfigForIdentity(sysVars, identity)
+	opts = appendSessionClientOptions(sysVars, opts)
+	adminClient, err := adminClientFactory(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return bindConstructedSession(Detached, nil, adminClient, clientConfig, opts, sysVars, identity), nil
 }
 
 func (s *Session) Mode() SessionMode {
@@ -593,11 +616,11 @@ func (s *Session) Close() {
 }
 
 func (s *Session) DatabasePath() string {
-	return s.systemVariables.DatabasePath()
+	return s.connection.DatabasePath()
 }
 
 func (s *Session) InstancePath() string {
-	return s.systemVariables.InstancePath()
+	return s.connection.InstancePath()
 }
 
 // InstanceExists reports whether the configured Spanner instance is reachable.
@@ -922,16 +945,5 @@ func createSession(ctx context.Context, credential []byte, sysVars *systemVariab
 	if err != nil {
 		return nil, err
 	}
-
-	var session *Session
-	// Create admin-only session if no database is specified
-	if sysVars.Connection.Database == "" {
-		session, err = NewAdminSession(ctx, sysVars, opts...)
-	} else {
-		session, err = NewSession(ctx, sysVars, opts...)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return session, nil
+	return createSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
 }

--- a/internal/mycli/session_modes_unit_test.go
+++ b/internal/mycli/session_modes_unit_test.go
@@ -41,6 +41,7 @@ func TestDetachedSessionSystemVariables(t *testing.T) {
 		client:          nil, // no database client in detached mode
 		adminClient:     nil, // we won't actually use the admin client in these tests
 		systemVariables: sysVars,
+		connection:      sysVars.Connection,
 	}
 	// Zero-value &Session{} needs a real (client-less) manager now that
 	// callers dispatch to session.txn directly instead of the deleted mirror.

--- a/internal/mycli/session_slow_test.go
+++ b/internal/mycli/session_slow_test.go
@@ -418,11 +418,11 @@ func TestInstanceExists(t *testing.T) {
 	})
 
 	t.Run("nonexistent instance", func(t *testing.T) {
-		// Temporarily point the session at an instance that does not exist so
-		// the databases.list call resolves to NotFound.
-		orig := session.systemVariables.Connection.Instance
-		session.systemVariables.Connection.Instance = "nonexistent-instance"
-		defer func() { session.systemVariables.Connection.Instance = orig }()
+		// Temporarily point the session identity at an instance that does not
+		// exist so the databases.list call resolves to NotFound.
+		orig := session.connection.Instance
+		session.connection.Instance = "nonexistent-instance"
+		defer func() { session.connection.Instance = orig }()
 
 		exists, err := session.InstanceExists(ctx)
 		if err != nil {

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -148,6 +148,11 @@ func TestNewSessionClosesClientWhenAdminClientCreationFails(t *testing.T) {
 				Database: "test-database",
 			},
 		},
+		ConnectionVars{
+			Project:  "test-project",
+			Instance: "test-instance",
+			Database: "test-database",
+		},
 		func(context.Context, string, spanner.ClientConfig, ...option.ClientOption) (*spanner.Client, error) {
 			return fakeClient, nil
 		},
@@ -352,6 +357,7 @@ func TestNewSessionWithFactoriesUsesEmbeddedClientConfig(t *testing.T) {
 	session, err := newSessionWithFactories(
 		context.Background(),
 		sysVars,
+		sysVars.Connection,
 		func(_ context.Context, _ string, cfg spanner.ClientConfig, _ ...option.ClientOption) (*spanner.Client, error) {
 			gotConfig = cfg
 			return &spanner.Client{}, nil
@@ -408,6 +414,7 @@ func TestNewSessionWithFactoriesDoesNotAppendInsecureForEmbeddedOptions(t *testi
 	session, err := newSessionWithFactories(
 		context.Background(),
 		sysVars,
+		sysVars.Connection,
 		func(_ context.Context, _ string, _ spanner.ClientConfig, opts ...option.ClientOption) (*spanner.Client, error) {
 			gotOpts = append([]option.ClientOption(nil), opts...)
 			return &spanner.Client{}, nil
@@ -426,5 +433,252 @@ func TestNewSessionWithFactoriesDoesNotAppendInsecureForEmbeddedOptions(t *testi
 	}
 	if len(gotOpts) != len(sysVars.Config.EmbeddedClientOptions)+len(defaultClientOpts) {
 		t.Fatalf("len(opts) = %d, want %d", len(gotOpts), len(sysVars.Config.EmbeddedClientOptions)+len(defaultClientOpts))
+	}
+}
+
+func TestSessionConstructionIdentityIndependentOfLiveConnection(t *testing.T) {
+	t.Parallel()
+
+	identityA := ConnectionVars{
+		Project:  "project-a",
+		Instance: "instance-a",
+		Database: "database-a",
+		Role:     "role-a",
+	}
+	identityB := ConnectionVars{
+		Project:  "project-b",
+		Instance: "instance-b",
+		Database: "database-b",
+		Role:     "role-b",
+	}
+	directedRead := &sppb.DirectedReadOptions{}
+	sysVars := &systemVariables{
+		Connection: identityA,
+		Query:      QueryVars{DirectedRead: directedRead},
+	}
+
+	var pathA string
+	var configA spanner.ClientConfig
+	var clientOptsA, adminOptsA []option.ClientOption
+	sessionA, err := newSessionWithFactories(
+		t.Context(),
+		sysVars,
+		sysVars.Connection,
+		func(_ context.Context, dbPath string, cfg spanner.ClientConfig, opts ...option.ClientOption) (*spanner.Client, error) {
+			pathA = dbPath
+			configA = cfg
+			clientOptsA = append([]option.ClientOption(nil), opts...)
+			return &spanner.Client{}, nil
+		},
+		func(_ context.Context, opts ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			adminOptsA = append([]option.ClientOption(nil), opts...)
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+		func(*spanner.Client) {},
+	)
+	if err != nil {
+		t.Fatalf("construct session A: %v", err)
+	}
+	if pathA != identityA.DatabasePath() {
+		t.Fatalf("client path = %q, want %q", pathA, identityA.DatabasePath())
+	}
+	if configA.DatabaseRole != identityA.Role {
+		t.Fatalf("DatabaseRole = %q, want %q", configA.DatabaseRole, identityA.Role)
+	}
+	if diff := cmp.Diff(directedRead, configA.DirectedReadOptions, protocmp.Transform()); diff != "" {
+		t.Errorf("DirectedReadOptions mismatch (-want +got):\n%s", diff)
+	}
+	if len(clientOptsA) != len(adminOptsA) {
+		t.Fatalf("client opts %d, admin opts %d", len(clientOptsA), len(adminOptsA))
+	}
+	if sessionA.DatabasePath() != identityA.DatabasePath() {
+		t.Fatalf("session A DatabasePath = %q, want %q", sessionA.DatabasePath(), identityA.DatabasePath())
+	}
+	if sessionA.InstancePath() != identityA.InstancePath() {
+		t.Fatalf("session A InstancePath = %q, want %q", sessionA.InstancePath(), identityA.InstancePath())
+	}
+	if sessionA.ProjectID() != identityA.Project {
+		t.Fatalf("session A ProjectID = %q, want %q", sessionA.ProjectID(), identityA.Project)
+	}
+
+	sysVars.Connection = identityB
+	if sysVars.DatabasePath() != identityB.DatabasePath() {
+		t.Fatalf("live DatabasePath = %q, want %q", sysVars.DatabasePath(), identityB.DatabasePath())
+	}
+	if sessionA.DatabasePath() != identityA.DatabasePath() {
+		t.Fatalf("session A DatabasePath after live mutation = %q, want %q", sessionA.DatabasePath(), identityA.DatabasePath())
+	}
+	if sessionA.InstancePath() != identityA.InstancePath() {
+		t.Fatalf("session A InstancePath after live mutation = %q, want %q", sessionA.InstancePath(), identityA.InstancePath())
+	}
+	if sessionA.clientConfig.DatabaseRole != identityA.Role {
+		t.Fatalf("session A DatabaseRole after live mutation = %q, want %q", sessionA.clientConfig.DatabaseRole, identityA.Role)
+	}
+	if sessionA.ProjectID() != identityA.Project {
+		t.Fatalf("session A ProjectID after live mutation = %q, want %q", sessionA.ProjectID(), identityA.Project)
+	}
+
+	var pathB string
+	var configB spanner.ClientConfig
+	sessionB, err := newSessionWithFactories(
+		t.Context(),
+		sysVars,
+		sysVars.Connection,
+		func(_ context.Context, dbPath string, cfg spanner.ClientConfig, _ ...option.ClientOption) (*spanner.Client, error) {
+			pathB = dbPath
+			configB = cfg
+			return &spanner.Client{}, nil
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+		func(*spanner.Client) {},
+	)
+	if err != nil {
+		t.Fatalf("construct session B: %v", err)
+	}
+	if pathB != identityB.DatabasePath() {
+		t.Fatalf("client path B = %q, want %q", pathB, identityB.DatabasePath())
+	}
+	if configB.DatabaseRole != identityB.Role {
+		t.Fatalf("session B DatabaseRole = %q, want %q", configB.DatabaseRole, identityB.Role)
+	}
+	if sessionB.DatabasePath() != identityB.DatabasePath() {
+		t.Fatalf("session B DatabasePath = %q, want %q", sessionB.DatabasePath(), identityB.DatabasePath())
+	}
+	if sessionA.DatabasePath() != identityA.DatabasePath() {
+		t.Fatalf("session A DatabasePath after constructing B = %q, want %q", sessionA.DatabasePath(), identityA.DatabasePath())
+	}
+
+	var explicitPath string
+	var explicitConfig spanner.ClientConfig
+	explicit, err := newSessionWithFactories(
+		t.Context(),
+		sysVars,
+		identityA,
+		func(_ context.Context, dbPath string, cfg spanner.ClientConfig, _ ...option.ClientOption) (*spanner.Client, error) {
+			explicitPath = dbPath
+			explicitConfig = cfg
+			return &spanner.Client{}, nil
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+		func(*spanner.Client) {},
+	)
+	if err != nil {
+		t.Fatalf("construct explicit identity A while live is B: %v", err)
+	}
+	if sysVars.DatabasePath() != identityB.DatabasePath() {
+		t.Fatalf("explicit construction mutated live DatabasePath = %q, want %q", sysVars.DatabasePath(), identityB.DatabasePath())
+	}
+	if explicitPath != identityA.DatabasePath() {
+		t.Fatalf("explicit client path = %q, want %q", explicitPath, identityA.DatabasePath())
+	}
+	if explicitConfig.DatabaseRole != identityA.Role {
+		t.Fatalf("explicit DatabaseRole = %q, want %q", explicitConfig.DatabaseRole, identityA.Role)
+	}
+	if explicit.DatabasePath() != identityA.DatabasePath() {
+		t.Fatalf("explicit session DatabasePath = %q, want %q", explicit.DatabasePath(), identityA.DatabasePath())
+	}
+}
+
+func TestAdminSessionConstructionIdentityIndependentOfLiveConnection(t *testing.T) {
+	t.Parallel()
+
+	identityA := ConnectionVars{
+		Project:  "project-a",
+		Instance: "instance-a",
+		Role:     "role-a",
+	}
+	identityB := ConnectionVars{
+		Project:  "project-b",
+		Instance: "instance-b",
+		Role:     "role-b",
+	}
+	sysVars := &systemVariables{Connection: identityA}
+
+	sessionA, err := newAdminSessionWithFactories(
+		t.Context(),
+		sysVars,
+		sysVars.Connection,
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct detached session A: %v", err)
+	}
+	if !sessionA.IsDetached() {
+		t.Fatal("session A mode: want detached")
+	}
+	if sessionA.InstancePath() != identityA.InstancePath() {
+		t.Fatalf("session A InstancePath = %q, want %q", sessionA.InstancePath(), identityA.InstancePath())
+	}
+	if sessionA.DatabasePath() != identityA.DatabasePath() {
+		t.Fatalf("session A DatabasePath = %q, want %q", sessionA.DatabasePath(), identityA.DatabasePath())
+	}
+	if sessionA.clientConfig.DatabaseRole != identityA.Role {
+		t.Fatalf("session A DatabaseRole = %q, want %q", sessionA.clientConfig.DatabaseRole, identityA.Role)
+	}
+
+	sysVars.Connection = identityB
+	if sysVars.InstancePath() != identityB.InstancePath() {
+		t.Fatalf("live InstancePath = %q, want %q", sysVars.InstancePath(), identityB.InstancePath())
+	}
+	if sessionA.InstancePath() != identityA.InstancePath() {
+		t.Fatalf("session A InstancePath after live mutation = %q, want %q", sessionA.InstancePath(), identityA.InstancePath())
+	}
+	if sessionA.clientConfig.DatabaseRole != identityA.Role {
+		t.Fatalf("session A DatabaseRole after live mutation = %q, want %q", sessionA.clientConfig.DatabaseRole, identityA.Role)
+	}
+
+	sessionB, err := newAdminSessionWithFactories(
+		t.Context(),
+		sysVars,
+		identityB,
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("construct detached session B: %v", err)
+	}
+	if !sessionB.IsDetached() {
+		t.Fatal("session B mode: want detached")
+	}
+	if sessionB.InstancePath() != identityB.InstancePath() {
+		t.Fatalf("session B InstancePath = %q, want %q", sessionB.InstancePath(), identityB.InstancePath())
+	}
+	if sessionA.InstancePath() != identityA.InstancePath() {
+		t.Fatalf("session A InstancePath after constructing B = %q, want %q", sessionA.InstancePath(), identityA.InstancePath())
+	}
+}
+
+func TestNewAdminSessionWithFactoriesClosesNothingWhenAdminCreationFails(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("admin client creation failed")
+	session, err := newAdminSessionWithFactories(
+		t.Context(),
+		&systemVariables{
+			Connection: ConnectionVars{
+				Project:  "test-project",
+				Instance: "test-instance",
+			},
+		},
+		ConnectionVars{
+			Project:  "test-project",
+			Instance: "test-instance",
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			return nil, expectedErr
+		},
+	)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("newAdminSessionWithFactories() error = %v, want %v", err, expectedErr)
+	}
+	if session != nil {
+		t.Fatalf("newAdminSessionWithFactories() session = %#v, want nil", session)
 	}
 }

--- a/internal/mycli/show_operation_test.go
+++ b/internal/mycli/show_operation_test.go
@@ -567,12 +567,14 @@ func newShowOperationTestSession(t *testing.T, server longrunningpb.OperationsSe
 	}
 	t.Cleanup(func() { _ = adminClient.Close() })
 
+	identity := ConnectionVars{
+		Project:  "test",
+		Instance: "test",
+		Database: "test",
+	}
 	return &Session{
-		adminClient: adminClient,
-		systemVariables: &systemVariables{Connection: ConnectionVars{
-			Project:  "test",
-			Instance: "test",
-			Database: "test",
-		}},
+		adminClient:     adminClient,
+		systemVariables: &systemVariables{Connection: identity},
+		connection:      identity,
 	}
 }

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -214,7 +214,7 @@ func (s *DropDatabaseStatement) isDetachedCompatible() {}
 
 func (s *DropDatabaseStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
 	if err := session.adminClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
-		Database: databasePath(session.systemVariables.Connection.Project, session.systemVariables.Connection.Instance, s.DatabaseId),
+		Database: databasePath(session.connection.Project, session.connection.Instance, s.DatabaseId),
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -26,6 +26,7 @@ func newSessionForLocalVarTest(t *testing.T) *Session {
 	session := &Session{
 		mode:            DatabaseConnected,
 		systemVariables: sysVars,
+		connection:      sysVars.Connection,
 		txn:             NewTransactionManager(nil, sysVars, spanner.ClientConfig{}),
 	}
 	sysVars.inTransaction = session.txn.InTransaction

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -84,12 +84,26 @@ type StartupConfig struct {
 
 // ConnectionVars holds the connection identity. Project and Instance are fixed
 // at startup; Database and Role are mutated in place only by USE/DETACH
-// (SessionHandler.switchSession).
+// (SessionHandler.switchSession). These live fields are the values shown by
+// the registry. Each Session stores a copy captured at construction and uses that
+// copy for client and administrative resource paths.
 type ConnectionVars struct {
 	Project  string // CLI_PROJECT
 	Instance string // CLI_INSTANCE
 	Database string // CLI_DATABASE
 	Role     string // CLI_ROLE
+}
+
+func (c ConnectionVars) ProjectPath() string {
+	return projectPath(c.Project)
+}
+
+func (c ConnectionVars) InstancePath() string {
+	return instancePath(c.Project, c.Instance)
+}
+
+func (c ConnectionVars) DatabasePath() string {
+	return databasePath(c.Project, c.Instance, c.Database)
 }
 
 // LastResult holds outputs of the most recently executed statement or
@@ -334,15 +348,15 @@ func databasePath(projectID, instanceID, databaseID string) string {
 }
 
 func (sv *systemVariables) InstancePath() string {
-	return instancePath(sv.Connection.Project, sv.Connection.Instance)
+	return sv.Connection.InstancePath()
 }
 
 func (sv *systemVariables) DatabasePath() string {
-	return databasePath(sv.Connection.Project, sv.Connection.Instance, sv.Connection.Database)
+	return sv.Connection.DatabasePath()
 }
 
 func (sv *systemVariables) ProjectPath() string {
-	return projectPath(sv.Connection.Project)
+	return sv.Connection.ProjectPath()
 }
 
 // newSystemVariablesWithDefaults creates a new systemVariables instance with default values.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Give each Session a copy of `ConnectionVars` captured at construction. Client database path, `DatabaseRole`, `Session.DatabasePath`/`InstancePath`, `DROP DATABASE`, and `ProjectID` use that copy rather than the live registry `Connection`.

Public constructors still wrap the current live `Connection` values. `createSessionWithIdentity` is the explicit-identity path for later SessionHandler adoption (#920). USE/DETACH still mutate live `Connection` first in this PR; callback binding is unchanged.

A session constructed for identity A keeps those client and administrative paths after the registry is changed to B. A separately constructed session, including an explicit-identity constructor call while the registry still shows A, uses B. Detached construction stores project/instance identity the same way. Admin-client creation failure still closes the Spanner client; admin-only construction failure still returns no session.

Validation:

- `go test -short ./internal/mycli/... -run 'Session|ClientOptions|LogLevel|TransactionTag'`
- `go test -short ./...`
- `go test -short -race ./...`
- `golangci-lint run` v2.13.2
- `make fmt-check`

Full `make check` / emulator suite was not run locally (no Docker). CI on this PR covers that gate.

Fixes #919
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b03c1f25-8392-504d-8540-f88200ddafe5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b03c1f25-8392-504d-8540-f88200ddafe5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

