### PR TITLE
test: cover offline LLM, BigQuery, and CQL feature clients

### DIFF
--- a/internal/mycli/feature/bigquery/client_offline_test.go
+++ b/internal/mycli/feature/bigquery/client_offline_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquery
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	bq "cloud.google.com/go/bigquery"
+	"google.golang.org/api/option"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli"
+)
+
+func TestClientCacheCloseNil(t *testing.T) {
+	t.Parallel()
+
+	c := &clientCache{}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestClientCacheGetRequiresProject(t *testing.T) {
+	t.Parallel()
+
+	session := &mycli.Session{}
+	c := &clientCache{cfg: &config{}}
+	_, err := c.get(t.Context(), session)
+	if err == nil || !strings.Contains(err.Error(), "CLI_BIGQUERY_PROJECT") {
+		t.Fatalf("get() error = %v, want project configuration error", err)
+	}
+}
+
+func TestClientCacheGetReusesMatchingClient(t *testing.T) {
+	t.Parallel()
+
+	session := &mycli.Session{}
+	fake, err := bq.NewClient(t.Context(), "bq-project", option.WithoutAuthentication(), option.WithEndpoint("http://127.0.0.1:1"))
+	if err != nil {
+		t.Fatalf("bq.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = fake.Close() })
+
+	c := &clientCache{
+		cfg:    &config{Project: "bq-project", Location: "US"},
+		client: fake,
+		key:    clientKey{project: "bq-project", location: "US"},
+	}
+	got, err := c.get(t.Context(), session)
+	if err != nil {
+		t.Fatalf("get() error = %v", err)
+	}
+	if got != fake {
+		t.Fatal("get() rebuilt the client instead of returning the cached instance")
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if c.client != nil {
+		t.Fatal("Close() left a cached client")
+	}
+}
+
+func TestBigQueryExecuteRequiresProject(t *testing.T) {
+	t.Parallel()
+
+	session := &mycli.Session{}
+	stmt := newBigQueryStatement("SELECT 1", &config{})
+	_, err := stmt.Execute(t.Context(), session)
+	if err == nil || !strings.Contains(err.Error(), "CLI_BIGQUERY_PROJECT") {
+		t.Fatalf("Execute() error = %v, want project configuration error", err)
+	}
+}
+
+func TestBigQueryExecuteFakeClient(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"jobComplete": true,
+			"totalRows": "1",
+			"jobReference": {"projectId": "bq-project", "jobId": "job-1", "location": "US"},
+			"schema": {"fields": [{"name": "col", "type": "STRING", "mode": "NULLABLE"}]},
+			"rows": [{"f": [{"v": "hello"}]}]
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bq.NewClient(t.Context(), "bq-project",
+		option.WithoutAuthentication(),
+		option.WithEndpoint(server.URL),
+		option.WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("bq.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	maxBytes := int64(12345)
+	cfg := &config{Project: "bq-project", Location: "US", MaxBytesBilled: &maxBytes}
+	session := &mycli.Session{}
+	if _, err := mycli.FeatureState(t.Context(), session, clientStateKey, func(context.Context, *mycli.Session) (*clientCache, error) {
+		return &clientCache{
+			cfg:    cfg,
+			client: client,
+			key:    clientKey{project: "bq-project", location: "US"},
+		}, nil
+	}); err != nil {
+		t.Fatalf("FeatureState: %v", err)
+	}
+
+	stmt := newBigQueryStatement("SELECT col FROM t", cfg)
+	got, err := stmt.Execute(t.Context(), session)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got.AffectedRows != 1 {
+		t.Errorf("AffectedRows = %d, want 1", got.AffectedRows)
+	}
+	if got.TableHeader == nil {
+		t.Fatal("TableHeader is nil")
+	}
+	if gotNames := got.TableHeader.Render(false); len(gotNames) != 1 || gotNames[0] != "col" {
+		t.Errorf("headers = %v, want [col]", gotNames)
+	}
+	if len(got.Rows) != 1 || len(got.Rows[0]) != 1 || got.Rows[0][0].RawText() != "hello" {
+		t.Errorf("rows = %#v, want hello", got.Rows)
+	}
+	if !strings.Contains(gotPath, "/projects/bq-project/queries") {
+		t.Errorf("request path = %q, want jobs.query", gotPath)
+	}
+	if gotBody["query"] != "SELECT col FROM t" {
+		t.Errorf("query = %v, want SELECT col FROM t", gotBody["query"])
+	}
+	if gotBody["location"] != "US" {
+		t.Errorf("location = %v, want US", gotBody["location"])
+	}
+	switch billed := gotBody["maximumBytesBilled"].(type) {
+	case string:
+		if billed != "12345" {
+			t.Errorf("maximumBytesBilled = %q, want 12345", billed)
+		}
+	case float64:
+		if billed != 12345 {
+			t.Errorf("maximumBytesBilled = %v, want 12345", billed)
+		}
+	default:
+		t.Errorf("maximumBytesBilled = %#v, want 12345", gotBody["maximumBytesBilled"])
+	}
+}
+
+func TestBigQueryExecuteFakeClientReadError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"job failed"}}`, http.StatusBadRequest)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bq.NewClient(t.Context(), "bq-project",
+		option.WithoutAuthentication(),
+		option.WithEndpoint(server.URL),
+		option.WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("bq.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	cfg := &config{Project: "bq-project"}
+	session := &mycli.Session{}
+	if _, err := mycli.FeatureState(t.Context(), session, clientStateKey, func(context.Context, *mycli.Session) (*clientCache, error) {
+		return &clientCache{
+			cfg:    cfg,
+			client: client,
+			key:    clientKey{project: "bq-project"},
+		}, nil
+	}); err != nil {
+		t.Fatalf("FeatureState: %v", err)
+	}
+
+	_, err = newBigQueryStatement("SELECT 1", cfg).Execute(t.Context(), session)
+	if err == nil {
+		t.Fatal("Execute() error = nil, want query read failure")
+	}
+}

--- a/internal/mycli/feature/cql/offline_test.go
+++ b/internal/mycli/feature/cql/offline_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cql
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql"
+)
+
+func TestFormatCassandraTypeName(t *testing.T) {
+	t.Parallel()
+
+	text := gocql.NewNativeType(4, gocql.TypeText, "")
+	intType := gocql.NewNativeType(4, gocql.TypeInt, "")
+
+	tests := []struct {
+		name string
+		in   gocql.TypeInfo
+		want string
+	}{
+		{name: "native text", in: text, want: "text"},
+		{
+			name: "list",
+			in: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(4, gocql.TypeList, ""),
+				Elem:       text,
+			},
+			want: "list<text>",
+		},
+		{
+			name: "set",
+			in: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(4, gocql.TypeSet, ""),
+				Elem:       intType,
+			},
+			want: "set<int>",
+		},
+		{
+			name: "map",
+			in: gocql.CollectionType{
+				NativeType: gocql.NewNativeType(4, gocql.TypeMap, ""),
+				Key:        text,
+				Elem:       intType,
+			},
+			want: "map<text, int>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatCassandraTypeName(tt.in); got != tt.want {
+				t.Errorf("formatCassandraTypeName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCQLSessionHolderCloseNil(t *testing.T) {
+	t.Parallel()
+
+	h := &cqlSessionHolder{}
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}

--- a/internal/mycli/feature/llm/compose_offline_test.go
+++ b/internal/mycli/feature/llm/compose_offline_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	adminpb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"google.golang.org/genai"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func TestGeminiSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	fds := &descriptorpb.FileDescriptorSet{
+		File: []*descriptorpb.FileDescriptorProto{{Name: proto.String("example.proto")}},
+	}
+	got := geminiSystemPrompt(&adminpb.GetDatabaseDdlResponse{
+		Statements: []string{"CREATE TABLE T (id INT64) PRIMARY KEY (id)"},
+	}, fds)
+	for _, want := range []string{
+		"Cloud Spanner query composer",
+		"CREATE TABLE T (id INT64) PRIMARY KEY (id);",
+		"example.proto",
+		"GoogleSQL syntax is not PostgreSQL syntax",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("system prompt missing %q", want)
+		}
+	}
+}
+
+func TestBuildDocCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded docs only", func(t *testing.T) {
+		t.Parallel()
+		cache, err := buildDocCache("")
+		if err != nil {
+			t.Fatalf("buildDocCache() error = %v", err)
+		}
+		holder := &docCacheHolder{cache: cache}
+		t.Cleanup(func() {
+			if err := holder.Close(); err != nil {
+				t.Errorf("Close() error = %v", err)
+			}
+		})
+		if len(cache.Names()) == 0 {
+			t.Fatal("embedded doc cache is empty")
+		}
+		if cache.fetch != nil || cache.batchFetch != nil || cache.apiSearch != nil {
+			t.Fatal("embedded cache should not wire Developer Knowledge fetchers")
+		}
+	})
+
+	t.Run("api key wires fetchers", func(t *testing.T) {
+		t.Parallel()
+		cache, err := buildDocCache("test-api-key")
+		if err != nil {
+			t.Fatalf("buildDocCache() error = %v", err)
+		}
+		t.Cleanup(cache.Close)
+		if cache.fetch == nil || cache.batchFetch == nil || cache.apiSearch == nil {
+			t.Fatal("API key should wire fetch, batch fetch, and API search")
+		}
+	})
+}
+
+func TestGeminiComposeQueryWithToolsOffline(t *testing.T) {
+	t.Parallel()
+
+	ddl := &adminpb.GetDatabaseDdlResponse{
+		Statements: []string{"CREATE TABLE Singers (SingerId INT64) PRIMARY KEY (SingerId)"},
+	}
+
+	t.Run("missing API key", func(t *testing.T) {
+		t.Parallel()
+		_, err := geminiComposeQueryWithTools(t.Context(), ddl, &genai.ClientConfig{Backend: genai.BackendGeminiAPI}, defaultVertexAIModel, thinkingLevelUnspecified, "list singers", nil, false)
+		if err == nil || !strings.Contains(err.Error(), "api key is required") {
+			t.Fatalf("error = %v, want api key required", err)
+		}
+	})
+
+	t.Run("invalid proto descriptors", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}))
+		t.Cleanup(server.Close)
+		_, err := geminiComposeQueryWithTools(t.Context(), &adminpb.GetDatabaseDdlResponse{
+			ProtoDescriptors: []byte("not-a-protobuf"),
+		}, fakeGeminiClientConfig(server), defaultVertexAIModel, thinkingLevelUnspecified, "list singers", nil, false)
+		if err == nil {
+			t.Fatal("expected proto unmarshal error")
+		}
+	})
+
+	t.Run("tool-use HTTP error", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"error":{"message":"model unavailable"}}`, http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+		cache := newTestCache(t)
+		_, err := geminiComposeQueryWithTools(t.Context(), ddl, fakeGeminiClientConfig(server), defaultVertexAIModel, "HIGH", "list singers", cache, false)
+		if err == nil || !strings.Contains(err.Error(), "tool-use round 0") {
+			t.Fatalf("error = %v, want tool-use round 0", err)
+		}
+	})
+
+	t.Run("tool round then structured output", func(t *testing.T) {
+		t.Parallel()
+		cache := newTestCache(t)
+		docName := docPrefix + "reference/standard-sql/query-syntax"
+		cache.Put(docName, "SELECT statement reference")
+
+		composedJSON := mustComposeJSON(t, &output{
+			CandidateStatements: []*statement{{
+				Text:                "SELECT SingerId FROM Singers;",
+				FixedText:           "SELECT SingerId FROM Singers;",
+				Reason:              "matches request",
+				SyntaxDescription:   "select one column",
+				SemanticDescription: "lists singer ids",
+			}},
+			Statement: &statement{
+				Text:                "SELECT SingerId FROM Singers;",
+				FixedText:           "SELECT SingerId FROM Singers;",
+				Reason:              "matches request",
+				SyntaxDescription:   "select one column",
+				SemanticDescription: "lists singer ids",
+			},
+		})
+
+		var requests []string
+		call := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+			}
+			requests = append(requests, r.URL.Path)
+			call++
+			w.Header().Set("Content-Type", "application/json")
+			switch call {
+			case 1:
+				if !strings.Contains(r.URL.Path, ":generateContent") {
+					t.Errorf("path = %q, want generateContent", r.URL.Path)
+				}
+				if !strings.Contains(string(body), "list singers") {
+					t.Errorf("phase 1 body missing prompt: %s", body)
+				}
+				writeGenerateContentFunctionCall(t, w, "get_cached_document", map[string]any{
+					"names": []any{docName},
+				})
+			case 2:
+				if !strings.Contains(string(body), "SELECT statement reference") {
+					t.Errorf("phase 1 follow-up missing tool result: %s", body)
+				}
+				writeGenerateContentText(t, w, "ready")
+			default:
+				writeGenerateContentText(t, w, composedJSON)
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		got, err := geminiComposeQueryWithTools(t.Context(), ddl, fakeGeminiClientConfig(server), defaultVertexAIModel, "HIGH", "list singers", cache, false)
+		if err != nil {
+			t.Fatalf("geminiComposeQueryWithTools() error = %v", err)
+		}
+		if got == nil || got.Statement == nil {
+			t.Fatalf("composed = %#v", got)
+		}
+		if got.Statement.Text != "SELECT SingerId FROM Singers;" {
+			t.Errorf("statement text = %q", got.Statement.Text)
+		}
+		if got.Statement.SemanticDescription != "lists singer ids" {
+			t.Errorf("semanticDescription = %q", got.Statement.SemanticDescription)
+		}
+		if len(requests) < 2 {
+			t.Fatalf("generateContent calls = %d, want at least 2", len(requests))
+		}
+	})
+}
+
+func fakeGeminiClientConfig(server *httptest.Server) *genai.ClientConfig {
+	return &genai.ClientConfig{
+		Backend:    genai.BackendGeminiAPI,
+		APIKey:     "test-api-key",
+		HTTPClient: server.Client(),
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: server.URL,
+		},
+	}
+}
+
+func mustComposeJSON(t *testing.T, composed *output) string {
+	t.Helper()
+	b, err := json.Marshal(composed)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return string(b)
+}
+
+func writeGenerateContentText(t *testing.T, w http.ResponseWriter, text string) {
+	t.Helper()
+	writeJSON(t, w, map[string]any{
+		"candidates": []map[string]any{
+			{
+				"content": map[string]any{
+					"role":  "model",
+					"parts": []map[string]any{{"text": text}},
+				},
+			},
+		},
+	})
+}
+
+func writeGenerateContentFunctionCall(t *testing.T, w http.ResponseWriter, name string, args map[string]any) {
+	t.Helper()
+	writeJSON(t, w, map[string]any{
+		"candidates": []map[string]any{
+			{
+				"content": map[string]any{
+					"role": "model",
+					"parts": []map[string]any{
+						{
+							"functionCall": map[string]any{
+								"id":   "call-1",
+								"name": name,
+								"args": args,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/mycli/feature/llm/compose_offline_test.go
+++ b/internal/mycli/feature/llm/compose_offline_test.go
@@ -16,6 +16,7 @@ package llm
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -85,20 +86,34 @@ func TestBuildDocCache(t *testing.T) {
 	})
 }
 
+func TestGeminiComposeQueryWithToolsMissingAPIKey(t *testing.T) {
+	// Not parallel: t.Setenv cannot run under a parallel parent, and the SDK
+	// falls back to GOOGLE_API_KEY / GEMINI_API_KEY when ClientConfig.APIKey is empty.
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+
+	ddl := &adminpb.GetDatabaseDdlResponse{
+		Statements: []string{"CREATE TABLE Singers (SingerId INT64) PRIMARY KEY (SingerId)"},
+	}
+	cfg := &genai.ClientConfig{
+		Backend: genai.BackendGeminiAPI,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errOfflineHTTP
+		})},
+		HTTPOptions: genai.HTTPOptions{BaseURL: "http://127.0.0.1:1"},
+	}
+	_, err := geminiComposeQueryWithTools(t.Context(), ddl, cfg, defaultVertexAIModel, thinkingLevelUnspecified, "list singers", nil, false)
+	if err == nil || !strings.Contains(err.Error(), "api key is required") {
+		t.Fatalf("error = %v, want api key required", err)
+	}
+}
+
 func TestGeminiComposeQueryWithToolsOffline(t *testing.T) {
 	t.Parallel()
 
 	ddl := &adminpb.GetDatabaseDdlResponse{
 		Statements: []string{"CREATE TABLE Singers (SingerId INT64) PRIMARY KEY (SingerId)"},
 	}
-
-	t.Run("missing API key", func(t *testing.T) {
-		t.Parallel()
-		_, err := geminiComposeQueryWithTools(t.Context(), ddl, &genai.ClientConfig{Backend: genai.BackendGeminiAPI}, defaultVertexAIModel, thinkingLevelUnspecified, "list singers", nil, false)
-		if err == nil || !strings.Contains(err.Error(), "api key is required") {
-			t.Fatalf("error = %v, want api key required", err)
-		}
-	})
 
 	t.Run("invalid proto descriptors", func(t *testing.T) {
 		t.Parallel()
@@ -200,6 +215,12 @@ func TestGeminiComposeQueryWithToolsOffline(t *testing.T) {
 		}
 	})
 }
+
+var errOfflineHTTP = errors.New("offline test: unexpected HTTP request")
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func fakeGeminiClientConfig(server *httptest.Server) *genai.ClientConfig {
 	return &genai.ClientConfig{

--- a/internal/mycli/feature/llm/doc_cache_test.go
+++ b/internal/mycli/feature/llm/doc_cache_test.go
@@ -770,6 +770,45 @@ func TestFormatDocCatalog(t *testing.T) {
 	}
 }
 
+func TestDocEmbedBaseWithoutSlash(t *testing.T) {
+	t.Parallel()
+	if got := docEmbedBase("graph-patterns"); got != "graph-patterns" {
+		t.Errorf("docEmbedBase(no slash) = %q", got)
+	}
+}
+
+func TestDocCache_APISearch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		c := newTestCache(t, withDocAPISearcher(func(_ context.Context, query string) ([]DocSearchResult, error) {
+			if query != "gql" {
+				t.Errorf("query = %q", query)
+			}
+			return []DocSearchResult{{Name: "documents/graph", Snippet: "snippet"}}, nil
+		}))
+		got, ok := c.APISearch(t.Context(), "gql")
+		if !ok {
+			t.Fatal("APISearch() ok = false")
+		}
+		if len(got) != 1 || got[0].Name != "documents/graph" {
+			t.Errorf("results = %#v", got)
+		}
+	})
+
+	t.Run("searcher error", func(t *testing.T) {
+		t.Parallel()
+		c := newTestCache(t, withDocAPISearcher(func(context.Context, string) ([]DocSearchResult, error) {
+			return nil, fmt.Errorf("api down")
+		}))
+		got, ok := c.APISearch(t.Context(), "gql")
+		if ok || got != nil {
+			t.Fatalf("APISearch() = %#v, %v, want miss", got, ok)
+		}
+	})
+}
+
 func TestLoadEmbeddedDocs(t *testing.T) {
 	t.Parallel()
 	c := newTestCache(t)

--- a/internal/mycli/feature/llm/feature_offline_test.go
+++ b/internal/mycli/feature/llm/feature_offline_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli"
+)
+
+func TestFeatureDispatchAndEnumVars(t *testing.T) {
+	t.Parallel()
+
+	feat := Feature()
+	if feat.Name != "GEMINI" {
+		t.Fatalf("Name = %q, want GEMINI", feat.Name)
+	}
+	if feat.KongVars["defaultVertexAIModel"] != defaultVertexAIModel {
+		t.Errorf("KongVars defaultVertexAIModel = %q, want %q", feat.KongVars["defaultVertexAIModel"], defaultVertexAIModel)
+	}
+	if feat.KongVars["defaultVertexAILocation"] != defaultVertexAILocation {
+		t.Errorf("KongVars defaultVertexAILocation = %q, want %q", feat.KongVars["defaultVertexAILocation"], defaultVertexAILocation)
+	}
+
+	defs := mycli.MergedStatementDefs(feat)
+	stmt, err := mycli.BuildStatementWithDefs(defs, `GEMINI "list tables"`)
+	if err != nil {
+		t.Fatalf("BuildStatementWithDefs() error = %v", err)
+	}
+	gs, ok := stmt.(*GeminiStatement)
+	if !ok {
+		t.Fatalf("dispatch returned %T, want *GeminiStatement", stmt)
+	}
+	if gs.Text != "list tables" {
+		t.Fatalf("Text = %q, want unquoted prompt", gs.Text)
+	}
+	if gs.cfg == nil {
+		t.Fatal("statement config is nil")
+	}
+
+	vars := featureVars(t, feat)
+	backend := vars["CLI_GENAI_BACKEND"]
+	if got, err := backend.Get(); err != nil || got != genAIBackendEnterprise {
+		t.Fatalf("CLI_GENAI_BACKEND Get() = %q, %v, want %q", got, err, genAIBackendEnterprise)
+	}
+	if err := backend.Set("vertex_ai"); err != nil {
+		t.Fatalf("Set(vertex_ai) error = %v", err)
+	}
+	if got, _ := backend.Get(); got != genAIBackendEnterprise {
+		t.Errorf("CLI_GENAI_BACKEND after alias = %q, want %s", got, genAIBackendEnterprise)
+	}
+	if err := backend.Set("gemini_api"); err != nil {
+		t.Fatalf("Set(gemini_api) error = %v", err)
+	}
+	if got, _ := backend.Get(); got != genAIBackendGeminiAPI {
+		t.Errorf("CLI_GENAI_BACKEND = %q, want %s", got, genAIBackendGeminiAPI)
+	}
+	if err := backend.Set("OTHER"); err == nil {
+		t.Fatal("Set(OTHER) error = nil")
+	} else if !strings.Contains(err.Error(), "GEMINI_ENTERPRISE") {
+		t.Errorf("invalid Set error = %v, want listed values", err)
+	}
+
+	enum, ok := backend.(interface{ ValidValues() []string })
+	if !ok {
+		t.Fatal("CLI_GENAI_BACKEND does not expose ValidValues")
+	}
+	wantValues := []string{"'GEMINI_ENTERPRISE'", "'GEMINI_API'"}
+	if diff := cmp.Diff(wantValues, enum.ValidValues()); diff != "" {
+		t.Errorf("ValidValues mismatch (-want +got):\n%s", diff)
+	}
+
+	thinking := vars["CLI_GENAI_THINKING_LEVEL"]
+	if err := thinking.Set("high"); err != nil {
+		t.Fatalf("Set(high) error = %v", err)
+	}
+	if got, _ := thinking.Get(); got != "HIGH" {
+		t.Errorf("CLI_GENAI_THINKING_LEVEL = %q, want HIGH", got)
+	}
+}
+
+func TestFeatureApplyFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset pointers skip model and location", func(t *testing.T) {
+		t.Parallel()
+		feat := Feature()
+		got := map[string]string{}
+		if err := feat.ApplyFlags(func(name, value string) error {
+			got[name] = value
+			return nil
+		}); err != nil {
+			t.Fatalf("ApplyFlags() error = %v", err)
+		}
+		want := map[string]string{"CLI_VERTEXAI_PROJECT": ""}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("ApplyFlags set calls mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("explicit flags route through setter", func(t *testing.T) {
+		t.Parallel()
+		feat := Feature()
+		f := feat.Flags.(*flags)
+		model := "gemini-test"
+		location := "us-central1"
+		f.VertexAIProject = "override-proj"
+		f.VertexAIModel = &model
+		f.VertexAILocation = &location
+
+		got := map[string]string{}
+		var order []string
+		if err := feat.ApplyFlags(func(name, value string) error {
+			got[name] = value
+			order = append(order, name)
+			return nil
+		}); err != nil {
+			t.Fatalf("ApplyFlags() error = %v", err)
+		}
+		want := map[string]string{
+			"CLI_VERTEXAI_PROJECT":  "override-proj",
+			"CLI_VERTEXAI_MODEL":    "gemini-test",
+			"CLI_VERTEXAI_LOCATION": "us-central1",
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("ApplyFlags values mismatch (-want +got):\n%s", diff)
+		}
+		if !slices.Equal(order, []string{"CLI_VERTEXAI_PROJECT", "CLI_VERTEXAI_MODEL", "CLI_VERTEXAI_LOCATION"}) {
+			t.Errorf("ApplyFlags order = %v", order)
+		}
+	})
+
+	t.Run("setter error is returned", func(t *testing.T) {
+		t.Parallel()
+		feat := Feature()
+		err := feat.ApplyFlags(func(name, value string) error {
+			return errors.New("set failed")
+		})
+		if err == nil || err.Error() != "set failed" {
+			t.Fatalf("ApplyFlags() error = %v, want set failed", err)
+		}
+	})
+}
+
+func featureVars(t *testing.T, feat mycli.Feature) map[string]mycli.Variable {
+	t.Helper()
+	vars := make(map[string]mycli.Variable, len(feat.Vars))
+	for _, fv := range feat.Vars {
+		vars[fv.Name] = fv.Var
+	}
+	return vars
+}

