### PR TITLE
Validate replacement sessions before publishing live connection values

### DIFF
--- a/dev-docs/architecture-guide.md
+++ b/dev-docs/architecture-guide.md
@@ -46,8 +46,10 @@ code comments before changing anything nearby; do not re-document them here.
   decomposition, and the single-instance contract (the struct is never copied;
   the registry holds raw pointers into it).
 - **Database switching**: `SessionHandler.switchSession` in
-  `internal/mycli/session.go` - USE/DETACH mutate the single live
-  `systemVariables` in place.
+  `internal/mycli/session.go` - candidates are constructed with an explicit
+  connection identity while live registry values stay unchanged; successful
+  USE/DETACH then publishes Database/Role and TransactionManager callbacks
+  in one adoption step.
 - **Transactions and locking**: `TransactionManager` in
   `internal/mycli/transaction_manager.go` - mutex rationale, the mandatory
   closure-based access helpers, the `WithLock` / `Locked` method-suffix

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -156,6 +156,9 @@ type Session struct {
 	// safety SCC before the row-presence query. Tests only.
 	dumpCyclePreflightProbe func(id tableID, txn *spanner.ReadOnlyTransaction) error
 
+	// databaseExistsOverride replaces DatabaseExists in tests.
+	databaseExistsOverride func(context.Context) (bool, error)
+
 	// featureState is the keyed per-session store for feature state contributed
 	// through the Feature seam (issue #778). Values implementing io.Closer are
 	// closed at the end of Close in reverse creation order.
@@ -182,6 +185,11 @@ func (s *Session) IncrementSchemaGeneration() {
 // SessionHandler manages a session pointer and can handle session-changing statements
 type SessionHandler struct {
 	*Session
+
+	// constructCandidate, if set, replaces createSessionWithIdentity for
+	// USE/DETACH candidates. Tests inject it to observe live connection values
+	// and callbacks without opening real clients.
+	constructCandidate func(context.Context, ConnectionVars) (*Session, error)
 }
 
 func NewSessionHandler(session *Session) *SessionHandler {
@@ -219,15 +227,19 @@ func (h *SessionHandler) ExecuteStatement(ctx context.Context, stmt Statement) (
 	}
 }
 
-// createSessionWithOpts creates a new session using current session's client options
-func (h *SessionHandler) createSessionWithOpts(ctx context.Context, sysVars *systemVariables) (*Session, error) {
-	var opts []option.ClientOption
-	current := h.Session
-	if current != nil {
-		opts = current.clientOpts
+// createCandidateSession builds a replacement Session for identity while
+// sharing the live systemVariables. Constructor internals do not bind
+// inTransaction / TRANSACTION_TAG callbacks; adoptSession publishes them.
+func (h *SessionHandler) createCandidateSession(ctx context.Context, identity ConnectionVars) (*Session, error) {
+	if h.constructCandidate != nil {
+		return h.constructCandidate(ctx, identity)
 	}
 
-	return createSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	var opts []option.ClientOption
+	if current := h.Session; current != nil {
+		opts = current.clientOpts
+	}
+	return createSessionWithIdentity(ctx, h.systemVariables, identity, opts...)
 }
 
 // validateSessionSwitch rejects USE/DETACH while a transaction or batch is
@@ -246,51 +258,48 @@ func (h *SessionHandler) validateSessionSwitch() error {
 	return nil
 }
 
-// switchSession mutates the single live systemVariables instance in place and
-// builds a replacement session around it. The registry holds pointers into this
-// struct and other components (Cli, StreamManager consumers) hold the same
-// pointer, so copying the struct would fork the state they read (split-brain).
-// On any failure the connection fields and the inTransaction hook (which
-// newSessionWithFactories points at the new session) are restored.
+// adoptSession retires the current session and publishes candidate as the live
+// session. Live Database/Role and the three TransactionManager callbacks are
+// assigned together after the old session is closed. No validation or client
+// creation happens here. Callback presence is preserved (including DETACH):
+// init-only policy treats a non-nil inTransaction as "session initialized".
+func (h *SessionHandler) adoptSession(candidate *Session) {
+	old := h.Session
+	if old != nil {
+		old.Close()
+	}
+	sv := candidate.systemVariables
+	h.Session = candidate
+	sv.Connection.Database = candidate.connection.Database
+	sv.Connection.Role = candidate.connection.Role
+	bindTransactionManagerCallbacks(sv, candidate.txn)
+}
+
+// switchSession constructs and validates a replacement session for database/role
+// without mutating live connection values or callbacks. On failure only the
+// candidate is closed. On success adoptSession publishes the candidate.
 func (h *SessionHandler) switchSession(ctx context.Context, database, role string, validate func(*Session) error) (*Result, error) {
 	if err := h.validateSessionSwitch(); err != nil {
 		return nil, err
 	}
 
-	sysVars := h.systemVariables
-	oldDatabase, oldRole := sysVars.Connection.Database, sysVars.Connection.Role
-	oldInTransaction := sysVars.inTransaction
-	oldTagView := sysVars.transactionTagView
-	oldSetTag := sysVars.setTransactionTagSlot
-	sysVars.Connection.Database = database
-	sysVars.Connection.Role = role
+	identity := h.systemVariables.Connection
+	identity.Database = database
+	identity.Role = role
 
-	restore := func() {
-		sysVars.Connection.Database = oldDatabase
-		sysVars.Connection.Role = oldRole
-		sysVars.inTransaction = oldInTransaction
-		sysVars.transactionTagView = oldTagView
-		sysVars.setTransactionTagSlot = oldSetTag
-	}
-
-	newSession, err := h.createSessionWithOpts(ctx, sysVars)
+	candidate, err := h.createCandidateSession(ctx, identity)
 	if err != nil {
-		restore()
 		return nil, err
 	}
 
 	if validate != nil {
-		if err := validate(newSession); err != nil {
-			newSession.Close()
-			restore()
+		if err := validate(candidate); err != nil {
+			candidate.Close()
 			return nil, err
 		}
 	}
 
-	// Replace the old session with the new one
-	h.Session.Close()
-	h.Session = newSession
-
+	h.adoptSession(candidate)
 	return &Result{}, nil
 }
 
@@ -347,13 +356,20 @@ func logGrpcClientOptions() []option.ClientOption {
 }
 
 func NewSession(ctx context.Context, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
-	return newSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	session, err := newSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	if err != nil {
+		return nil, err
+	}
+	bindTransactionManagerCallbacks(sysVars, session.txn)
+	return session, nil
 }
 
 // createSessionWithIdentity constructs a Session for identity while sharing
 // sysVars for registry, query/transaction settings, runtime logging,
-// StreamManager and feature variables. Public constructors capture the live
-// Connection values instead of taking identity explicitly.
+// StreamManager and feature variables. It does not bind inTransaction,
+// transactionTagView or setTransactionTagSlot; public constructors and
+// SessionHandler.adoptSession publish those callbacks after the session is
+// fully constructed and validated.
 func createSessionWithIdentity(ctx context.Context, sysVars *systemVariables, identity ConnectionVars, opts ...option.ClientOption) (*Session, error) {
 	if identity.Database == "" {
 		return newAdminSessionWithIdentity(ctx, sysVars, identity, opts...)
@@ -390,7 +406,7 @@ func appendSessionClientOptions(sysVars *systemVariables, opts []option.ClientOp
 	return append(opts, defaultClientOpts...)
 }
 
-func bindConstructedSession(
+func newConstructedSession(
 	mode SessionMode,
 	client *spanner.Client,
 	adminClient *adminapi.DatabaseAdminClient,
@@ -399,18 +415,16 @@ func bindConstructedSession(
 	sysVars *systemVariables,
 	identity ConnectionVars,
 ) *Session {
-	session := &Session{
+	return &Session{
 		mode:            mode,
 		client:          client,
 		clientConfig:    clientConfig,
 		clientOpts:      opts,
 		adminClient:     adminClient,
-		txn:             NewTransactionManager(client, sysVars, clientConfig),
+		txn:             newTransactionManager(client, sysVars, clientConfig),
 		systemVariables: sysVars,
 		connection:      identity,
 	}
-	sysVars.inTransaction = session.txn.InTransaction
-	return session
 }
 
 func newSessionWithFactories(
@@ -435,11 +449,16 @@ func newSessionWithFactories(
 		return nil, err
 	}
 
-	return bindConstructedSession(DatabaseConnected, client, adminClient, clientConfig, opts, sysVars, identity), nil
+	return newConstructedSession(DatabaseConnected, client, adminClient, clientConfig, opts, sysVars, identity), nil
 }
 
 func NewAdminSession(ctx context.Context, sysVars *systemVariables, opts ...option.ClientOption) (*Session, error) {
-	return newAdminSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	session, err := newAdminSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	if err != nil {
+		return nil, err
+	}
+	bindTransactionManagerCallbacks(sysVars, session.txn)
+	return session, nil
 }
 
 func newAdminSessionWithIdentity(ctx context.Context, sysVars *systemVariables, identity ConnectionVars, opts ...option.ClientOption) (*Session, error) {
@@ -475,7 +494,7 @@ func newAdminSessionWithFactories(
 		return nil, err
 	}
 
-	return bindConstructedSession(Detached, nil, adminClient, clientConfig, opts, sysVars, identity), nil
+	return newConstructedSession(Detached, nil, adminClient, clientConfig, opts, sysVars, identity), nil
 }
 
 func (s *Session) Mode() SessionMode {
@@ -710,6 +729,10 @@ func (s *Session) InstanceExists(ctx context.Context) (bool, error) {
 }
 
 func (s *Session) DatabaseExists(ctx context.Context) (bool, error) {
+	if s.databaseExistsOverride != nil {
+		return s.databaseExistsOverride(ctx)
+	}
+
 	if err := s.ValidateDatabaseOperation(); err != nil {
 		return false, err
 	}
@@ -945,5 +968,10 @@ func createSession(ctx context.Context, credential []byte, sysVars *systemVariab
 	if err != nil {
 		return nil, err
 	}
-	return createSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	session, err := createSessionWithIdentity(ctx, sysVars, sysVars.Connection, opts...)
+	if err != nil {
+		return nil, err
+	}
+	bindTransactionManagerCallbacks(sysVars, session.txn)
+	return session, nil
 }

--- a/internal/mycli/session_test.go
+++ b/internal/mycli/session_test.go
@@ -500,6 +500,7 @@ func TestSessionConstructionIdentityIndependentOfLiveConnection(t *testing.T) {
 	if sessionA.ProjectID() != identityA.Project {
 		t.Fatalf("session A ProjectID = %q, want %q", sessionA.ProjectID(), identityA.Project)
 	}
+	assertCallbacksUnbound(t, sysVars)
 
 	sysVars.Connection = identityB
 	if sysVars.DatabasePath() != identityB.DatabasePath() {
@@ -621,6 +622,7 @@ func TestAdminSessionConstructionIdentityIndependentOfLiveConnection(t *testing.
 	if sessionA.clientConfig.DatabaseRole != identityA.Role {
 		t.Fatalf("session A DatabaseRole = %q, want %q", sessionA.clientConfig.DatabaseRole, identityA.Role)
 	}
+	assertCallbacksUnbound(t, sysVars)
 
 	sysVars.Connection = identityB
 	if sysVars.InstancePath() != identityB.InstancePath() {
@@ -681,4 +683,507 @@ func TestNewAdminSessionWithFactoriesClosesNothingWhenAdminCreationFails(t *test
 	if session != nil {
 		t.Fatalf("newAdminSessionWithFactories() session = %#v, want nil", session)
 	}
+}
+
+func assertCallbacksUnbound(t *testing.T, sv *systemVariables) {
+	t.Helper()
+	if sv.inTransaction != nil || sv.transactionTagView != nil || sv.setTransactionTagSlot != nil {
+		t.Fatal("constructor bound live callbacks")
+	}
+}
+
+func TestNewTransactionManagerPublishesCallbacks(t *testing.T) {
+	t.Parallel()
+
+	sv := &systemVariables{}
+	tm := NewTransactionManager(nil, sv, spanner.ClientConfig{})
+	if tm == nil {
+		t.Fatal("NewTransactionManager returned nil")
+	}
+	if sv.inTransaction == nil || sv.transactionTagView == nil || sv.setTransactionTagSlot == nil {
+		t.Fatal("NewTransactionManager did not bind callbacks")
+	}
+	if sv.inTransaction() {
+		t.Fatal("idle manager reported an active transaction")
+	}
+
+	unboundVars := &systemVariables{}
+	unbound := newTransactionManager(nil, unboundVars, spanner.ClientConfig{})
+	if unbound == nil {
+		t.Fatal("newTransactionManager returned nil")
+	}
+	assertCallbacksUnbound(t, unboundVars)
+}
+
+func TestSessionConstructionLeavesExistingCallbacksUntouched(t *testing.T) {
+	t.Parallel()
+
+	live := ConnectionVars{
+		Project:  "project-live",
+		Instance: "instance-live",
+		Database: "database-live",
+		Role:     "role-live",
+	}
+	candidate := ConnectionVars{
+		Project:  "project-live",
+		Instance: "instance-live",
+		Database: "database-candidate",
+		Role:     "role-candidate",
+	}
+	sv := &systemVariables{Connection: live}
+	sentinelErr := errors.New("live setTransactionTagSlot")
+	sv.inTransaction = func() bool { return true }
+	sv.transactionTagView = func() string { return "live-tag" }
+	sv.setTransactionTagSlot = func(string) error { return sentinelErr }
+
+	var sawLiveDuringClient, sawLiveDuringAdmin bool
+	session, err := newSessionWithFactories(
+		t.Context(),
+		sv,
+		candidate,
+		func(_ context.Context, dbPath string, cfg spanner.ClientConfig, _ ...option.ClientOption) (*spanner.Client, error) {
+			sawLiveDuringClient = sv.Connection == live && sv.inTransaction() && sv.transactionTagView() == "live-tag"
+			if dbPath != candidate.DatabasePath() {
+				t.Errorf("client path = %q, want %q", dbPath, candidate.DatabasePath())
+			}
+			if cfg.DatabaseRole != candidate.Role {
+				t.Errorf("DatabaseRole = %q, want %q", cfg.DatabaseRole, candidate.Role)
+			}
+			return &spanner.Client{}, nil
+		},
+		func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+			sawLiveDuringAdmin = sv.Connection == live && sv.inTransaction()
+			return &adminapi.DatabaseAdminClient{}, nil
+		},
+		func(*spanner.Client) {},
+	)
+	if err != nil {
+		t.Fatalf("construct candidate: %v", err)
+	}
+	if !sawLiveDuringClient || !sawLiveDuringAdmin {
+		t.Fatal("factories did not observe live connection/callbacks")
+	}
+	if sv.Connection != live {
+		t.Fatalf("live Connection = %+v, want %+v", sv.Connection, live)
+	}
+	if !sv.inTransaction() || sv.transactionTagView() != "live-tag" {
+		t.Fatal("construction rebound live callbacks")
+	}
+	if err := sv.setTransactionTagSlot("x"); !errors.Is(err, sentinelErr) {
+		t.Fatalf("setTransactionTagSlot error = %v, want %v", err, sentinelErr)
+	}
+	if session.DatabasePath() != candidate.DatabasePath() {
+		t.Fatalf("candidate DatabasePath = %q, want %q", session.DatabasePath(), candidate.DatabasePath())
+	}
+}
+
+type countingCloser struct {
+	n int
+}
+
+func (c *countingCloser) Close() error {
+	c.n++
+	return nil
+}
+
+type orderedCloser struct {
+	name string
+	seq  *[]string
+}
+
+func (c *orderedCloser) Close() error {
+	*c.seq = append(*c.seq, c.name)
+	return nil
+}
+
+func attachFeatureCloser[T interface{ Close() error }](t *testing.T, s *Session, key string, closer T) {
+	t.Helper()
+	if _, err := FeatureState(t.Context(), s, key, func(context.Context, *Session) (T, error) {
+		return closer, nil
+	}); err != nil {
+		t.Fatalf("FeatureState(%q): %v", key, err)
+	}
+}
+
+func newBoundSwitchSession(t *testing.T, identity ConnectionVars) (*systemVariables, *Session) {
+	t.Helper()
+	sv := newSystemVariablesWithDefaultsForTest()
+	sv.Connection = identity
+	sv.ensureRegistry()
+	session := &Session{
+		mode:            DatabaseConnected,
+		systemVariables: sv,
+		connection:      identity,
+		txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+	}
+	bindTransactionManagerCallbacks(sv, session.txn)
+	return sv, session
+}
+
+func TestSwitchSessionValidatesBeforePublishing(t *testing.T) {
+	t.Parallel()
+
+	live := ConnectionVars{
+		Project:  "project-live",
+		Instance: "instance-live",
+		Database: "database-live",
+		Role:     "role-live",
+	}
+
+	assertLiveUnchanged := func(t *testing.T, sv *systemVariables, session *Session, handler *SessionHandler) {
+		t.Helper()
+		if sv.Connection != live {
+			t.Fatalf("live Connection = %+v, want %+v", sv.Connection, live)
+		}
+		if handler.Session != session {
+			t.Fatal("live session pointer changed")
+		}
+		if sv.inTransaction == nil || sv.transactionTagView == nil || sv.setTransactionTagSlot == nil {
+			t.Fatal("live callbacks were cleared")
+		}
+	}
+
+	t.Run("client creation failure", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		oldCloser := &countingCloser{}
+		attachFeatureCloser(t, session, "old", oldCloser)
+		handler := NewSessionHandler(session)
+		createErr := errors.New("client creation failed")
+		var factoryObservedLive bool
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			if sv.Connection != live {
+				t.Errorf("live Connection during client failure = %+v, want %+v", sv.Connection, live)
+			}
+			if identity.Database != "database-next" || identity.Role != "role-next" {
+				t.Errorf("candidate identity = %+v", identity)
+			}
+			factoryObservedLive = sv.inTransaction != nil && !sv.inTransaction()
+			return nil, createErr
+		}
+
+		_, err := handler.ExecuteStatement(t.Context(), &UseStatement{Database: "database-next", Role: "role-next"})
+		if !errors.Is(err, createErr) {
+			t.Fatalf("error = %v, want %v", err, createErr)
+		}
+		if !factoryObservedLive {
+			t.Fatal("factory did not observe idle live callbacks")
+		}
+		assertLiveUnchanged(t, sv, session, handler)
+		if oldCloser.n != 0 {
+			t.Fatalf("old feature closer called %d times, want 0", oldCloser.n)
+		}
+	})
+
+	t.Run("admin creation failure closes only candidate client", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		oldCloser := &countingCloser{}
+		attachFeatureCloser(t, session, "old", oldCloser)
+		handler := NewSessionHandler(session)
+		adminErr := errors.New("admin client creation failed")
+		fakeClient := &spanner.Client{}
+		var closedClient *spanner.Client
+		var closeCount int
+		handler.constructCandidate = func(ctx context.Context, identity ConnectionVars) (*Session, error) {
+			if sv.Connection != live {
+				t.Errorf("live Connection during admin failure = %+v, want %+v", sv.Connection, live)
+			}
+			return newSessionWithFactories(
+				ctx,
+				sv,
+				identity,
+				func(context.Context, string, spanner.ClientConfig, ...option.ClientOption) (*spanner.Client, error) {
+					return fakeClient, nil
+				},
+				func(context.Context, ...option.ClientOption) (*adminapi.DatabaseAdminClient, error) {
+					return nil, adminErr
+				},
+				func(client *spanner.Client) {
+					closeCount++
+					closedClient = client
+				},
+			)
+		}
+
+		_, err := handler.ExecuteStatement(t.Context(), &UseStatement{Database: "database-next"})
+		if !errors.Is(err, adminErr) {
+			t.Fatalf("error = %v, want %v", err, adminErr)
+		}
+		if closedClient != fakeClient {
+			t.Fatalf("closed client = %p, want %p", closedClient, fakeClient)
+		}
+		if closeCount != 1 {
+			t.Fatalf("candidate client closed %d times, want 1", closeCount)
+		}
+		assertLiveUnchanged(t, sv, session, handler)
+		if oldCloser.n != 0 {
+			t.Fatalf("old feature closer called %d times, want 0", oldCloser.n)
+		}
+	})
+
+	t.Run("instance validation failure", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		oldCloser := &countingCloser{}
+		attachFeatureCloser(t, session, "old", oldCloser)
+		handler := NewSessionHandler(session)
+		candidateCloser := &countingCloser{}
+		instanceErr := errors.New("unknown instance")
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			if identity.Database != "" || identity.Role != "" {
+				t.Errorf("DETACH identity = %+v, want empty database/role", identity)
+			}
+			if sv.Connection != live {
+				t.Errorf("live Connection during instance failure = %+v, want %+v", sv.Connection, live)
+			}
+			candidate := &Session{
+				mode:            Detached,
+				systemVariables: sv,
+				connection:      identity,
+				txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+			}
+			attachFeatureCloser(t, candidate, "candidate", candidateCloser)
+			candidate.Close()
+			return nil, instanceErr
+		}
+
+		_, err := handler.ExecuteStatement(t.Context(), &DetachStatement{})
+		if !errors.Is(err, instanceErr) {
+			t.Fatalf("error = %v, want %v", err, instanceErr)
+		}
+		if candidateCloser.n != 1 {
+			t.Fatalf("candidate closed %d times, want 1", candidateCloser.n)
+		}
+		assertLiveUnchanged(t, sv, session, handler)
+		if oldCloser.n != 0 {
+			t.Fatalf("old feature closer called %d times, want 0", oldCloser.n)
+		}
+		if err := sv.Registry.Set("CLI_ENABLE_ADC_PLUS", "FALSE", false); err == nil {
+			t.Fatal("init-only variable became settable after failed DETACH")
+		}
+	})
+
+	t.Run("database existence error", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		oldCloser := &countingCloser{}
+		attachFeatureCloser(t, session, "old", oldCloser)
+		handler := NewSessionHandler(session)
+		existsErr := errors.New("checking database existence failed")
+		candidateCloser := &countingCloser{}
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			if sv.Connection != live {
+				t.Errorf("live Connection during existence error = %+v, want %+v", sv.Connection, live)
+			}
+			candidate := &Session{
+				mode:            DatabaseConnected,
+				systemVariables: sv,
+				connection:      identity,
+				txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+				databaseExistsOverride: func(context.Context) (bool, error) {
+					if sv.Connection != live {
+						t.Errorf("live Connection during DatabaseExists = %+v, want %+v", sv.Connection, live)
+					}
+					return false, existsErr
+				},
+			}
+			attachFeatureCloser(t, candidate, "candidate", candidateCloser)
+			return candidate, nil
+		}
+
+		_, err := handler.ExecuteStatement(t.Context(), &UseStatement{Database: "database-next"})
+		if !errors.Is(err, existsErr) {
+			t.Fatalf("error = %v, want %v", err, existsErr)
+		}
+		if candidateCloser.n != 1 {
+			t.Fatalf("candidate closed %d times, want 1", candidateCloser.n)
+		}
+		assertLiveUnchanged(t, sv, session, handler)
+		if oldCloser.n != 0 {
+			t.Fatalf("old feature closer called %d times, want 0", oldCloser.n)
+		}
+	})
+
+	t.Run("unknown database", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		oldCloser := &countingCloser{}
+		attachFeatureCloser(t, session, "old", oldCloser)
+		handler := NewSessionHandler(session)
+		candidateCloser := &countingCloser{}
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			candidate := &Session{
+				mode:            DatabaseConnected,
+				systemVariables: sv,
+				connection:      identity,
+				txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+				databaseExistsOverride: func(context.Context) (bool, error) {
+					return false, nil
+				},
+			}
+			attachFeatureCloser(t, candidate, "candidate", candidateCloser)
+			return candidate, nil
+		}
+
+		_, err := handler.ExecuteStatement(t.Context(), &UseStatement{Database: "missing-db"})
+		if err == nil || !strings.Contains(err.Error(), `unknown database "missing-db"`) {
+			t.Fatalf("error = %v, want unknown database", err)
+		}
+		if candidateCloser.n != 1 {
+			t.Fatalf("candidate closed %d times, want 1", candidateCloser.n)
+		}
+		assertLiveUnchanged(t, sv, session, handler)
+		if oldCloser.n != 0 {
+			t.Fatalf("old feature closer called %d times, want 0", oldCloser.n)
+		}
+	})
+
+	t.Run("successful USE publishes together", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		sv.Feature.EchoInput = true
+		registry := sv.Registry
+		var closeOrder []string
+		attachFeatureCloser(t, session, "first", &orderedCloser{name: "first", seq: &closeOrder})
+		attachFeatureCloser(t, session, "second", &orderedCloser{name: "second", seq: &closeOrder})
+		handler := NewSessionHandler(session)
+		oldTM := session.txn
+		var observedLiveDuringFactory bool
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			observedLiveDuringFactory = sv.Connection == live && sv.inTransaction != nil && !sv.inTransaction()
+			candidate := &Session{
+				mode:            DatabaseConnected,
+				systemVariables: sv,
+				connection:      identity,
+				txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+				databaseExistsOverride: func(context.Context) (bool, error) {
+					if sv.Connection != live {
+						t.Errorf("live Connection during DatabaseExists = %+v, want %+v", sv.Connection, live)
+					}
+					return true, nil
+				},
+			}
+			return candidate, nil
+		}
+
+		if _, err := handler.ExecuteStatement(t.Context(), &UseStatement{Database: "database-next", Role: "role-next"}); err != nil {
+			t.Fatalf("USE: %v", err)
+		}
+		if !observedLiveDuringFactory {
+			t.Fatal("factory did not observe old live connection")
+		}
+		if handler.Session == session {
+			t.Fatal("successful USE left the old session")
+		}
+		if handler.txn == oldTM {
+			t.Fatal("successful USE left the old TransactionManager")
+		}
+		want := ConnectionVars{
+			Project:  live.Project,
+			Instance: live.Instance,
+			Database: "database-next",
+			Role:     "role-next",
+		}
+		if sv.Connection != want {
+			t.Fatalf("live Connection = %+v, want %+v", sv.Connection, want)
+		}
+		if handler.connection != want {
+			t.Fatalf("adopted identity = %+v, want %+v", handler.connection, want)
+		}
+		if sv.Registry != registry {
+			t.Fatal("USE forked Registry")
+		}
+		if !sv.Feature.EchoInput {
+			t.Fatal("USE dropped feature configuration")
+		}
+		if sv.inTransaction == nil || sv.transactionTagView == nil || sv.setTransactionTagSlot == nil {
+			t.Fatal("successful USE left callbacks unbound")
+		}
+		if sv.inTransaction() {
+			t.Fatal("adopted session reported an active transaction")
+		}
+		if diff := cmp.Diff([]string{"second", "first"}, closeOrder); diff != "" {
+			t.Fatalf("old feature close order mismatch (-want +got):\n%s", diff)
+		}
+		if err := sv.Registry.Set("CLI_ENABLE_ADC_PLUS", "FALSE", false); err == nil {
+			t.Fatal("init-only variable became settable after USE")
+		}
+		if err := sv.setTransactionTagSlot("after-use"); err != nil {
+			t.Fatalf("TRANSACTION_TAG after USE: %v", err)
+		}
+		if sv.transactionTagView() != "after-use" {
+			t.Fatalf("TRANSACTION_TAG view = %q, want after-use", sv.transactionTagView())
+		}
+	})
+
+	t.Run("successful metadata USE", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		handler := NewSessionHandler(session)
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			if identity.Role != "" {
+				t.Errorf("metadata USE identity role = %q, want empty", identity.Role)
+			}
+			return &Session{
+				mode:            DatabaseConnected,
+				systemVariables: sv,
+				connection:      identity,
+				txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+				databaseExistsOverride: func(context.Context) (bool, error) {
+					return true, nil
+				},
+			}, nil
+		}
+
+		if _, err := handler.ExecuteStatement(t.Context(), &UseDatabaseMetaCommand{Database: "meta-db"}); err != nil {
+			t.Fatalf("\\u: %v", err)
+		}
+		if sv.Connection.Database != "meta-db" || sv.Connection.Role != "" {
+			t.Fatalf("live Connection after metadata USE = %+v", sv.Connection)
+		}
+	})
+
+	t.Run("successful DETACH keeps callbacks", func(t *testing.T) {
+		t.Parallel()
+		sv, session := newBoundSwitchSession(t, live)
+		registry := sv.Registry
+		handler := NewSessionHandler(session)
+		handler.constructCandidate = func(_ context.Context, identity ConnectionVars) (*Session, error) {
+			if sv.Connection != live {
+				t.Errorf("live Connection during DETACH construction = %+v, want %+v", sv.Connection, live)
+			}
+			return &Session{
+				mode:            Detached,
+				systemVariables: sv,
+				connection:      identity,
+				txn:             newTransactionManager(nil, sv, spanner.ClientConfig{}),
+			}, nil
+		}
+
+		if _, err := handler.ExecuteStatement(t.Context(), &DetachStatement{}); err != nil {
+			t.Fatalf("DETACH: %v", err)
+		}
+		if !handler.IsDetached() {
+			t.Fatal("DETACH did not adopt a detached session")
+		}
+		if sv.Connection.Database != "" || sv.Connection.Role != "" {
+			t.Fatalf("live Connection after DETACH = %+v", sv.Connection)
+		}
+		if sv.Connection.Project != live.Project || sv.Connection.Instance != live.Instance {
+			t.Fatalf("DETACH changed project/instance: %+v", sv.Connection)
+		}
+		if sv.inTransaction == nil || sv.transactionTagView == nil || sv.setTransactionTagSlot == nil {
+			t.Fatal("DETACH reset callbacks to nil")
+		}
+		if sv.Registry != registry {
+			t.Fatal("DETACH forked Registry")
+		}
+		if err := sv.Registry.Set("CLI_ENABLE_ADC_PLUS", "FALSE", false); err == nil {
+			t.Fatal("init-only variable became settable after DETACH")
+		}
+		if _, err := handler.ExecuteStatement(t.Context(), &BeginStatement{}); err == nil {
+			t.Fatal("BEGIN succeeded in detached mode")
+		}
+	})
 }

--- a/internal/mycli/system_variables.go
+++ b/internal/mycli/system_variables.go
@@ -83,8 +83,8 @@ type StartupConfig struct {
 }
 
 // ConnectionVars holds the connection identity. Project and Instance are fixed
-// at startup; Database and Role are mutated in place only by USE/DETACH
-// (SessionHandler.switchSession). These live fields are the values shown by
+// at startup; Database and Role are published on successful USE/DETACH
+// (SessionHandler.adoptSession). These live fields are the values shown by
 // the registry. Each Session stores a copy captured at construction and uses that
 // copy for client and administrative resource paths.
 type ConnectionVars struct {
@@ -225,8 +225,8 @@ type InternalVars struct {
 //     mutated through the Registry (and transaction-scoped via SET LOCAL)
 //
 // There is exactly one live instance per process: the Registry captures
-// pointers into this struct, so it must never be copied (USE/DETACH mutate it
-// in place; see SessionHandler.switchSession).
+// pointers into this struct, so it must never be copied (successful USE/DETACH
+// mutate Database/Role in place; see SessionHandler.adoptSession).
 type systemVariables struct {
 	Config      StartupConfig
 	Connection  ConnectionVars

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -158,13 +158,23 @@ type savedLocalVar struct {
 	oldValue string // display-string value before SET LOCAL, restored via Registry.Set
 }
 
-// NewTransactionManager creates a new TransactionManager.
-func NewTransactionManager(client *spanner.Client, sysVars *systemVariables, clientConfig spanner.ClientConfig) *TransactionManager {
-	tm := &TransactionManager{
+// newTransactionManager allocates a TransactionManager without publishing
+// registry callbacks. Public NewTransactionManager and SessionHandler
+// adoption bind those callbacks; USE/DETACH candidates stay unbound until
+// the live session is replaced.
+func newTransactionManager(client *spanner.Client, sysVars *systemVariables, clientConfig spanner.ClientConfig) *TransactionManager {
+	return &TransactionManager{
 		client:       client,
 		sysVars:      sysVars,
 		clientConfig: clientConfig,
 	}
+}
+
+// NewTransactionManager creates a TransactionManager and binds it as the
+// live inTransaction / TRANSACTION_TAG callbacks. SessionHandler candidate
+// construction uses newTransactionManager instead.
+func NewTransactionManager(client *spanner.Client, sysVars *systemVariables, clientConfig spanner.ClientConfig) *TransactionManager {
+	tm := newTransactionManager(client, sysVars, clientConfig)
 	bindTransactionManagerCallbacks(sysVars, tm)
 	return tm
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Construct USE/DETACH candidates with the explicit connection identity from #919/#929, then publish live Database/Role and the three TransactionManager callbacks only after the candidate is fully constructed and validated.

`switchSession` no longer mutates live connection fields or callbacks before building a replacement, and the saved-value restore closure is gone. Candidates share the existing `systemVariables`/Registry. Constructor internals allocate an unbound TransactionManager; public `NewSession` / `NewAdminSession` / `NewTransactionManager` wrappers still bind as before. `adoptSession` closes the old session, then assigns the candidate, Database/Role, and callbacks together. DETACH keeps callbacks non-nil so init-only policy still treats a session as initialized.

On client, admin, instance, or unknown-database failure only candidate resources are closed. The old session, live connection values, callbacks, and feature state stay usable.

Validation:

- `go test -short ./internal/mycli/... -run 'Session|LogLevel|TransactionTag|SetLocal|VarRegistry'`
- `go test -short ./...`
- `go test -short -race ./...` (`make check-race`)
- `golangci-lint run` v2.13.2
- `make fmt-check`

Full `make check` / emulator suite was not run locally (no Docker). CI on this PR covers that gate.

Fixes #920

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-091fbc0a-f0f1-592e-91cf-45061f72be51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-091fbc0a-f0f1-592e-91cf-45061f72be51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

