### PR TITLE
Add --init-command and --init-command-add startup SQL flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,90 +136,90 @@ https://github.com/apstndb/spanner-mycli/pkgs/container/spanner-mycli
 Usage: spanner-mycli [flags]
 
 Flags:
-  -p, --project=STRING                           (required) GCP Project ID ($SPANNER_PROJECT_ID).
-  -i, --instance=STRING                          (required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)
-  -d, --database=STRING                          Cloud Spanner Database ID. Optional when --detached is used
-                                                 ($SPANNER_DATABASE_ID).
-      --detached                                 Start in detached mode, ignoring database env var/flag
-  -e, --execute=STRING                           Execute SQL statement and quit. --sql is an alias.
-  -f, --file=STRING                              Execute SQL statement from file and quit. --source is an alias.
-      --init-command=STRING                      SQL to execute after connecting, before other input. Failure aborts
-                                                 startup.
-      --init-command-add=INIT-COMMAND-ADD,...    Additional startup SQL (repeatable). Appended after --init-command.
-                                                 Failure aborts startup.
-  -t, --table                                    Display output in table format for batch mode.
-      --html                                     Display output in HTML format.
-      --xml                                      Display output in XML format.
-      --csv                                      Display output in CSV format.
-      --format=STRING                            Output format (table, tab, tsv, vertical, html, xml, csv, jsonl)
-  -v, --verbose                                  Display verbose output.
-      --credential=STRING                        Use the specific credential file
-      --prompt=PROMPT                            Set the prompt to the specified format (default: "spanner%t> ")
-      --prompt2=PROMPT2                          Set the prompt2 to the specified format (default: "%P%R> ")
-      --history=HISTORY                          Set the history file to the specified path (default:
-                                                 ~/.spanner_mycli_history)
-      --priority=STRING                          Set default request priority (HIGH|MEDIUM|LOW)
-      --role=STRING                              Use the specific database role. --database-role is an alias.
-      --endpoint=STRING                          Set the Spanner API endpoint (host:port)
-      --host=STRING                              Host on which Spanner server is located
-      --port=INT                                 Port number for Spanner connection
-      --directed-read=STRING                     Directed read option (replica_location:replica_type). The replica_type
-                                                 is optional and either READ_ONLY or READ_WRITE
-      --set=KEY=VALUE                            Set system variables e.g. --set=name1=value1 --set=name2=value2
-      --param=KEY=VALUE                          Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only)
-                                                 e.g. --param="p1='string_value'" --param=p2=FLOAT64
-      --proto-descriptor-file=STRING             Path of a file that contains a protobuf-serialized
-                                                 google.protobuf.FileDescriptorSet message.
-      --insecure                                 Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is
-                                                 an alias.
-      --embedded-emulator                        Use embedded Cloud Spanner Emulator. --project, --instance, --database,
-                                                 --endpoint, --insecure will be automatically configured.
-      --embedded-omni                            Use embedded experimental Spanner Omni. --project, --instance,
-                                                 --database, --endpoint, --insecure will be automatically configured.
-      --emulator-image=STRING                    container image for embedded runtime (--embedded-emulator or
-                                                 --embedded-omni)
-      --emulator-platform=STRING                 Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
-      --sample-database=STRING                   Initialize embedded runtime with built-in sample (e.g. fingraph,
-                                                 singers, banking) or path to a metadata file (.json, .yaml, .yml).
-                                                 Requires --embedded-emulator or --embedded-omni. Cannot be combined
-                                                 with --detached.
-      --list-samples                             List available sample databases and exit
-      --output-template=STRING                   Filepath of output template. (EXPERIMENTAL)
-      --log-level=STRING                         Set CLI log level (DEBUG, INFO, WARN, ERROR). INFO and DEBUG include
-                                                 embedded runtime container lifecycle logs. SQL SET CLI_LOG_LEVEL does
-                                                 not change those container logs.
-      --log-grpc                                 Show gRPC logs
-      --query-mode=QUERY-MODE                    Mode in which the query must be processed. Allowed values: NORMAL,
-                                                 PLAN, PROFILE, WITH_STATS, WITH_PLAN_AND_STATS.
-      --strong                                   Perform a strong query.
-      --read-timestamp=STRING                    Perform a query at the given timestamp.
-      --database-dialect=DATABASE-DIALECT        The SQL dialect of the Cloud Spanner Database. Allowed values:
-                                                 POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit
-                                                 this flag to leave it unset.
-      --impersonate-service-account=STRING       Impersonate service account email
-  -h, --help                                     Show this help message and exit.
-      --version                                  Show version string.
-      --enable-partitioned-dml                   Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
-      --timeout=STRING                           Statement timeout (e.g., '10s', '5m', '1h'). Omit for 10m on ordinary
-                                                 statements and 24h on partitioned DML.
-      --async                                    Return immediately, without waiting for the operation in progress to
-                                                 complete
-      --try-partition-query                      Test whether the query can be executed as partition query without
-                                                 execution
-      --mcp                                      Run as MCP server
-      --skip-system-command                      Do not allow system commands
-      --system-command=ON|OFF                    Enable or disable system commands (ON/OFF). Default: ON.
-      --tee=STRING                               Append a copy of output to the specified file (both screen and file)
-  -o, --output=STRING                            Redirect query/data output to file (overwrites existing file)
-      --skip-column-names                        Suppress column headers in output
-      --table-streaming="AUTO"                   Table streaming output mode: AUTO/FALSE buffer table output, TRUE
-                                                 streams table output. Non-table formats always stream.
-      --color="AUTO"                             ANSI styling in output: AUTO (styled if TTY), TRUE (always styled),
-                                                 FALSE (never styled)
-  -q, --quiet                                    Suppress result lines like 'rows in set' for clean output
-      --vertexai-project=STRING                  Gemini Enterprise project override
-      --vertexai-model=VERTEXAI-MODEL            Gemini model (default: gemini-3.7-flash)
-      --vertexai-location=VERTEXAI-LOCATION      Gemini Enterprise location (default: global)
+  -p, --project=STRING                         (required) GCP Project ID ($SPANNER_PROJECT_ID).
+  -i, --instance=STRING                        (required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)
+  -d, --database=STRING                        Cloud Spanner Database ID. Optional when --detached is used
+                                               ($SPANNER_DATABASE_ID).
+      --detached                               Start in detached mode, ignoring database env var/flag
+  -e, --execute=STRING                         Execute SQL statement and quit. --sql is an alias.
+  -f, --file=STRING                            Execute SQL statement from file and quit. --source is an alias.
+      --init-command=STRING                    SQL to execute after connecting, before other input. Failure aborts
+                                               startup.
+      --init-command-add=INIT-COMMAND-ADD      Additional startup SQL (repeatable). Appended after --init-command.
+                                               Failure aborts startup.
+  -t, --table                                  Display output in table format for batch mode.
+      --html                                   Display output in HTML format.
+      --xml                                    Display output in XML format.
+      --csv                                    Display output in CSV format.
+      --format=STRING                          Output format (table, tab, tsv, vertical, html, xml, csv, jsonl)
+  -v, --verbose                                Display verbose output.
+      --credential=STRING                      Use the specific credential file
+      --prompt=PROMPT                          Set the prompt to the specified format (default: "spanner%t> ")
+      --prompt2=PROMPT2                        Set the prompt2 to the specified format (default: "%P%R> ")
+      --history=HISTORY                        Set the history file to the specified path (default:
+                                               ~/.spanner_mycli_history)
+      --priority=STRING                        Set default request priority (HIGH|MEDIUM|LOW)
+      --role=STRING                            Use the specific database role. --database-role is an alias.
+      --endpoint=STRING                        Set the Spanner API endpoint (host:port)
+      --host=STRING                            Host on which Spanner server is located
+      --port=INT                               Port number for Spanner connection
+      --directed-read=STRING                   Directed read option (replica_location:replica_type). The replica_type is
+                                               optional and either READ_ONLY or READ_WRITE
+      --set=KEY=VALUE                          Set system variables e.g. --set=name1=value1 --set=name2=value2
+      --param=KEY=VALUE                        Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only)
+                                               e.g. --param="p1='string_value'" --param=p2=FLOAT64
+      --proto-descriptor-file=STRING           Path of a file that contains a protobuf-serialized
+                                               google.protobuf.FileDescriptorSet message.
+      --insecure                               Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an
+                                               alias.
+      --embedded-emulator                      Use embedded Cloud Spanner Emulator. --project, --instance, --database,
+                                               --endpoint, --insecure will be automatically configured.
+      --embedded-omni                          Use embedded experimental Spanner Omni. --project, --instance,
+                                               --database, --endpoint, --insecure will be automatically configured.
+      --emulator-image=STRING                  container image for embedded runtime (--embedded-emulator or
+                                               --embedded-omni)
+      --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
+      --sample-database=STRING                 Initialize embedded runtime with built-in sample (e.g. fingraph,
+                                               singers, banking) or path to a metadata file (.json, .yaml, .yml).
+                                               Requires --embedded-emulator or --embedded-omni. Cannot be combined with
+                                               --detached.
+      --list-samples                           List available sample databases and exit
+      --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
+      --log-level=STRING                       Set CLI log level (DEBUG, INFO, WARN, ERROR). INFO and DEBUG include
+                                               embedded runtime container lifecycle logs. SQL SET CLI_LOG_LEVEL does not
+                                               change those container logs.
+      --log-grpc                               Show gRPC logs
+      --query-mode=QUERY-MODE                  Mode in which the query must be processed. Allowed values: NORMAL, PLAN,
+                                               PROFILE, WITH_STATS, WITH_PLAN_AND_STATS.
+      --strong                                 Perform a strong query.
+      --read-timestamp=STRING                  Perform a query at the given timestamp.
+      --database-dialect=DATABASE-DIALECT      The SQL dialect of the Cloud Spanner Database. Allowed values:
+                                               POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this
+                                               flag to leave it unset.
+      --impersonate-service-account=STRING     Impersonate service account email
+  -h, --help                                   Show this help message and exit.
+      --version                                Show version string.
+      --enable-partitioned-dml                 Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
+      --timeout=STRING                         Statement timeout (e.g., '10s', '5m', '1h'). Omit for 10m on ordinary
+                                               statements and 24h on partitioned DML.
+      --async                                  Return immediately, without waiting for the operation in progress to
+                                               complete
+      --try-partition-query                    Test whether the query can be executed as partition query without
+                                               execution
+      --mcp                                    Run as MCP server
+      --skip-system-command                    Do not allow system commands
+      --system-command=ON|OFF                  Enable or disable system commands (ON/OFF). Default: ON.
+      --tee=STRING                             Append a copy of output to the specified file (both screen and file)
+  -o, --output=STRING                          Redirect query/data output to file (overwrites existing file)
+      --skip-column-names                      Suppress column headers in output
+      --table-streaming="AUTO"                 Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams
+                                               table output. Non-table formats always stream.
+      --color="AUTO"                           ANSI styling in output: AUTO (styled if TTY), TRUE (always styled),
+                                               FALSE (never styled)
+  -q, --quiet                                  Suppress result lines like 'rows in set' for clean output
+      --vertexai-project=STRING                Gemini Enterprise project override
+      --vertexai-model=VERTEXAI-MODEL          Gemini model (default: gemini-3.7-flash)
+      --vertexai-location=VERTEXAI-LOCATION    Gemini Enterprise location (default: global)
 ```
 <!-- readme-help end -->
 

--- a/README.md
+++ b/README.md
@@ -136,86 +136,90 @@ https://github.com/apstndb/spanner-mycli/pkgs/container/spanner-mycli
 Usage: spanner-mycli [flags]
 
 Flags:
-  -p, --project=STRING                         (required) GCP Project ID ($SPANNER_PROJECT_ID).
-  -i, --instance=STRING                        (required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)
-  -d, --database=STRING                        Cloud Spanner Database ID. Optional when --detached is used
-                                               ($SPANNER_DATABASE_ID).
-      --detached                               Start in detached mode, ignoring database env var/flag
-  -e, --execute=STRING                         Execute SQL statement and quit. --sql is an alias.
-  -f, --file=STRING                            Execute SQL statement from file and quit. --source is an alias.
-  -t, --table                                  Display output in table format for batch mode.
-      --html                                   Display output in HTML format.
-      --xml                                    Display output in XML format.
-      --csv                                    Display output in CSV format.
-      --format=STRING                          Output format (table, tab, tsv, vertical, html, xml, csv, jsonl)
-  -v, --verbose                                Display verbose output.
-      --credential=STRING                      Use the specific credential file
-      --prompt=PROMPT                          Set the prompt to the specified format (default: "spanner%t> ")
-      --prompt2=PROMPT2                        Set the prompt2 to the specified format (default: "%P%R> ")
-      --history=HISTORY                        Set the history file to the specified path (default:
-                                               ~/.spanner_mycli_history)
-      --priority=STRING                        Set default request priority (HIGH|MEDIUM|LOW)
-      --role=STRING                            Use the specific database role. --database-role is an alias.
-      --endpoint=STRING                        Set the Spanner API endpoint (host:port)
-      --host=STRING                            Host on which Spanner server is located
-      --port=INT                               Port number for Spanner connection
-      --directed-read=STRING                   Directed read option (replica_location:replica_type). The replica_type is
-                                               optional and either READ_ONLY or READ_WRITE
-      --set=KEY=VALUE                          Set system variables e.g. --set=name1=value1 --set=name2=value2
-      --param=KEY=VALUE                        Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only)
-                                               e.g. --param="p1='string_value'" --param=p2=FLOAT64
-      --proto-descriptor-file=STRING           Path of a file that contains a protobuf-serialized
-                                               google.protobuf.FileDescriptorSet message.
-      --insecure                               Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is an
-                                               alias.
-      --embedded-emulator                      Use embedded Cloud Spanner Emulator. --project, --instance, --database,
-                                               --endpoint, --insecure will be automatically configured.
-      --embedded-omni                          Use embedded experimental Spanner Omni. --project, --instance,
-                                               --database, --endpoint, --insecure will be automatically configured.
-      --emulator-image=STRING                  container image for embedded runtime (--embedded-emulator or
-                                               --embedded-omni)
-      --emulator-platform=STRING               Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
-      --sample-database=STRING                 Initialize embedded runtime with built-in sample (e.g. fingraph,
-                                               singers, banking) or path to a metadata file (.json, .yaml, .yml).
-                                               Requires --embedded-emulator or --embedded-omni. Cannot be combined with
-                                               --detached.
-      --list-samples                           List available sample databases and exit
-      --output-template=STRING                 Filepath of output template. (EXPERIMENTAL)
-      --log-level=STRING                       Set CLI log level (DEBUG, INFO, WARN, ERROR). INFO and DEBUG include
-                                               embedded runtime container lifecycle logs. SQL SET CLI_LOG_LEVEL does not
-                                               change those container logs.
-      --log-grpc                               Show gRPC logs
-      --query-mode=QUERY-MODE                  Mode in which the query must be processed. Allowed values: NORMAL, PLAN,
-                                               PROFILE, WITH_STATS, WITH_PLAN_AND_STATS.
-      --strong                                 Perform a strong query.
-      --read-timestamp=STRING                  Perform a query at the given timestamp.
-      --database-dialect=DATABASE-DIALECT      The SQL dialect of the Cloud Spanner Database. Allowed values:
-                                               POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit this
-                                               flag to leave it unset.
-      --impersonate-service-account=STRING     Impersonate service account email
-  -h, --help                                   Show this help message and exit.
-      --version                                Show version string.
-      --enable-partitioned-dml                 Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
-      --timeout=STRING                         Statement timeout (e.g., '10s', '5m', '1h'). Omit for 10m on ordinary
-                                               statements and 24h on partitioned DML.
-      --async                                  Return immediately, without waiting for the operation in progress to
-                                               complete
-      --try-partition-query                    Test whether the query can be executed as partition query without
-                                               execution
-      --mcp                                    Run as MCP server
-      --skip-system-command                    Do not allow system commands
-      --system-command=ON|OFF                  Enable or disable system commands (ON/OFF). Default: ON.
-      --tee=STRING                             Append a copy of output to the specified file (both screen and file)
-  -o, --output=STRING                          Redirect query/data output to file (overwrites existing file)
-      --skip-column-names                      Suppress column headers in output
-      --table-streaming="AUTO"                 Table streaming output mode: AUTO/FALSE buffer table output, TRUE streams
-                                               table output. Non-table formats always stream.
-      --color="AUTO"                           ANSI styling in output: AUTO (styled if TTY), TRUE (always styled),
-                                               FALSE (never styled)
-  -q, --quiet                                  Suppress result lines like 'rows in set' for clean output
-      --vertexai-project=STRING                Gemini Enterprise project override
-      --vertexai-model=VERTEXAI-MODEL          Gemini model (default: gemini-3.7-flash)
-      --vertexai-location=VERTEXAI-LOCATION    Gemini Enterprise location (default: global)
+  -p, --project=STRING                           (required) GCP Project ID ($SPANNER_PROJECT_ID).
+  -i, --instance=STRING                          (required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)
+  -d, --database=STRING                          Cloud Spanner Database ID. Optional when --detached is used
+                                                 ($SPANNER_DATABASE_ID).
+      --detached                                 Start in detached mode, ignoring database env var/flag
+  -e, --execute=STRING                           Execute SQL statement and quit. --sql is an alias.
+  -f, --file=STRING                              Execute SQL statement from file and quit. --source is an alias.
+      --init-command=STRING                      SQL to execute after connecting, before other input. Failure aborts
+                                                 startup.
+      --init-command-add=INIT-COMMAND-ADD,...    Additional startup SQL (repeatable). Appended after --init-command.
+                                                 Failure aborts startup.
+  -t, --table                                    Display output in table format for batch mode.
+      --html                                     Display output in HTML format.
+      --xml                                      Display output in XML format.
+      --csv                                      Display output in CSV format.
+      --format=STRING                            Output format (table, tab, tsv, vertical, html, xml, csv, jsonl)
+  -v, --verbose                                  Display verbose output.
+      --credential=STRING                        Use the specific credential file
+      --prompt=PROMPT                            Set the prompt to the specified format (default: "spanner%t> ")
+      --prompt2=PROMPT2                          Set the prompt2 to the specified format (default: "%P%R> ")
+      --history=HISTORY                          Set the history file to the specified path (default:
+                                                 ~/.spanner_mycli_history)
+      --priority=STRING                          Set default request priority (HIGH|MEDIUM|LOW)
+      --role=STRING                              Use the specific database role. --database-role is an alias.
+      --endpoint=STRING                          Set the Spanner API endpoint (host:port)
+      --host=STRING                              Host on which Spanner server is located
+      --port=INT                                 Port number for Spanner connection
+      --directed-read=STRING                     Directed read option (replica_location:replica_type). The replica_type
+                                                 is optional and either READ_ONLY or READ_WRITE
+      --set=KEY=VALUE                            Set system variables e.g. --set=name1=value1 --set=name2=value2
+      --param=KEY=VALUE                          Set query parameters, it can be literal or type(EXPLAIN/DESCRIBE only)
+                                                 e.g. --param="p1='string_value'" --param=p2=FLOAT64
+      --proto-descriptor-file=STRING             Path of a file that contains a protobuf-serialized
+                                                 google.protobuf.FileDescriptorSet message.
+      --insecure                                 Skip TLS verification and permit plaintext gRPC. --skip-tls-verify is
+                                                 an alias.
+      --embedded-emulator                        Use embedded Cloud Spanner Emulator. --project, --instance, --database,
+                                                 --endpoint, --insecure will be automatically configured.
+      --embedded-omni                            Use embedded experimental Spanner Omni. --project, --instance,
+                                                 --database, --endpoint, --insecure will be automatically configured.
+      --emulator-image=STRING                    container image for embedded runtime (--embedded-emulator or
+                                                 --embedded-omni)
+      --emulator-platform=STRING                 Container platform (e.g. linux/amd64, linux/arm64) for embedded runtime
+      --sample-database=STRING                   Initialize embedded runtime with built-in sample (e.g. fingraph,
+                                                 singers, banking) or path to a metadata file (.json, .yaml, .yml).
+                                                 Requires --embedded-emulator or --embedded-omni. Cannot be combined
+                                                 with --detached.
+      --list-samples                             List available sample databases and exit
+      --output-template=STRING                   Filepath of output template. (EXPERIMENTAL)
+      --log-level=STRING                         Set CLI log level (DEBUG, INFO, WARN, ERROR). INFO and DEBUG include
+                                                 embedded runtime container lifecycle logs. SQL SET CLI_LOG_LEVEL does
+                                                 not change those container logs.
+      --log-grpc                                 Show gRPC logs
+      --query-mode=QUERY-MODE                    Mode in which the query must be processed. Allowed values: NORMAL,
+                                                 PLAN, PROFILE, WITH_STATS, WITH_PLAN_AND_STATS.
+      --strong                                   Perform a strong query.
+      --read-timestamp=STRING                    Perform a query at the given timestamp.
+      --database-dialect=DATABASE-DIALECT        The SQL dialect of the Cloud Spanner Database. Allowed values:
+                                                 POSTGRESQL, GOOGLE_STANDARD_SQL, DATABASE_DIALECT_UNSPECIFIED. Omit
+                                                 this flag to leave it unset.
+      --impersonate-service-account=STRING       Impersonate service account email
+  -h, --help                                     Show this help message and exit.
+      --version                                  Show version string.
+      --enable-partitioned-dml                   Partitioned DML as default (AUTOCOMMIT_DML_MODE=PARTITIONED_NON_ATOMIC)
+      --timeout=STRING                           Statement timeout (e.g., '10s', '5m', '1h'). Omit for 10m on ordinary
+                                                 statements and 24h on partitioned DML.
+      --async                                    Return immediately, without waiting for the operation in progress to
+                                                 complete
+      --try-partition-query                      Test whether the query can be executed as partition query without
+                                                 execution
+      --mcp                                      Run as MCP server
+      --skip-system-command                      Do not allow system commands
+      --system-command=ON|OFF                    Enable or disable system commands (ON/OFF). Default: ON.
+      --tee=STRING                               Append a copy of output to the specified file (both screen and file)
+  -o, --output=STRING                            Redirect query/data output to file (overwrites existing file)
+      --skip-column-names                        Suppress column headers in output
+      --table-streaming="AUTO"                   Table streaming output mode: AUTO/FALSE buffer table output, TRUE
+                                                 streams table output. Non-table formats always stream.
+      --color="AUTO"                             ANSI styling in output: AUTO (styled if TTY), TRUE (always styled),
+                                                 FALSE (never styled)
+  -q, --quiet                                    Suppress result lines like 'rows in set' for clean output
+      --vertexai-project=STRING                  Gemini Enterprise project override
+      --vertexai-model=VERTEXAI-MODEL            Gemini model (default: gemini-3.7-flash)
+      --vertexai-location=VERTEXAI-LOCATION      Gemini Enterprise location (default: global)
 ```
 <!-- readme-help end -->
 

