### PR TITLE
Share native statement-kind mapping between parsers

### DIFF
--- a/internal/mycli/cli_test.go
+++ b/internal/mycli/cli_test.go
@@ -148,6 +148,21 @@ func TestBuildCommands(t *testing.T) {
 			Input:       `SELECT 1; \! echo test`,
 			ExpectError: true, // Meta commands not supported in batch mode
 		},
+		{
+			Desc:  "CREATE DATABASE is not grouped with following DDL",
+			Input: `CREATE DATABASE d1; CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);`,
+			Expected: []Statement{
+				&CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d1"},
+				&BulkDdlStatement{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)"}},
+			},
+		},
+		{
+			Desc:  "EXPORT DATA",
+			Input: `EXPORT DATA OPTIONS (format = 'CLOUD_SPANNER', table = 'Account') AS SELECT 1;`,
+			Expected: []Statement{
+				&ExportDataStatement{SQL: `EXPORT DATA OPTIONS (format = 'CLOUD_SPANNER', table = 'Account') AS SELECT 1`},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -424,6 +424,24 @@ func BuildStatementWithCommentsWithMode(stripped, raw string, mode enums.ParseMo
 	return parser(stripped, raw)
 }
 
+// statementFromNativeKind maps a normalized native kind to a Statement.
+// The bool means that kind was handled; it is not a parsing-policy option.
+func statementFromNativeKind(kind stmtkind.StatementKind, raw string) (Statement, bool) {
+	switch {
+	// DML is ExecuteSQL-compatible but must use DmlStatement, not SelectStatement.
+	case kind.IsDML():
+		return &DmlStatement{Dml: raw}, true
+	case kind.IsExportData():
+		return &ExportDataStatement{SQL: raw}, true
+	case kind.IsExecuteSQLCompatible():
+		return &SelectStatement{Query: raw}, true
+	case kind.IsDDL():
+		return &DdlStatement{Ddl: raw}, true
+	default:
+		return nil, false
+	}
+}
+
 func BuildNativeStatementMemefish(stripped, raw string) (Statement, error) {
 	stmt, err := memefish.ParseStatement("", raw)
 	if err != nil {
@@ -431,25 +449,15 @@ func BuildNativeStatementMemefish(stripped, raw string) (Statement, error) {
 	}
 
 	kind := stmtkind.DetectSemantic(stmt)
-	switch {
-	// DML statements are compatible with ExecuteSQL, but they should be executed with DmlStatement, not SelectStatement.
-	case kind.IsDML():
-		return &DmlStatement{Dml: raw}, nil
-	case kind.IsExportData():
-		return &ExportDataStatement{SQL: raw}, nil
-	// All ExecuteSQL compatible statements can be executed with SelectStatement.
-	case kind.IsExecuteSQLCompatible():
-		return &SelectStatement{Query: raw}, nil
-	case kind.IsDDL():
-		// Only CREATE DATABASE needs special treatment in DDL.
+	if kind.IsDDL() {
 		if _, ok := stmt.(*ast.CreateDatabase); ok {
 			return &CreateDatabaseStatement{CreateStatement: raw}, nil
 		}
-
-		return &DdlStatement{Ddl: raw}, nil
-	default:
-		return nil, fmt.Errorf("unknown memefish statement, stmt %T, err: %w", stmt, errStatementNotMatched)
 	}
+	if mapped, ok := statementFromNativeKind(kind, raw); ok {
+		return mapped, nil
+	}
+	return nil, fmt.Errorf("unknown memefish statement, stmt %T, err: %w", stmt, errStatementNotMatched)
 }
 
 func BuildNativeStatementLexical(stripped string, raw string) (Statement, error) {
@@ -458,25 +466,15 @@ func BuildNativeStatementLexical(stripped string, raw string) (Statement, error)
 		return nil, err
 	}
 
-	switch {
-	// DML statements are compatible with ExecuteSQL, but they should be executed with DmlStatement, not SelectStatement.
-	case kind.IsDML():
-		return &DmlStatement{Dml: raw}, nil
-	case kind.IsExportData():
-		return &ExportDataStatement{SQL: raw}, nil
-	// All ExecuteSQL compatible statements can be executed with SelectStatement.
-	case kind.IsExecuteSQLCompatible():
-		return &SelectStatement{Query: raw}, nil
-	case kind.IsDDL():
-		// Only CREATE DATABASE needs special treatment in DDL.
+	if kind.IsDDL() {
 		if createDatabaseRe.MatchString(stripped) {
 			return &CreateDatabaseStatement{CreateStatement: raw}, nil
 		}
-
-		return &DdlStatement{Ddl: raw}, nil
-	default:
-		return nil, errors.New("invalid statement")
 	}
+	if mapped, ok := statementFromNativeKind(kind, raw); ok {
+		return mapped, nil
+	}
+	return nil, errors.New("invalid statement")
 }
 
 // unquoteIdentifier strips surrounding backquotes from an argument.

--- a/internal/mycli/statement_processing_test.go
+++ b/internal/mycli/statement_processing_test.go
@@ -18,6 +18,7 @@ package mycli
 
 import (
 	_ "embed"
+	"errors"
 	"reflect"
 	"slices"
 	"strings"
@@ -149,6 +150,16 @@ func TestBuildStatement(t *testing.T) {
 			desc:  "CREATE DATABASE statement",
 			input: "CREATE DATABASE d1",
 			want:  &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d1"},
+		},
+		{
+			desc:  "CREATE DATABASE statement with extra spaces",
+			input: "CREATE  DATABASE  d1",
+			want:  &CreateDatabaseStatement{CreateStatement: "CREATE  DATABASE  d1"},
+		},
+		{
+			desc:  "CREATE DATABASE statement with leading comment",
+			input: "/* c */ CREATE DATABASE d1",
+			want:  &CreateDatabaseStatement{CreateStatement: "/* c */ CREATE DATABASE d1"},
 		},
 		{
 			desc:  "DROP DATABASE statement",
@@ -1236,6 +1247,202 @@ TABLE Singers (42)
 			input := strings.ToLower(test.input)
 			testStatementTypeOnly(t, input, test.want, test.skipParseModes)
 		})
+	}
+}
+
+func TestNativeStatementKindMapping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc  string
+		input string
+		want  Statement
+	}{
+		{
+			desc:  "SELECT query",
+			input: "SELECT * FROM t1",
+			want:  &SelectStatement{Query: "SELECT * FROM t1"},
+		},
+		{
+			desc:  "SELECT with leading comment",
+			input: "/* c */ SELECT * FROM t1",
+			want:  &SelectStatement{Query: "/* c */ SELECT * FROM t1"},
+		},
+		{
+			desc:  "SELECT with statement hint",
+			input: "@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT * FROM t1",
+			want:  &SelectStatement{Query: "@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT * FROM t1"},
+		},
+		{
+			desc:  "INSERT DML",
+			input: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')",
+			want:  &DmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},
+		},
+		{
+			desc:  "UPDATE DML",
+			input: "UPDATE t1 SET name = hello WHERE id = 1",
+			want:  &DmlStatement{Dml: "UPDATE t1 SET name = hello WHERE id = 1"},
+		},
+		{
+			desc:  "DELETE DML",
+			input: "DELETE FROM t1 WHERE id = 1",
+			want:  &DmlStatement{Dml: "DELETE FROM t1 WHERE id = 1"},
+		},
+		{
+			desc:  "ordinary DDL",
+			input: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)",
+			want:  &DdlStatement{Ddl: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)"},
+		},
+		{
+			desc:  "CREATE DATABASE",
+			input: "CREATE DATABASE d1",
+			want:  &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d1"},
+		},
+		{
+			desc:  "CREATE DATABASE extra spaces",
+			input: "CREATE  DATABASE  d1",
+			want:  &CreateDatabaseStatement{CreateStatement: "CREATE  DATABASE  d1"},
+		},
+		{
+			desc:  "CREATE DATABASE lowercase",
+			input: "create database d1",
+			want:  &CreateDatabaseStatement{CreateStatement: "create database d1"},
+		},
+		{
+			desc:  "CREATE DATABASE leading comment",
+			input: "/* c */ CREATE DATABASE d1",
+			want:  &CreateDatabaseStatement{CreateStatement: "/* c */ CREATE DATABASE d1"},
+		},
+		{
+			desc:  "CALL ExecuteSQL",
+			input: `CALL cancel_query("1234567890123456789")`,
+			want:  &SelectStatement{Query: `CALL cancel_query("1234567890123456789")`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			stripped, err := gsqlutils.StripComments("", tt.input)
+			if err != nil {
+				t.Fatalf("StripComments(%q) error: %v", tt.input, err)
+			}
+
+			sem, err := BuildNativeStatementMemefish(stripped, tt.input)
+			if err != nil {
+				t.Fatalf("BuildNativeStatementMemefish(%q) error: %v", tt.input, err)
+			}
+			lex, err := BuildNativeStatementLexical(stripped, tt.input)
+			if err != nil {
+				t.Fatalf("BuildNativeStatementLexical(%q) error: %v", tt.input, err)
+			}
+
+			if diff := cmp.Diff(tt.want, sem); diff != "" {
+				t.Errorf("semantic mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want, lex); diff != "" {
+				t.Errorf("lexical mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNativeStatementKindMapping_ExportDataLexical(t *testing.T) {
+	t.Parallel()
+	const input = `EXPORT DATA OPTIONS (format = 'CLOUD_SPANNER', table = 'Account') AS SELECT 1`
+	stripped, err := gsqlutils.StripComments("", input)
+	if err != nil {
+		t.Fatalf("StripComments(%q) error: %v", input, err)
+	}
+
+	lex, err := BuildNativeStatementLexical(stripped, input)
+	if err != nil {
+		t.Fatalf("BuildNativeStatementLexical(%q) error: %v", input, err)
+	}
+	want := &ExportDataStatement{SQL: input}
+	if diff := cmp.Diff(want, lex); diff != "" {
+		t.Errorf("lexical EXPORT DATA mismatch (-want +got):\n%s", diff)
+	}
+
+	_, err = BuildNativeStatementMemefish(stripped, input)
+	if err == nil {
+		t.Fatal("BuildNativeStatementMemefish(EXPORT DATA) expected parse error, got nil")
+	}
+	if errors.Is(err, errStatementNotMatched) {
+		t.Fatalf("BuildNativeStatementMemefish(EXPORT DATA) wrapped errStatementNotMatched: %v", err)
+	}
+}
+
+func TestNativeStatementKindMapping_UnsupportedSemantic(t *testing.T) {
+	t.Parallel()
+	const input = "GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id"
+	stripped, err := gsqlutils.StripComments("", input)
+	if err != nil {
+		t.Fatalf("StripComments(%q) error: %v", input, err)
+	}
+
+	_, err = BuildNativeStatementMemefish(stripped, input)
+	if err == nil {
+		t.Fatal("BuildNativeStatementMemefish(GRAPH) expected error, got nil")
+	}
+	if !errors.Is(err, errStatementNotMatched) {
+		t.Fatalf("BuildNativeStatementMemefish(GRAPH) error=%v, want errStatementNotMatched", err)
+	}
+	if !strings.Contains(err.Error(), "unknown memefish statement") {
+		t.Fatalf("BuildNativeStatementMemefish(GRAPH) error=%q, want unknown memefish statement", err)
+	}
+
+	lex, err := BuildNativeStatementLexical(stripped, input)
+	if err != nil {
+		t.Fatalf("BuildNativeStatementLexical(GRAPH) error: %v", err)
+	}
+	want := &SelectStatement{Query: input}
+	if diff := cmp.Diff(want, lex); diff != "" {
+		t.Errorf("lexical GRAPH mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNativeStatementKindMapping_LexicalInvalid(t *testing.T) {
+	t.Parallel()
+	const input = "FOO BAR"
+	stripped, err := gsqlutils.StripComments("", input)
+	if err != nil {
+		t.Fatalf("StripComments(%q) error: %v", input, err)
+	}
+
+	_, err = BuildNativeStatementLexical(stripped, input)
+	if err == nil {
+		t.Fatal("BuildNativeStatementLexical(FOO BAR) expected error, got nil")
+	}
+	if errors.Is(err, errStatementNotMatched) {
+		t.Fatalf("BuildNativeStatementLexical(FOO BAR) wrapped errStatementNotMatched: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unknown statement with first token") {
+		t.Fatalf("BuildNativeStatementLexical(FOO BAR) error=%q, want unknown-first-token error", err)
+	}
+}
+
+func TestNativeStatementKindMapping_CreateDatabaseHint(t *testing.T) {
+	t.Parallel()
+	const input = "@{foo=1} CREATE DATABASE d1"
+	stripped, err := gsqlutils.StripComments("", input)
+	if err != nil {
+		t.Fatalf("StripComments(%q) error: %v", input, err)
+	}
+
+	_, err = BuildNativeStatementMemefish(stripped, input)
+	if err == nil {
+		t.Fatal("BuildNativeStatementMemefish(hinted CREATE DATABASE) expected parse error, got nil")
+	}
+	if errors.Is(err, errStatementNotMatched) {
+		t.Fatalf("BuildNativeStatementMemefish(hinted CREATE DATABASE) wrapped errStatementNotMatched: %v", err)
+	}
+
+	lex, err := BuildNativeStatementLexical(stripped, input)
+	if err != nil {
+		t.Fatalf("BuildNativeStatementLexical(hinted CREATE DATABASE) error: %v", err)
+	}
+	want := &DdlStatement{Ddl: input}
+	if diff := cmp.Diff(want, lex); diff != "" {
+		t.Errorf("lexical hinted CREATE DATABASE mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #912. Tracking: #911.

The semantic and lexical native frontends duplicated the DML / EXPORT DATA / ExecuteSQL / DDL mapping. Detection and error behavior still differ on purpose; only that mapping is shared.

`statementFromNativeKind` takes a `stmtkind.StatementKind` and the original raw SQL and returns `(Statement, bool)`. The bool means the normalized kind was handled. Precedence is unchanged: DML, then EXPORT DATA, then other ExecuteSQL-compatible kinds, then ordinary DDL. Each frontend still calls `DetectSemantic` / `DetectLexical`, handles CREATE DATABASE in its own DDL branch (AST type vs `createDatabaseRe` on stripped input), and keeps its unsupported-kind errors.

## Behavior

- Both frontends produce the same concrete types and raw text for shared valid examples: DML, queries (including comments and hints), ordinary DDL, and CREATE DATABASE (including extra spaces, case, and leading comments).
- Unsupported semantic ASTs such as GRAPH still wrap `errStatementNotMatched`. Lexical invalid input still returns the DetectLexical first-token error, so fallback parsing is unchanged.
- EXPORT DATA remains lexical-only: memefish still fails to parse it, and that error is not wrapped as `errStatementNotMatched`.
- Hinted CREATE DATABASE keeps the current split: semantic parse error, lexical `DdlStatement` (the CREATE DATABASE regex is applied to stripped text that still starts with the hint).
- CREATE DATABASE is not grouped into `BulkDdlStatement` by `buildCommands`.

## Validation

```sh
go test -short ./internal/mycli/... -run 'BuildStatement|NativeStatement|BuildCommands'
go test -short ./...
go test -short -race ./...
golangci-lint run --timeout=5m
make fmt-check
```

Full `make check` (`go test ./...` plus lint/fmt) was not completed locally because this environment has no Docker/emulator. CI should run the required emulator suite.

## Changed files

- `internal/mycli/statement_processing.go` — shared `statementFromNativeKind`; CREATE DATABASE stays in each frontend
- `internal/mycli/statement_processing_test.go` — native frontend seam tests; CREATE DATABASE comment/spacing cases on `BuildStatement`
- `internal/mycli/cli_test.go` — `buildCommands` CREATE DATABASE vs DDL grouping and EXPORT DATA

Deleted: the duplicate DML / EXPORT DATA / ExecuteSQL / DDL switch arms in `BuildNativeStatementMemefish` and `BuildNativeStatementLexical`.

No parser upgrades, keyword detection changes, client-side statement table edits, dependency upgrades, or unrelated cleanup.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d60445b3-b697-598c-8e8e-340bc2d181a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d60445b3-b697-598c-8e8e-340bc2d181a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