--- a/internal/mycli/feature/llm/tooluse_test.go
+++ b/internal/mycli/feature/llm/tooluse_test.go
@@ -658,3 +658,105 @@ func prefixLabel(prefix string) string {
 	}
 	return string([]rune(prefix)[0])
 }
+
+func TestExecuteToolCall_GetDeveloperDocument(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t)
+	c.Put("documents/docs.cloud.google.com/spanner/docs/ref1", "from-api")
+
+	resp := executeToolCall(t.Context(), &genai.FunctionCall{
+		Name: "get_developer_document",
+		Args: map[string]any{"names": []any{"documents/docs.cloud.google.com/spanner/docs/ref1", "documents/missing"}},
+	}, c)
+
+	docs, ok := resp["documents"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected documents map, got %T", resp["documents"])
+	}
+	if docs["documents/docs.cloud.google.com/spanner/docs/ref1"] != "from-api" {
+		t.Errorf("fetched doc = %v", docs["documents/docs.cloud.google.com/spanner/docs/ref1"])
+	}
+	errMap, ok := docs["documents/missing"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error map for missing doc, got %T", docs["documents/missing"])
+	}
+	if errMap["error"] != "failed to fetch document" {
+		t.Errorf("missing doc error = %v", errMap["error"])
+	}
+}
+
+func TestExecuteToolCall_SearchDeveloperDocs_API(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, withDocAPISearcher(func(_ context.Context, query string) ([]DocSearchResult, error) {
+		if query != "graph patterns" {
+			t.Errorf("query = %q", query)
+		}
+		return []DocSearchResult{{Name: "documents/graph", Snippet: "GQL patterns"}}, nil
+	}))
+
+	resp := executeToolCall(t.Context(), &genai.FunctionCall{
+		Name: "search_developer_docs",
+		Args: map[string]any{"queries": []any{"graph patterns"}},
+	}, c)
+	qr, _ := resp["query_results"].(map[string]any)["graph patterns"].(map[string]any)
+	if qr == nil {
+		t.Fatalf("missing query result: %v", resp)
+	}
+	if qr["source"] == "local_cache" {
+		t.Fatal("API search should not fall back to local cache")
+	}
+	if qr["count"] != 1 {
+		t.Errorf("count = %v, want 1", qr["count"])
+	}
+}
+
+func TestDevKnowledgeDocSearcher_SearchInvalidJSON(t *testing.T) {
+	t.Parallel()
+	searcher := newTestDocSearcher(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not-json"))
+	})
+	_, err := searcher.Search(t.Context(), "query")
+	if err == nil {
+		t.Fatal("expected JSON unmarshal error")
+	}
+}
+
+func TestDevKnowledgeDocSearcher_GetDocumentInvalidJSON(t *testing.T) {
+	t.Parallel()
+	searcher := newTestDocSearcher(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not-json"))
+	})
+	_, err := searcher.GetDocument(t.Context(), "documents/docs.cloud.google.com/spanner/docs/ref")
+	if err == nil {
+		t.Fatal("expected JSON unmarshal error")
+	}
+}
+
+func TestDevKnowledgeDocSearcher_BatchGetDocuments_NonClientError(t *testing.T) {
+	t.Parallel()
+	searcher := newTestDocSearcher(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"message":"boom"}}`))
+	})
+	_, err := searcher.BatchGetDocuments(t.Context(), []string{"documents/docs.cloud.google.com/spanner/docs/ref1"})
+	if err == nil || !strings.Contains(err.Error(), "batch_get_documents failed") {
+		t.Fatalf("error = %v, want batch_get_documents failed", err)
+	}
+}
+
+func TestDevKnowledgeDocSearcher_BatchGetDocuments_FallbackAllFail(t *testing.T) {
+	t.Parallel()
+	searcher := newTestDocSearcher(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/documents:batchGet" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"invalid name"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"message":"missing"}}`))
+	})
+	_, err := searcher.BatchGetDocuments(t.Context(), []string{"documents/docs.cloud.google.com/spanner/docs/ref1"})
+	if err == nil || !strings.Contains(err.Error(), "all individual document fetches failed") {
+		t.Fatalf("error = %v, want all individual document fetches failed", err)
+	}
+}


### PR DESCRIPTION
Refs #941.

Add offline regression tests for LLM composition and tool use, BigQuery request/result handling, CQL type formatting, and feature/cache error paths. Use local HTTP servers and fake clients; isolate the missing-key test from ambient credentials.

Only tests change. The full-suite coverage scope and 80% CI floor remain unchanged. Combined progress toward 85% is tracked in #941 and measured from integrated CI results.

Validation: `make check` passed before publication; current-head hosted test, lint, race, vulnerability and cross-compile checks passed. The missing-key test passed with the race detector for 3 repetitions while both ambient key variables contained non-secret placeholders.