--- a/internal/mycli/app.go
+++ b/internal/mycli/app.go
@@ -391,6 +391,12 @@ func run(ctx context.Context, opts *spannerOptions, features ...Feature) error {
 		return cli.RunMCP(ctx)
 	}
 
+	// Startup statements run after connect and before batch/interactive input
+	// (#353). A failure aborts with a non-zero exit, same as batch mode.
+	if err := cli.executeStartupSQL(ctx, collectStartupSQL(opts)); err != nil {
+		return err
+	}
+
 	input, interactive, err := determineInputAndMode(opts, os.Stdin)
 	if err != nil {
 		return err

--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -308,22 +308,22 @@ func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 // trailing line comment. Failures abort startup. EXIT is rejected so an init
 // script cannot close the session before the main input or interactive loop.
 func (c *Cli) executeStartupSQL(ctx context.Context, parts []string) error {
-	var stmts []Statement
+	var cmds []command
 	for _, sql := range parts {
 		parsed, err := buildCommands(sql, c.SystemVariables.Query.BuildStatementMode)
 		if err != nil {
 			c.PrintBatchError(err)
 			return NewExitCodeError(exitCodeError)
 		}
-		stmts = append(stmts, parsed...)
+		cmds = append(cmds, parsed...)
 	}
 
-	for _, stmt := range stmts {
-		if _, ok := stmt.(*ExitStatement); ok {
+	for _, cmd := range cmds {
+		if _, ok := cmd.stmt.(*ExitStatement); ok {
 			c.PrintBatchError(errors.New("EXIT is not allowed in --init-command"))
 			return NewExitCodeError(exitCodeError)
 		}
-		if _, err := c.executeStatement(ctx, stmt, false, "", c.GetWriter()); err != nil {
+		if _, err := c.executeStatement(ctx, cmd.stmt, false, "", c.GetWriter()); err != nil {
 			c.PrintBatchError(err)
 			return NewExitCodeError(exitCodeError)
 		}

--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -313,17 +313,18 @@ func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 }
 
 // executeStartupSQL runs --init-command / --init-command-add after connect.
-// Failures abort startup. EXIT is rejected so an init script cannot close the
-// session before the main input or interactive loop.
-func (c *Cli) executeStartupSQL(ctx context.Context, sql string) error {
-	if strings.TrimSpace(sql) == "" {
-		return nil
-	}
-
-	stmts, err := buildCommands(sql, c.SystemVariables.Query.BuildStatementMode)
-	if err != nil {
-		c.PrintBatchError(err)
-		return NewExitCodeError(exitCodeError)
+// Each flag value is parsed on its own so adjacent flags cannot glue across a
+// trailing line comment. Failures abort startup. EXIT is rejected so an init
+// script cannot close the session before the main input or interactive loop.
+func (c *Cli) executeStartupSQL(ctx context.Context, parts []string) error {
+	var stmts []Statement
+	for _, sql := range parts {
+		parsed, err := buildCommands(sql, c.SystemVariables.Query.BuildStatementMode)
+		if err != nil {
+			c.PrintBatchError(err)
+			return NewExitCodeError(exitCodeError)
+		}
+		stmts = append(stmts, parsed...)
 	}
 
 	for _, stmt := range stmts {

--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -312,6 +312,33 @@ func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 	return nil
 }
 
+// executeStartupSQL runs --init-command / --init-command-add after connect.
+// Failures abort startup. EXIT is rejected so an init script cannot close the
+// session before the main input or interactive loop.
+func (c *Cli) executeStartupSQL(ctx context.Context, sql string) error {
+	if strings.TrimSpace(sql) == "" {
+		return nil
+	}
+
+	stmts, err := buildCommands(sql, c.SystemVariables.Query.BuildStatementMode)
+	if err != nil {
+		c.PrintBatchError(err)
+		return NewExitCodeError(exitCodeError)
+	}
+
+	for _, stmt := range stmts {
+		if _, ok := stmt.(*ExitStatement); ok {
+			c.PrintBatchError(errors.New("EXIT is not allowed in --init-command"))
+			return NewExitCodeError(exitCodeError)
+		}
+		if _, err := c.executeStatement(ctx, stmt, false, "", c.GetWriter()); err != nil {
+			c.PrintBatchError(err)
+			return NewExitCodeError(exitCodeError)
+		}
+	}
+	return nil
+}
+
 func (c *Cli) RunBatch(ctx context.Context, input string) error {
 	stmts, err := buildCommands(input, c.SystemVariables.Query.BuildStatementMode)
 	if err != nil {

--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -308,22 +308,22 @@ func (c *Cli) executeSourceFile(ctx context.Context, filePath string) error {
 // trailing line comment. Failures abort startup. EXIT is rejected so an init
 // script cannot close the session before the main input or interactive loop.
 func (c *Cli) executeStartupSQL(ctx context.Context, parts []string) error {
-	var stmts []Statement
+	var cmds []command
 	for _, sql := range parts {
 		parsed, err := buildCommands(sql, c.SystemVariables.Query.BuildStatementMode)
 		if err != nil {
 			c.PrintBatchError(err)
 			return NewExitCodeError(exitCodeError)
 		}
-		stmts = append(stmts, parsed...)
+		cmds = append(cmds, parsed...)
 	}
 
-	for _, stmt := range stmts {
-		if _, ok := stmt.(*ExitStatement); ok {
+	for _, cmd := range cmds {
+		if _, ok := cmd.stmt.(*ExitStatement); ok {
 			c.PrintBatchError(errors.New("EXIT is not allowed in --init-command"))
 			return NewExitCodeError(exitCodeError)
 		}
-		if _, err := c.executeStatement(ctx, stmt, false, "", c.GetWriter()); err != nil {
+		if _, err := c.executeStatement(ctx, cmd.stmt, false, cmd.echoText(), c.GetWriter()); err != nil {
 			c.PrintBatchError(err)
 			return NewExitCodeError(exitCodeError)
 		}

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -1792,3 +1792,64 @@ func TestCli_PrintResult_invalidPagerCommand(t *testing.T) {
 		t.Fatalf("error = %v, want invalid pager command error", err)
 	}
 }
+
+func TestCli_executeStartupSQL(t *testing.T) {
+	t.Parallel()
+
+	newCli := func(t *testing.T) *Cli {
+		t.Helper()
+		session := newDetachedTestSession(io.Discard)
+		t.Cleanup(session.Close)
+		session.systemVariables.Query.BuildStatementMode = enums.ParseModeFallback
+		return &Cli{
+			SessionHandler:  NewSessionHandler(session),
+			SystemVariables: session.systemVariables,
+		}
+	}
+
+	t.Run("runs init-command then init-command-add", func(t *testing.T) {
+		cli := newCli(t)
+		sql := collectStartupSQL(&spannerOptions{
+			InitCommand:    "SET CLI_PROMPT = 'before'",
+			InitCommandAdd: []string{"SET CLI_PROMPT = 'after'"},
+		})
+		if err := cli.executeStartupSQL(context.Background(), sql); err != nil {
+			t.Fatalf("executeStartupSQL: %v", err)
+		}
+		if cli.SystemVariables.Display.Prompt != "after" {
+			t.Errorf("CLI_PROMPT = %q, want after", cli.SystemVariables.Display.Prompt)
+		}
+	})
+
+	t.Run("quoted semicolon stays one statement", func(t *testing.T) {
+		cli := newCli(t)
+		if err := cli.executeStartupSQL(context.Background(), "SET CLI_PROMPT = 'a;b'"); err != nil {
+			t.Fatalf("executeStartupSQL: %v", err)
+		}
+		if cli.SystemVariables.Display.Prompt != "a;b" {
+			t.Errorf("CLI_PROMPT = %q, want a;b", cli.SystemVariables.Display.Prompt)
+		}
+	})
+
+	t.Run("parse failure aborts before execution", func(t *testing.T) {
+		cli := newCli(t)
+		err := cli.executeStartupSQL(context.Background(), "SET CLI_PROMPT = 'changed';\nINVALID SYNTAX;")
+		if GetExitCode(err) != exitCodeError {
+			t.Fatalf("error = %v, want parse failure exit", err)
+		}
+		if cli.SystemVariables.Display.Prompt != defaultPrompt {
+			t.Errorf("CLI_PROMPT = %q, want unchanged default", cli.SystemVariables.Display.Prompt)
+		}
+	})
+
+	t.Run("EXIT is rejected without closing the session", func(t *testing.T) {
+		cli := newCli(t)
+		err := cli.executeStartupSQL(context.Background(), "SET CLI_PROMPT = 'before'; EXIT; SET CLI_PROMPT = 'after';")
+		if GetExitCode(err) != exitCodeError {
+			t.Fatalf("error = %v, want EXIT rejection", err)
+		}
+		if cli.SystemVariables.Display.Prompt != "before" {
+			t.Errorf("CLI_PROMPT = %q, want before (EXIT must not skip remaining after a reject)", cli.SystemVariables.Display.Prompt)
+		}
+	})
+}

--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -1809,11 +1809,11 @@ func TestCli_executeStartupSQL(t *testing.T) {
 
 	t.Run("runs init-command then init-command-add", func(t *testing.T) {
 		cli := newCli(t)
-		sql := collectStartupSQL(&spannerOptions{
+		parts := collectStartupSQL(&spannerOptions{
 			InitCommand:    "SET CLI_PROMPT = 'before'",
 			InitCommandAdd: []string{"SET CLI_PROMPT = 'after'"},
 		})
-		if err := cli.executeStartupSQL(context.Background(), sql); err != nil {
+		if err := cli.executeStartupSQL(context.Background(), parts); err != nil {
 			t.Fatalf("executeStartupSQL: %v", err)
 		}
 		if cli.SystemVariables.Display.Prompt != "after" {
@@ -1823,7 +1823,7 @@ func TestCli_executeStartupSQL(t *testing.T) {
 
 	t.Run("quoted semicolon stays one statement", func(t *testing.T) {
 		cli := newCli(t)
-		if err := cli.executeStartupSQL(context.Background(), "SET CLI_PROMPT = 'a;b'"); err != nil {
+		if err := cli.executeStartupSQL(context.Background(), []string{"SET CLI_PROMPT = 'a;b'"}); err != nil {
 			t.Fatalf("executeStartupSQL: %v", err)
 		}
 		if cli.SystemVariables.Display.Prompt != "a;b" {
@@ -1831,9 +1831,43 @@ func TestCli_executeStartupSQL(t *testing.T) {
 		}
 	})
 
+	t.Run("trailing line comment does not swallow the next flag", func(t *testing.T) {
+		cli := newCli(t)
+		parts := collectStartupSQL(&spannerOptions{
+			InitCommand:    "SET CLI_PROMPT2 = 'from-first' -- trailing comment",
+			InitCommandAdd: []string{"SET CLI_PROMPT = 'second'"},
+		})
+		if err := cli.executeStartupSQL(context.Background(), parts); err != nil {
+			t.Fatalf("executeStartupSQL: %v", err)
+		}
+		if cli.SystemVariables.Display.Prompt2 != "from-first" {
+			t.Errorf("CLI_PROMPT2 = %q, want from-first", cli.SystemVariables.Display.Prompt2)
+		}
+		if cli.SystemVariables.Display.Prompt != "second" {
+			t.Errorf("CLI_PROMPT = %q, want second", cli.SystemVariables.Display.Prompt)
+		}
+	})
+
+	t.Run("quoted comma survives the flag parser", func(t *testing.T) {
+		cli := newCli(t)
+		gopts, err := parseAndValidate(withRequiredFlags(
+			"--init-command-add", "SET CLI_PROMPT = 'a,b'",
+			"--execute", "SELECT 1",
+		))
+		if err != nil {
+			t.Fatalf("parseAndValidate: %v", err)
+		}
+		if err := cli.executeStartupSQL(context.Background(), collectStartupSQL(&gopts.Spanner)); err != nil {
+			t.Fatalf("executeStartupSQL: %v", err)
+		}
+		if cli.SystemVariables.Display.Prompt != "a,b" {
+			t.Errorf("CLI_PROMPT = %q, want a,b", cli.SystemVariables.Display.Prompt)
+		}
+	})
+
 	t.Run("parse failure aborts before execution", func(t *testing.T) {
 		cli := newCli(t)
-		err := cli.executeStartupSQL(context.Background(), "SET CLI_PROMPT = 'changed';\nINVALID SYNTAX;")
+		err := cli.executeStartupSQL(context.Background(), []string{"SET CLI_PROMPT = 'changed';\nINVALID SYNTAX;"})
 		if GetExitCode(err) != exitCodeError {
 			t.Fatalf("error = %v, want parse failure exit", err)
 		}
@@ -1844,7 +1878,7 @@ func TestCli_executeStartupSQL(t *testing.T) {
 
 	t.Run("EXIT is rejected without closing the session", func(t *testing.T) {
 		cli := newCli(t)
-		err := cli.executeStartupSQL(context.Background(), "SET CLI_PROMPT = 'before'; EXIT; SET CLI_PROMPT = 'after';")
+		err := cli.executeStartupSQL(context.Background(), []string{"SET CLI_PROMPT = 'before'; EXIT; SET CLI_PROMPT = 'after';"})
 		if GetExitCode(err) != exitCodeError {
 			t.Fatalf("error = %v, want EXIT rejection", err)
 		}

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -105,13 +105,18 @@ func (v *caseInsensitiveEnumValue) UnmarshalText(text []byte) error {
 }
 
 type spannerOptions struct {
-	ProjectId           string            `name:"project" short:"p" help:"(required) GCP Project ID ($SPANNER_PROJECT_ID)."`
-	InstanceId          string            `name:"instance" short:"i" help:"(required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)"`
-	DatabaseId          string            `name:"database" short:"d" help:"Cloud Spanner Database ID. Optional when --detached is used ($SPANNER_DATABASE_ID)."`
-	Detached            bool              `name:"detached" help:"Start in detached mode, ignoring database env var/flag"`
-	Execute             string            `name:"execute" short:"e" help:"Execute SQL statement and quit. --sql is an alias."`
-	File                string            `name:"file" short:"f" help:"Execute SQL statement from file and quit. --source is an alias."`
-	Source              string            `name:"source" hidden:"" help:"Hidden alias of --file for Google Cloud Spanner CLI compatibility"`
+	ProjectId  string `name:"project" short:"p" help:"(required) GCP Project ID ($SPANNER_PROJECT_ID)."`
+	InstanceId string `name:"instance" short:"i" help:"(required) Cloud Spanner Instance ID ($SPANNER_INSTANCE_ID)"`
+	DatabaseId string `name:"database" short:"d" help:"Cloud Spanner Database ID. Optional when --detached is used ($SPANNER_DATABASE_ID)."`
+	Detached   bool   `name:"detached" help:"Start in detached mode, ignoring database env var/flag"`
+	Execute    string `name:"execute" short:"e" help:"Execute SQL statement and quit. --sql is an alias."`
+	File       string `name:"file" short:"f" help:"Execute SQL statement from file and quit. --source is an alias."`
+	Source     string `name:"source" hidden:"" help:"Hidden alias of --file for Google Cloud Spanner CLI compatibility"`
+	// InitCommand and InitCommandAdd are startup statements (#353), executed
+	// after connect and before --file/--execute or the interactive loop.
+	// --init-command-add is repeatable and is not a teardown hook.
+	InitCommand         string            `name:"init-command" help:"SQL to execute after connecting, before other input. Failure aborts startup."`
+	InitCommandAdd      []string          `name:"init-command-add" help:"Additional startup SQL (repeatable). Appended after --init-command. Failure aborts startup."`
 	Table               bool              `name:"table" short:"t" help:"Display output in table format for batch mode."`
 	HTML                bool              `name:"html" help:"Display output in HTML format."`
 	XML                 bool              `name:"xml" help:"Display output in XML format."`
@@ -782,8 +787,34 @@ func readStdinCapped(stdin io.Reader, maxSize int64) (string, error) {
 	return string(data), nil
 }
 
+// collectStartupSQL concatenates --init-command then each --init-command-add
+// in flag order. Each flag value is one SQL argument: a terminator is added
+// between values so adjacent flags do not glue together. Splitting inside a
+// value is left to separateInput/buildCommands, including quoted semicolons.
+func collectStartupSQL(opts *spannerOptions) string {
+	var b strings.Builder
+	appendStartupPart := func(part string) {
+		s := strings.TrimRight(part, " \t\r\n")
+		if strings.TrimSpace(s) == "" {
+			return
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(s)
+		if !strings.HasSuffix(s, ";") {
+			b.WriteByte(';')
+		}
+	}
+	appendStartupPart(opts.InitCommand)
+	for _, s := range opts.InitCommandAdd {
+		appendStartupPart(s)
+	}
+	return b.String()
+}
+
 // determineInputAndMode decides whether to run in interactive or batch mode
-// and returns the input string, interactive flag, and any error
+// and returns the input string, interactive flag, and any error.
 func determineInputAndMode(opts *spannerOptions, stdin io.Reader) (input string, interactive bool, err error) {
 	// Handle alias flags - aliases have lower precedence
 	// Note: This precedence may override normal flag/env/TOML precedence

--- a/internal/mycli/config.go
+++ b/internal/mycli/config.go
@@ -116,7 +116,7 @@ type spannerOptions struct {
 	// after connect and before --file/--execute or the interactive loop.
 	// --init-command-add is repeatable and is not a teardown hook.
 	InitCommand         string            `name:"init-command" help:"SQL to execute after connecting, before other input. Failure aborts startup."`
-	InitCommandAdd      []string          `name:"init-command-add" help:"Additional startup SQL (repeatable). Appended after --init-command. Failure aborts startup."`
+	InitCommandAdd      []string          `name:"init-command-add" sep:"none" help:"Additional startup SQL (repeatable). Appended after --init-command. Failure aborts startup."`
 	Table               bool              `name:"table" short:"t" help:"Display output in table format for batch mode."`
 	HTML                bool              `name:"html" help:"Display output in HTML format."`
 	XML                 bool              `name:"xml" help:"Display output in XML format."`
@@ -787,30 +787,24 @@ func readStdinCapped(stdin io.Reader, maxSize int64) (string, error) {
 	return string(data), nil
 }
 
-// collectStartupSQL concatenates --init-command then each --init-command-add
-// in flag order. Each flag value is one SQL argument: a terminator is added
-// between values so adjacent flags do not glue together. Splitting inside a
-// value is left to separateInput/buildCommands, including quoted semicolons.
-func collectStartupSQL(opts *spannerOptions) string {
-	var b strings.Builder
+// collectStartupSQL returns --init-command then each --init-command-add in
+// flag order. Each value is parsed independently later; they are not
+// concatenated, so a trailing line comment cannot swallow the next flag and
+// a semicolon inside a comment is not treated as a terminator.
+func collectStartupSQL(opts *spannerOptions) []string {
+	var parts []string
 	appendStartupPart := func(part string) {
-		s := strings.TrimRight(part, " \t\r\n")
-		if strings.TrimSpace(s) == "" {
+		s := strings.TrimSpace(part)
+		if s == "" {
 			return
 		}
-		if b.Len() > 0 {
-			b.WriteByte('\n')
-		}
-		b.WriteString(s)
-		if !strings.HasSuffix(s, ";") {
-			b.WriteByte(';')
-		}
+		parts = append(parts, s)
 	}
 	appendStartupPart(opts.InitCommand)
 	for _, s := range opts.InitCommandAdd {
 		appendStartupPart(s)
 	}
-	return b.String()
+	return parts
 }
 
 // determineInputAndMode decides whether to run in interactive or batch mode

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -2684,3 +2684,54 @@ func TestEmbeddedOmniFlag(t *testing.T) {
 		t.Fatal("EmbeddedEmulator unexpectedly set")
 	}
 }
+
+func TestInitCommandFlags(t *testing.T) {
+	t.Parallel()
+
+	gopts, err := parseAndValidate(withRequiredFlags(
+		"--init-command", "SET CLI_PROMPT = 'one'",
+		"--init-command-add", "SET CLI_PROMPT2 = 'two'",
+		"--init-command-add", "SET CLI_VERBOSE = TRUE",
+		"--execute", "SELECT 1",
+	))
+	if err != nil {
+		t.Fatalf("parseAndValidate: %v", err)
+	}
+	if gopts.Spanner.InitCommand != "SET CLI_PROMPT = 'one'" {
+		t.Errorf("InitCommand = %q", gopts.Spanner.InitCommand)
+	}
+	wantAdd := []string{"SET CLI_PROMPT2 = 'two'", "SET CLI_VERBOSE = TRUE"}
+	if diff := cmp.Diff(wantAdd, gopts.Spanner.InitCommandAdd); diff != "" {
+		t.Errorf("InitCommandAdd mismatch (-want +got):\n%s", diff)
+	}
+
+	got := collectStartupSQL(&gopts.Spanner)
+	want := "SET CLI_PROMPT = 'one';\nSET CLI_PROMPT2 = 'two';\nSET CLI_VERBOSE = TRUE;"
+	if got != want {
+		t.Errorf("collectStartupSQL() = %q, want %q", got, want)
+	}
+}
+
+func TestCollectStartupSQL_skipsEmpty(t *testing.T) {
+	t.Parallel()
+	got := collectStartupSQL(&spannerOptions{
+		InitCommand:    "   ",
+		InitCommandAdd: []string{"", "SET CLI_PROMPT = 'x'", " \t "},
+	})
+	if got != "SET CLI_PROMPT = 'x';" {
+		t.Errorf("collectStartupSQL() = %q", got)
+	}
+
+	quoted := collectStartupSQL(&spannerOptions{InitCommand: "SET CLI_PROMPT = 'a;b'"})
+	if quoted != "SET CLI_PROMPT = 'a;b';" {
+		t.Errorf("quoted semicolon collectStartupSQL() = %q", quoted)
+	}
+
+	alreadyTerminated := collectStartupSQL(&spannerOptions{
+		InitCommand:    "SET CLI_PROMPT = 'one';",
+		InitCommandAdd: []string{"SET CLI_PROMPT2 = 'two';"},
+	})
+	if alreadyTerminated != "SET CLI_PROMPT = 'one';\nSET CLI_PROMPT2 = 'two';" {
+		t.Errorf("already-terminated collectStartupSQL() = %q", alreadyTerminated)
+	}
+}

--- a/internal/mycli/main_flags_test.go
+++ b/internal/mycli/main_flags_test.go
@@ -2706,9 +2706,9 @@ func TestInitCommandFlags(t *testing.T) {
 	}
 
 	got := collectStartupSQL(&gopts.Spanner)
-	want := "SET CLI_PROMPT = 'one';\nSET CLI_PROMPT2 = 'two';\nSET CLI_VERBOSE = TRUE;"
-	if got != want {
-		t.Errorf("collectStartupSQL() = %q, want %q", got, want)
+	want := []string{"SET CLI_PROMPT = 'one'", "SET CLI_PROMPT2 = 'two'", "SET CLI_VERBOSE = TRUE"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("collectStartupSQL() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -2718,20 +2718,34 @@ func TestCollectStartupSQL_skipsEmpty(t *testing.T) {
 		InitCommand:    "   ",
 		InitCommandAdd: []string{"", "SET CLI_PROMPT = 'x'", " \t "},
 	})
-	if got != "SET CLI_PROMPT = 'x';" {
-		t.Errorf("collectStartupSQL() = %q", got)
+	if diff := cmp.Diff([]string{"SET CLI_PROMPT = 'x'"}, got); diff != "" {
+		t.Errorf("collectStartupSQL() mismatch (-want +got):\n%s", diff)
 	}
 
 	quoted := collectStartupSQL(&spannerOptions{InitCommand: "SET CLI_PROMPT = 'a;b'"})
-	if quoted != "SET CLI_PROMPT = 'a;b';" {
-		t.Errorf("quoted semicolon collectStartupSQL() = %q", quoted)
+	if diff := cmp.Diff([]string{"SET CLI_PROMPT = 'a;b'"}, quoted); diff != "" {
+		t.Errorf("quoted semicolon collectStartupSQL() mismatch (-want +got):\n%s", diff)
 	}
+}
 
-	alreadyTerminated := collectStartupSQL(&spannerOptions{
-		InitCommand:    "SET CLI_PROMPT = 'one';",
-		InitCommandAdd: []string{"SET CLI_PROMPT2 = 'two';"},
-	})
-	if alreadyTerminated != "SET CLI_PROMPT = 'one';\nSET CLI_PROMPT2 = 'two';" {
-		t.Errorf("already-terminated collectStartupSQL() = %q", alreadyTerminated)
+func TestInitCommandAdd_preservesCommas(t *testing.T) {
+	t.Parallel()
+
+	gopts, err := parseAndValidate(withRequiredFlags(
+		"--init-command-add", "SET CLI_PROMPT = 'a,b'",
+		"--init-command-add", "SELECT a, b FROM t",
+		"--init-command-add", "CREATE TABLE t (id INT64, name STRING(MAX))",
+		"--execute", "SELECT 1",
+	))
+	if err != nil {
+		t.Fatalf("parseAndValidate: %v", err)
+	}
+	wantAdd := []string{
+		"SET CLI_PROMPT = 'a,b'",
+		"SELECT a, b FROM t",
+		"CREATE TABLE t (id INT64, name STRING(MAX))",
+	}
+	if diff := cmp.Diff(wantAdd, gopts.Spanner.InitCommandAdd); diff != "" {
+		t.Errorf("InitCommandAdd mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #353. Parent: #342.

`--init-command` and `--init-command-add` run once after connect and before `--file`/`--execute` or the interactive loop. `--init-command-add` is repeatable and is not a teardown hook.

## Behavior

- Order: `--init-command`, then each `--init-command-add` in CLI order, then the main input.
- Applies in batch and interactive modes. `--mcp` skips these flags.
- A failing startup statement aborts with a non-zero exit, same as batch mode.
- Each flag value is parsed independently with `separateInput`/`buildCommands`, so quoted semicolons stay inside one statement and a trailing line comment cannot swallow the next flag.
- `--init-command-add` uses `sep:"none"`; only repeated flags add elements, so commas inside SQL stay intact.
- `EXIT` in init SQL is rejected without closing the session, so an init script cannot skip the main input.

## Validation

```sh
go test -short ./internal/mycli/ -run 'TestInitCommandFlags|TestCollectStartupSQL|TestInitCommandAdd_preservesCommas|TestCli_executeStartupSQL'
go test -short ./...
golangci-lint run ./...
make fmt-check
```

Full `make check` needs the emulator and is left to CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a472e6b-50a9-530e-b001-f2f59ec20d5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a472e6b-50a9-530e-b001-f2f59ec20d5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

