### PR TITLE
Test CLI input, meta-command, and EOF error paths

### DIFF
--- a/internal/mycli/cli_input_test.go
+++ b/internal/mycli/cli_input_test.go
@@ -1,0 +1,580 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mycli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/apstndb/spanner-mycli/enums"
+	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
+	"github.com/hymkor/go-multiline-ny"
+)
+
+func newConnectedTestCli(t *testing.T, out io.Writer) *Cli {
+	t.Helper()
+	if out == nil {
+		out = io.Discard
+	}
+	session := newDetachedTestSession(out)
+	t.Cleanup(session.Close)
+	session.mode = DatabaseConnected
+	session.systemVariables.Query.BuildStatementMode = enums.ParseModeFallback
+	session.systemVariables.Display.CLIFormat = enums.DisplayModeTab
+	return &Cli{
+		SessionHandler:  NewSessionHandler(session),
+		SystemVariables: session.systemVariables,
+	}
+}
+
+func TestCli_streamAccessors(t *testing.T) {
+	t.Parallel()
+	in := io.NopCloser(strings.NewReader("in"))
+	var out, errOut bytes.Buffer
+	sysVars := &systemVariables{
+		StreamManager: streamio.NewStreamManager(in, &out, &errOut),
+	}
+	cli := &Cli{SystemVariables: sysVars}
+
+	if cli.GetWriter() != sysVars.StreamManager.GetWriter() {
+		t.Fatal("GetWriter should return StreamManager writer")
+	}
+	if cli.GetErrStream() != sysVars.StreamManager.GetErrStream() {
+		t.Fatal("GetErrStream should return StreamManager error stream")
+	}
+	if cli.GetInStream() != sysVars.StreamManager.GetInStream() {
+		t.Fatal("GetInStream should return StreamManager input")
+	}
+	if cli.GetTtyStream() != nil {
+		t.Fatal("GetTtyStream should be nil until a TTY is attached")
+	}
+	tty := attachTTYPipe(t, cli)
+	if cli.GetTtyStream() == nil {
+		t.Fatal("GetTtyStream should return the attached TTY")
+	}
+	_ = tty
+}
+
+func TestCli_parseStatement_metaCommands(t *testing.T) {
+	t.Parallel()
+	cli := &Cli{SystemVariables: &systemVariables{Query: QueryVars{BuildStatementMode: enums.ParseModeFallback}}}
+
+	got, err := cli.parseStatement(&inputStatement{statement: `\! echo hello`})
+	if err != nil {
+		t.Fatalf("parseStatement: %v", err)
+	}
+	shell, ok := got.(*ShellMetaCommand)
+	if !ok || shell.Command != "echo hello" {
+		t.Fatalf("got %#v, want ShellMetaCommand echo hello", got)
+	}
+
+	got, err = cli.parseStatement(&inputStatement{statement: `\. setup.sql`})
+	if err != nil {
+		t.Fatalf("parseStatement: %v", err)
+	}
+	src, ok := got.(*SourceMetaCommand)
+	if !ok || src.FilePath != "setup.sql" {
+		t.Fatalf("got %#v, want SourceMetaCommand setup.sql", got)
+	}
+
+	_, err = cli.parseStatement(&inputStatement{statement: `\d unknown`})
+	if err == nil || !strings.Contains(err.Error(), "unsupported meta command") {
+		t.Fatalf("error = %v, want unsupported meta command", err)
+	}
+}
+
+func TestCli_handleSpecialStatements_sourceFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file prints interactive error and continues", func(t *testing.T) {
+		var out, errOut bytes.Buffer
+		session := newDetachedTestSession(&out)
+		t.Cleanup(session.Close)
+		session.systemVariables.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), &out, &errOut)
+		cli := &Cli{SessionHandler: NewSessionHandler(session), SystemVariables: session.systemVariables}
+
+		exitCode, processed := cli.handleSpecialStatements(context.Background(), &SourceMetaCommand{FilePath: filepath.Join(t.TempDir(), "missing.sql")})
+		if exitCode != -1 || !processed {
+			t.Fatalf("exitCode=%d processed=%v, want -1, true", exitCode, processed)
+		}
+		if !strings.Contains(errOut.String(), "ERROR:") || !strings.Contains(errOut.String(), "no such file") {
+			t.Fatalf("stderr = %q, want sourced-file error", errOut.String())
+		}
+	})
+
+	t.Run("valid file executes and continues", func(t *testing.T) {
+		var out bytes.Buffer
+		cli := newDetachedEchoCli(t, &out)
+		path := writeTempSQL(t, "SET CLI_PROMPT = 'from-source';")
+		exitCode, processed := cli.handleSpecialStatements(context.Background(), &SourceMetaCommand{FilePath: path})
+		if exitCode != -1 || !processed {
+			t.Fatalf("exitCode=%d processed=%v, want -1, true", exitCode, processed)
+		}
+		if cli.SystemVariables.Display.Prompt != "from-source" {
+			t.Fatalf("CLI_PROMPT = %q, want from-source", cli.SystemVariables.Display.Prompt)
+		}
+	})
+}
+
+func TestCli_handleSpecialStatements_dropDatabaseConfirm(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantProcessed bool
+	}{
+		{name: "user declines", input: "no\n", wantProcessed: true},
+		{name: "user confirms", input: "yes\n", wantProcessed: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			sysVars := &systemVariables{Connection: ConnectionVars{Database: "current-db"}}
+			sysVars.StreamManager = streamio.NewStreamManager(io.NopCloser(strings.NewReader(tt.input)), &out, &errOut)
+			cli := &Cli{
+				SessionHandler:  NewSessionHandler(&Session{systemVariables: sysVars}),
+				SystemVariables: sysVars,
+			}
+			attachTTYPipe(t, cli)
+
+			exitCode, processed := cli.handleSpecialStatements(context.Background(), &DropDatabaseStatement{DatabaseId: "other-db"})
+			if exitCode != -1 {
+				t.Fatalf("exitCode = %d, want -1", exitCode)
+			}
+			if processed != tt.wantProcessed {
+				t.Fatalf("processed = %v, want %v", processed, tt.wantProcessed)
+			}
+			if errOut.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", errOut.String())
+			}
+		})
+	}
+}
+
+func TestCli_PrintInteractiveError(t *testing.T) {
+	t.Parallel()
+	var errOut bytes.Buffer
+	cli := &Cli{
+		SystemVariables: &systemVariables{
+			StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), io.Discard, &errOut),
+		},
+	}
+	cli.PrintInteractiveError(errors.New("interactive boom"))
+	if errOut.String() != "ERROR: interactive boom\n" {
+		t.Fatalf("stderr = %q", errOut.String())
+	}
+}
+
+func TestCli_PrintResult_nilWriterUsesStream(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := &Cli{
+		SystemVariables: &systemVariables{
+			Display:       DisplayVars{CLIFormat: enums.DisplayModeTab},
+			StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), &out, io.Discard),
+		},
+	}
+	err := cli.PrintResult(80, &Result{TableHeader: toTableHeader("col"), Rows: []Row{toRow("v")}}, false, "", nil)
+	if err != nil {
+		t.Fatalf("PrintResult: %v", err)
+	}
+	if !strings.Contains(out.String(), "col") || !strings.Contains(out.String(), "v") {
+		t.Fatalf("stream output = %q", out.String())
+	}
+}
+
+func TestCli_displayResult_nilWriterAndInteractiveNewline(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := &Cli{
+		SystemVariables: &systemVariables{
+			Display:       DisplayVars{CLIFormat: enums.DisplayModeTab},
+			StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), &out, io.Discard),
+		},
+	}
+	result := &Result{TableHeader: toTableHeader("col"), Rows: []Row{toRow("v")}}
+	sink := cli.newResultSink(context.Background(), &out, "")
+	if err := cli.displayResult(sink, result, true, nil); err != nil {
+		t.Fatalf("displayResult: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "col") || !strings.Contains(got, "v") {
+		t.Fatalf("output missing table content: %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("interactive display should end with a newline, got %q", got)
+	}
+}
+
+func TestCli_readInputLine_readError(t *testing.T) {
+	cli := newReadlineTestCli(t)
+	ed := &multiline.Editor{}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	type result struct {
+		stmt *inputStatement
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		stmt, err := cli.readInputLine(ctx, ed)
+		done <- result{stmt: stmt, err: err}
+	}()
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("readInputLine did not return")
+	}
+	if got.err == nil {
+		t.Fatal("expected read error from an uninitialized editor")
+	}
+	if got.stmt != nil {
+		t.Fatalf("statement = %+v, want nil", got.stmt)
+	}
+}
+
+func TestCli_executeStatementInteractive_error(t *testing.T) {
+	t.Parallel()
+	cli := newDetachedEchoCli(t, io.Discard)
+	_, err := cli.executeStatementInteractive(context.Background(), &SelectStatement{Query: "SELECT 1"}, &inputStatement{statement: "SELECT 1"})
+	if err == nil || !strings.Contains(err.Error(), "not compatible with detached session mode") {
+		t.Fatalf("error = %v, want detached-mode rejection", err)
+	}
+}
+
+func TestCli_updateSystemVariables(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	cli := &Cli{SystemVariables: &systemVariables{}}
+
+	cli.updateSystemVariables(&Result{
+		ReadTimestamp:   ts,
+		CommitTimestamp: ts,
+		CommitStats:     &sppb.CommitResponse_CommitStats{MutationCount: 4},
+	})
+	if !cli.SystemVariables.LastResult.ReadTimestamp.Equal(ts) || !cli.SystemVariables.LastResult.CommitTimestamp.Equal(ts) {
+		t.Fatalf("timestamps not stored: %+v", cli.SystemVariables.LastResult)
+	}
+	if cli.SystemVariables.LastResult.CommitResponse == nil || cli.SystemVariables.LastResult.CommitResponse.CommitStats.MutationCount != 4 {
+		t.Fatalf("commit response = %#v", cli.SystemVariables.LastResult.CommitResponse)
+	}
+	if !cli.SystemVariables.LastResult.CommitResponse.CommitTimestamp.AsTime().Equal(ts) {
+		t.Fatalf("commit timestamp proto = %v", cli.SystemVariables.LastResult.CommitResponse.CommitTimestamp)
+	}
+
+	cli.updateSystemVariables(&Result{ReadTimestamp: ts.Add(time.Second)})
+	if cli.SystemVariables.LastResult.CommitResponse != nil {
+		t.Fatal("CommitResponse should be cleared when CommitStats is nil")
+	}
+
+	cli.updateSystemVariables(&Result{CommitStats: &sppb.CommitResponse_CommitStats{MutationCount: 1}})
+	if cli.SystemVariables.LastResult.CommitResponse == nil {
+		t.Fatal("CommitResponse should be set when CommitStats is present")
+	}
+	if cli.SystemVariables.LastResult.CommitResponse.CommitTimestamp != nil {
+		t.Fatal("zero commit timestamp should not be copied into the proto")
+	}
+}
+
+func TestGetTerminalSize_nonFile(t *testing.T) {
+	t.Parallel()
+	_, err := GetTerminalSize(&bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "writer is not a file") {
+		t.Fatalf("error = %v, want writer is not a file", err)
+	}
+}
+
+func TestCli_GetTerminalSizeWithTty_andResolveScreenWidth(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := &Cli{
+		SystemVariables: &systemVariables{
+			Display:       DisplayVars{AutoWrap: true},
+			StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), &out, io.Discard),
+		},
+	}
+
+	_, err := cli.GetTerminalSizeWithTty(&out)
+	if err == nil || !strings.Contains(err.Error(), "writer is not a file and TtyOutStream is not set") {
+		t.Fatalf("error = %v, want missing TTY and non-file writer", err)
+	}
+
+	if width := cli.resolveScreenWidth(&out); width != math.MaxInt {
+		t.Fatalf("AutoWrap with unknown size = %d, want MaxInt", width)
+	}
+
+	cli.SystemVariables.Display.AutoWrap = false
+	if width := cli.resolveScreenWidth(&out); width != math.MaxInt {
+		t.Fatalf("AutoWrap=false width = %d, want MaxInt", width)
+	}
+
+	fixed := int64(72)
+	cli.SystemVariables.Display.AutoWrap = true
+	cli.SystemVariables.Display.FixedWidth = &fixed
+	if width := cli.resolveScreenWidth(&out); width != 72 {
+		t.Fatalf("fixed width = %d, want 72", width)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "notty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	cli.SystemVariables.Display.FixedWidth = nil
+	if width := cli.resolveScreenWidth(f); width != math.MaxInt {
+		t.Fatalf("non-terminal file width = %d, want MaxInt", width)
+	}
+}
+
+type abortStatement struct{}
+
+func (abortStatement) isDetachedCompatible() {}
+
+func (abortStatement) Execute(context.Context, *Session) (*Result, error) {
+	return nil, spanner.ToSpannerError(status.Error(codes.Aborted, "txn aborted"))
+}
+
+func TestCli_executeStatement_abortedJoinsRecreateError(t *testing.T) {
+	t.Parallel()
+	cli := newConnectedTestCli(t, io.Discard)
+	_, err := cli.executeStatement(context.Background(), abortStatement{}, false, "", io.Discard)
+	if err == nil {
+		t.Fatal("expected aborted execution error")
+	}
+	if spanner.ErrCode(err) != codes.Aborted {
+		t.Fatalf("ErrCode = %v, want Aborted", spanner.ErrCode(err))
+	}
+	if !strings.Contains(err.Error(), "database operation requires a database connection") {
+		t.Fatalf("error = %v, want joined RecreateClient failure", err)
+	}
+}
+
+func TestCli_executeStatement_metaCommandSkipsDecoratedDisplay(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newConnectedTestCli(t, &out)
+	cli.SystemVariables.Display.MarkdownCodeblock = true
+	cli.SystemVariables.Feature.EchoInput = true
+
+	pre, err := cli.executeStatement(context.Background(), &PromptMetaCommand{PromptString: "meta>"}, true, `\R meta>`, &out)
+	if err != nil {
+		t.Fatalf("executeStatement: %v", err)
+	}
+	if pre != "" {
+		t.Fatalf("PreInput = %q, want empty", pre)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("meta command wrote decorated output %q", out.String())
+	}
+	if cli.SystemVariables.Display.Prompt != "meta> " {
+		t.Fatalf("prompt = %q, want %q", cli.SystemVariables.Display.Prompt, "meta> ")
+	}
+}
+
+func TestCli_executeStatementInteractive_andNilWriter(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newConnectedTestCli(t, &out)
+	pre, err := cli.executeStatementInteractive(context.Background(), &SetStatement{VarName: "CLI_PROMPT", Value: "'interactive'"}, &inputStatement{statement: "SET CLI_PROMPT = 'interactive'"})
+	if err != nil {
+		t.Fatalf("executeStatementInteractive: %v", err)
+	}
+	if pre != "" {
+		t.Fatalf("PreInput = %q", pre)
+	}
+	if cli.SystemVariables.Display.Prompt != "interactive" {
+		t.Fatalf("prompt = %q, want interactive", cli.SystemVariables.Display.Prompt)
+	}
+	if out.Len() == 0 {
+		t.Fatal("interactive execution produced no output")
+	}
+
+	_, err = cli.executeStatement(context.Background(), &SetStatement{VarName: "CLI_PROMPT2", Value: "'from-nil'"}, false, "", nil)
+	if err != nil {
+		t.Fatalf("executeStatement nil writer: %v", err)
+	}
+	if cli.SystemVariables.Display.Prompt2 != "from-nil" {
+		t.Fatalf("prompt2 = %q, want from-nil", cli.SystemVariables.Display.Prompt2)
+	}
+}
+
+func TestCli_executeStatement_updatesResultTimestamps(t *testing.T) {
+	t.Parallel()
+	cli := newConnectedTestCli(t, io.Discard)
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	_, err := cli.executeStatement(context.Background(), timestampResultStatement{ts: ts}, false, "", io.Discard)
+	if err != nil {
+		t.Fatalf("executeStatement: %v", err)
+	}
+	if !cli.SystemVariables.LastResult.ReadTimestamp.Equal(ts) {
+		t.Fatalf("ReadTimestamp = %v, want %v", cli.SystemVariables.LastResult.ReadTimestamp, ts)
+	}
+	if cli.SystemVariables.LastResult.CommitResponse == nil || cli.SystemVariables.LastResult.CommitResponse.CommitStats.MutationCount != 2 {
+		t.Fatalf("CommitResponse = %#v", cli.SystemVariables.LastResult.CommitResponse)
+	}
+}
+
+type timestampResultStatement struct{ ts time.Time }
+
+func (timestampResultStatement) isDetachedCompatible() {}
+
+func (s timestampResultStatement) Execute(context.Context, *Session) (*Result, error) {
+	return &Result{
+		ReadTimestamp:   s.ts,
+		CommitTimestamp: s.ts,
+		CommitStats:     &sppb.CommitResponse_CommitStats{MutationCount: 2},
+	}, nil
+}
+
+func TestCli_executeSourceFile_executionError(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	cli := newDetachedEchoCli(t, &out)
+	err := cli.executeSourceFile(context.Background(), writeTempSQL(t, "SELECT 1;"))
+	if err == nil || !strings.Contains(err.Error(), "error executing statement 1") {
+		t.Fatalf("error = %v, want statement execution failure", err)
+	}
+}
+
+func TestCli_executeStartupSQL_executionError(t *testing.T) {
+	t.Parallel()
+	var errOut bytes.Buffer
+	cli := newDetachedEchoCli(t, io.Discard)
+	cli.SystemVariables.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), io.Discard, &errOut)
+	err := cli.executeStartupSQL(context.Background(), []string{"SET CLI_FORMAT = 'NOT_A_FORMAT'"})
+	if GetExitCode(err) != exitCodeError {
+		t.Fatalf("error = %v, want execution exit", err)
+	}
+	if !strings.Contains(errOut.String(), "ERROR:") {
+		t.Fatalf("stderr = %q, want printed batch error", errOut.String())
+	}
+}
+
+func TestCli_RunBatch_parseAndExecutionErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parse error", func(t *testing.T) {
+		var errOut bytes.Buffer
+		cli := newDetachedEchoCli(t, io.Discard)
+		cli.SystemVariables.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), io.Discard, &errOut)
+		err := cli.RunBatch(context.Background(), "INVALID SYNTAX;")
+		if GetExitCode(err) != exitCodeError {
+			t.Fatalf("error = %v, want parse exit", err)
+		}
+		if !strings.Contains(errOut.String(), "ERROR:") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+
+	t.Run("execution error", func(t *testing.T) {
+		var errOut bytes.Buffer
+		cli := newDetachedEchoCli(t, io.Discard)
+		cli.SystemVariables.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), io.Discard, &errOut)
+		err := cli.RunBatch(context.Background(), "SELECT 1;")
+		if GetExitCode(err) != exitCodeError {
+			t.Fatalf("error = %v, want execution exit", err)
+		}
+		if !strings.Contains(errOut.String(), "ERROR:") {
+			t.Fatalf("stderr = %q", errOut.String())
+		}
+	})
+}
+
+func TestHandleInterrupt_contextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		handleInterrupt(ctx, func() {})
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleInterrupt did not return after context cancellation")
+	}
+}
+
+func TestSetupProgressMark_excludedStatements(t *testing.T) {
+	cli := newDecorationTestCli()
+	tty := attachTTYPipe(t, cli)
+	for _, stmt := range []Statement{
+		&DdlStatement{Ddl: "CREATE TABLE t (id INT64) PRIMARY KEY (id)"},
+		&ExitStatement{},
+		&DumpSchemaStatement{},
+		&RunBatchStatement{},
+	} {
+		stop := cli.setupProgressMark(stmt, io.Discard)
+		stop()
+	}
+	if got := readPipeDeadline(t, tty, 50*time.Millisecond); got != "" {
+		t.Fatalf("excluded statements should not start progress, TTY got %q", got)
+	}
+}
+
+func TestCli_executeStatement_keepVariablesSkipsTimestampUpdate(t *testing.T) {
+	t.Parallel()
+	cli := newConnectedTestCli(t, io.Discard)
+	prior := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	cli.SystemVariables.LastResult.ReadTimestamp = prior
+	_, err := cli.executeStatement(context.Background(), keepVariablesStatement{}, false, "", io.Discard)
+	if err != nil {
+		t.Fatalf("executeStatement: %v", err)
+	}
+	if !cli.SystemVariables.LastResult.ReadTimestamp.Equal(prior) {
+		t.Fatalf("KeepVariables should not update timestamps, got %v", cli.SystemVariables.LastResult.ReadTimestamp)
+	}
+}
+
+type keepVariablesStatement struct{}
+
+func (keepVariablesStatement) isDetachedCompatible() {}
+
+func (keepVariablesStatement) Execute(context.Context, *Session) (*Result, error) {
+	return &Result{
+		KeepVariables: true,
+		ReadTimestamp: time.Date(2026, 9, 12, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func TestCli_displayResult_outputError(t *testing.T) {
+	t.Parallel()
+	cli := &Cli{
+		SystemVariables: &systemVariables{
+			Display:       DisplayVars{CLIFormat: enums.DisplayModeTab},
+			StreamManager: streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), io.Discard, io.Discard),
+		},
+	}
+	cause := errors.New("display dest failed")
+	w := &resultFailureWriter{err: cause}
+	err := cli.displayResult(cli.newResultSink(context.Background(), w, ""), &Result{TableHeader: toTableHeader("c"), Rows: []Row{toRow("1")}}, false, w)
+	if !errors.Is(err, cause) {
+		t.Fatalf("error = %v, want %v", err, cause)
+	}
+}

--- a/internal/mycli/cli_input_test.go
+++ b/internal/mycli/cli_input_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/apstndb/spanner-mycli/enums"
 	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
-	"github.com/hymkor/go-multiline-ny"
 )
 
 func newConnectedTestCli(t *testing.T, out io.Writer) *Cli {
@@ -232,30 +231,17 @@ func TestCli_displayResult_nilWriterAndInteractiveNewline(t *testing.T) {
 
 func TestCli_readInputLine_readError(t *testing.T) {
 	cli := newReadlineTestCli(t)
-	ed := &multiline.Editor{}
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
+	ed := newIsolatedReadlineEditor(t, nil, nil)
 
-	type result struct {
-		stmt *inputStatement
-		err  error
+	stmt, err := cli.readInputLine(context.Background(), ed)
+	if stmt != nil {
+		t.Fatalf("statement = %+v, want nil", stmt)
 	}
-	done := make(chan result, 1)
-	go func() {
-		stmt, err := cli.readInputLine(ctx, ed)
-		done <- result{stmt: stmt, err: err}
-	}()
-	var got result
-	select {
-	case got = <-done:
-	case <-time.After(3 * time.Second):
-		t.Fatal("readInputLine did not return")
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("error = %v, want failed to read input wrapping io.EOF", err)
 	}
-	if got.err == nil {
-		t.Fatal("expected read error from an uninitialized editor")
-	}
-	if got.stmt != nil {
-		t.Fatalf("statement = %+v, want nil", got.stmt)
+	if !strings.Contains(err.Error(), "failed to read input") {
+		t.Fatalf("error = %v, want failed to read input wrapping io.EOF", err)
 	}
 }
 

--- a/internal/mycli/cli_readline_test.go
+++ b/internal/mycli/cli_readline_test.go
@@ -1,19 +1,28 @@
 package mycli
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apstndb/gsqlutils"
 	"github.com/cloudspannerecosystem/memefish"
 	"github.com/cloudspannerecosystem/memefish/token"
 	"github.com/fatih/color"
+	"github.com/hymkor/go-multiline-ny"
+	"github.com/nyaosorg/go-readline-ny"
 	"github.com/nyaosorg/go-readline-ny/simplehistory"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/apstndb/spanner-mycli/internal/mycli/streamio"
 )
 
 func TestLexerHighlighterWithError(t *testing.T) {
@@ -1173,4 +1182,337 @@ func (e *errorFS) OpenFile(name string, flag int, perm os.FileMode) (afero.File,
 		return nil, e.readError
 	}
 	return e.Fs.OpenFile(name, flag, perm)
+}
+
+type failWriteFS struct {
+	afero.Fs
+	writeErr error
+	closeErr error
+}
+
+type failWriteFile struct {
+	afero.File
+	writeErr error
+	closeErr error
+}
+
+func (f *failWriteFile) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return f.File.Write(p)
+}
+
+func (f *failWriteFile) Close() error {
+	err := f.File.Close()
+	if f.closeErr != nil {
+		return f.closeErr
+	}
+	return err
+}
+
+func (fs *failWriteFS) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	f, err := fs.Fs.OpenFile(name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return &failWriteFile{File: f, writeErr: fs.writeErr, closeErr: fs.closeErr}, nil
+}
+
+func TestPersistentHistoryAdd_writeAndCloseErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write failure still keeps in-memory history", func(t *testing.T) {
+		fs := &failWriteFS{Fs: afero.NewMemMapFs(), writeErr: errors.New("disk full")}
+		h := simplehistory.New()
+		ph := &persistentHistory{filename: "history.txt", history: h, fs: fs}
+		ph.Add("SELECT 1")
+		if h.Len() != 1 || h.At(0) != "SELECT 1" {
+			t.Fatalf("in-memory history = %d %q", h.Len(), h.At(0))
+		}
+	})
+
+	t.Run("close failure is logged and does not panic", func(t *testing.T) {
+		fs := &failWriteFS{Fs: afero.NewMemMapFs(), closeErr: errors.New("close failed")}
+		h := simplehistory.New()
+		ph := &persistentHistory{filename: "history.txt", history: h, fs: fs}
+		ph.Add("SELECT 1")
+		if h.Len() != 1 {
+			t.Fatalf("history len = %d", h.Len())
+		}
+		content, err := afero.ReadFile(fs, "history.txt")
+		require.NoError(t, err)
+		if !strings.Contains(string(content), "SELECT 1") {
+			t.Fatalf("file content = %q", content)
+		}
+	})
+}
+
+func TestIsInterrupted(t *testing.T) {
+	t.Parallel()
+	if isInterrupted(nil) {
+		t.Fatal("nil should not be interrupted")
+	}
+	if isInterrupted(errors.New("Ctrl-C")) {
+		t.Fatal("plain error should not match readline.CtrlC")
+	}
+	if !isInterrupted(readline.CtrlC) {
+		t.Fatal("readline.CtrlC should be interrupted")
+	}
+	if !isInterrupted(errors.Join(errors.New("wrap"), readline.CtrlC)) {
+		t.Fatal("wrapped readline.CtrlC should be interrupted")
+	}
+}
+
+func TestErrorHighlighter(t *testing.T) {
+	t.Parallel()
+	hl := errorHighlighter(func(me *memefish.Error) bool {
+		return me.Message == errMessageUnclosedStringLiteral || me.Message == errMessageUnclosedTripleQuotedStringLiteral
+	})
+
+	if got := hl("SELECT 1", -1); len(got) != 0 {
+		t.Fatalf("valid SQL highlights = %v, want none", got)
+	}
+	if got := hl("SELECT 'unclosed", -1); len(got) != 1 {
+		t.Fatalf("unclosed string highlights = %v, want 1 range", got)
+	}
+	if got := hl("SELECT '''unclosed", -1); len(got) != 1 {
+		t.Fatalf("unclosed triple-quoted highlights = %v, want 1 range", got)
+	}
+}
+
+func TestHighlighterFuncFindAllStringIndex(t *testing.T) {
+	t.Parallel()
+	f := highlighterFunc(func(s string, n int) [][]int {
+		if s != "abc" || n != -1 {
+			t.Errorf("highlighterFunc args = (%q, %d)", s, n)
+		}
+		return [][]int{{0, 1}}
+	})
+	got := f.FindAllStringIndex("abc", -1)
+	if len(got) != 1 || got[0][0] != 0 || got[0][1] != 1 {
+		t.Fatalf("FindAllStringIndex = %v", got)
+	}
+}
+
+func TestLexerHighlighter(t *testing.T) {
+	t.Parallel()
+	hl := lexerHighlighter(func(tok token.Token) [][]int {
+		if tok.Kind == token.TokenInt {
+			return [][]int{{int(tok.Pos), int(tok.End)}}
+		}
+		return nil
+	})
+	got := hl("SELECT 42", -1)
+	if len(got) != 1 {
+		t.Fatalf("lexerHighlighter = %v, want one int token", got)
+	}
+}
+
+func TestSetLineEditor(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	originalNoColor := color.NoColor
+	defer func() { color.NoColor = originalNoColor }()
+
+	ed := &multiline.Editor{}
+
+	color.NoColor = true
+	setLineEditor(ed, true)
+	if ed.Highlight != nil || ed.DefaultColor != "" || ed.ResetColor != "" {
+		t.Fatalf("NoColor should disable highlight, got Highlight=%v Default=%q Reset=%q", ed.Highlight, ed.DefaultColor, ed.ResetColor)
+	}
+
+	color.NoColor = false
+	setLineEditor(ed, false)
+	if ed.Highlight != nil || ed.DefaultColor != "" || ed.ResetColor != "" {
+		t.Fatalf("enableHighlight=false should disable highlight, got Highlight=%v", ed.Highlight)
+	}
+
+	setLineEditor(ed, true)
+	if len(ed.Highlight) != len(defaultHighlights) {
+		t.Fatalf("Highlight len = %d, want %d", len(ed.Highlight), len(defaultHighlights))
+	}
+	if color.NoColor {
+		t.Fatal("expected color.NoColor=false after enabling highlight")
+	}
+	if ed.ResetColor == "" || ed.DefaultColor == "" {
+		// Some environments still emit empty sequences even after forcing NoColor=false.
+		// Highlight assignment is the contract that matters for syntax coloring.
+		t.Logf("color sequences empty (Reset=%q Default=%q); highlight table still installed", ed.ResetColor, ed.DefaultColor)
+	}
+}
+
+func TestSetupHistory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new file", func(t *testing.T) {
+		ed := &multiline.Editor{}
+		path := filepath.Join(t.TempDir(), "history")
+		h, err := setupHistory(ed, path)
+		if err != nil {
+			t.Fatalf("setupHistory: %v", err)
+		}
+		if h.Len() != 0 {
+			t.Fatalf("new history len = %d", h.Len())
+		}
+		h.Add("SELECT 1")
+		if h.Len() != 1 || h.At(0) != "SELECT 1" {
+			t.Fatalf("history after add = %d %q", h.Len(), h.At(0))
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		ed := &multiline.Editor{}
+		path := filepath.Join(t.TempDir(), "history")
+		if err := os.WriteFile(path, []byte("not-quoted\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := setupHistory(ed, path)
+		if err == nil || !strings.Contains(err.Error(), "history file format error") {
+			t.Fatalf("error = %v, want history file format error", err)
+		}
+	})
+}
+
+func newReadlineTestCli(t *testing.T) *Cli {
+	t.Helper()
+	sysVars := newSystemVariablesWithDefaults()
+	sysVars.Display.HistoryFile = filepath.Join(t.TempDir(), "history")
+	sysVars.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), io.Discard, io.Discard)
+	session := newDetachedTestSession(io.Discard)
+	session.systemVariables = &sysVars
+	cli := &Cli{
+		SessionHandler:  NewSessionHandler(session),
+		SystemVariables: &sysVars,
+	}
+	return cli
+}
+
+func requireControllingTTY(t *testing.T) {
+	t.Helper()
+	if !controllingTTYAvailable() {
+		t.Skip("no controlling terminal for readline BindKey")
+	}
+}
+
+func controllingTTYAvailable() bool {
+	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+func TestInitializeMultilineEditor(t *testing.T) {
+	t.Run("requires TTY", func(t *testing.T) {
+		cli := newReadlineTestCli(t)
+		_, _, err := initializeMultilineEditor(cli)
+		if err == nil || !strings.Contains(err.Error(), "stdout is not a terminal") {
+			t.Fatalf("error = %v, want missing TTY", err)
+		}
+	})
+
+	t.Run("bind key without controlling terminal", func(t *testing.T) {
+		if controllingTTYAvailable() {
+			t.Skip("controlling terminal is present")
+		}
+		cli := newReadlineTestCli(t)
+		attachTTYPipe(t, cli)
+		_, _, err := initializeMultilineEditor(cli)
+		if err == nil || !strings.Contains(err.Error(), "Tty.Open") {
+			t.Fatalf("error = %v, want readline Tty.Open failure", err)
+		}
+	})
+
+	t.Run("unknown fuzzy finder key still initializes", func(t *testing.T) {
+		requireControllingTTY(t)
+		cli := newReadlineTestCli(t)
+		attachTTYPipe(t, cli)
+		cli.SystemVariables.Feature.FuzzyFinderKey = "NOT_A_KEY"
+		ed, history, err := initializeMultilineEditor(cli)
+		if err != nil {
+			t.Fatalf("initializeMultilineEditor: %v", err)
+		}
+		if ed == nil || history == nil {
+			t.Fatal("editor and history must be non-nil")
+		}
+	})
+
+	t.Run("known fuzzy finder key", func(t *testing.T) {
+		requireControllingTTY(t)
+		cli := newReadlineTestCli(t)
+		attachTTYPipe(t, cli)
+		cli.SystemVariables.Feature.FuzzyFinderKey = "C_T"
+		ed, history, err := initializeMultilineEditor(cli)
+		if err != nil {
+			t.Fatalf("initializeMultilineEditor: %v", err)
+		}
+		if ed == nil || history == nil {
+			t.Fatal("editor and history must be non-nil")
+		}
+	})
+
+	t.Run("empty fuzzy finder key", func(t *testing.T) {
+		requireControllingTTY(t)
+		cli := newReadlineTestCli(t)
+		attachTTYPipe(t, cli)
+		cli.SystemVariables.Feature.FuzzyFinderKey = ""
+		if _, _, err := initializeMultilineEditor(cli); err != nil {
+			t.Fatalf("initializeMultilineEditor: %v", err)
+		}
+	})
+
+	t.Run("invalid history file", func(t *testing.T) {
+		requireControllingTTY(t)
+		cli := newReadlineTestCli(t)
+		attachTTYPipe(t, cli)
+		path := cli.SystemVariables.Display.HistoryFile
+		if err := os.WriteFile(path, []byte("broken\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := initializeMultilineEditor(cli)
+		if err == nil || !strings.Contains(err.Error(), "history file format error") {
+			t.Fatalf("error = %v, want history format error", err)
+		}
+	})
+}
+
+func TestReadInteractiveInput_cancelledContext(t *testing.T) {
+	requireControllingTTY(t)
+	cli := newReadlineTestCli(t)
+	attachTTYPipe(t, cli)
+	ed, _, err := initializeMultilineEditor(cli)
+	if err != nil {
+		t.Fatalf("initializeMultilineEditor: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	type result struct {
+		stmt *inputStatement
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		stmt, err := cli.readInputLine(ctx, ed)
+		done <- result{stmt: stmt, err: err}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("readInputLine did not return after context timeout")
+	}
+	if got.err == nil {
+		t.Fatal("expected cancelled or read error")
+	}
+	if got.stmt != nil {
+		t.Fatalf("statement = %+v, want nil on empty failed read", got.stmt)
+	}
+	if !errors.Is(got.err, context.DeadlineExceeded) && !strings.Contains(got.err.Error(), "failed to read input") {
+		t.Fatalf("error = %v, want failed to read input wrapping a deadline or similar read failure", got.err)
+	}
 }

--- a/internal/mycli/cli_readline_test.go
+++ b/internal/mycli/cli_readline_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1388,107 +1389,60 @@ func newReadlineTestCli(t *testing.T) *Cli {
 	return cli
 }
 
-func requireControllingTTY(t *testing.T) {
-	t.Helper()
-	if !controllingTTYAvailable() {
-		t.Skip("no controlling terminal for readline BindKey")
-	}
+// scriptedTTY is an isolated readline TTY that never opens the caller's
+// controlling terminal. Empty keys yield io.EOF; onGetKey can inject a
+// sentinel such as context.Canceled.
+type scriptedTTY struct {
+	keys     []string
+	onGetKey func() error
 }
 
-func controllingTTYAvailable() bool {
-	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		return false
+func (t *scriptedTTY) IsOpen() bool              { return true }
+func (t *scriptedTTY) Open(func(int, int)) error { return nil }
+func (t *scriptedTTY) Size() (int, int, error)   { return 80, 24, nil }
+func (t *scriptedTTY) Close() error              { return nil }
+func (t *scriptedTTY) GetKey() (string, error) {
+	if len(t.keys) == 0 {
+		return "", io.EOF
 	}
-	_ = f.Close()
-	return true
+	if t.onGetKey != nil {
+		if err := t.onGetKey(); err != nil {
+			return "", err
+		}
+	}
+	key := t.keys[0]
+	t.keys = t.keys[1:]
+	return key, nil
+}
+
+func newIsolatedReadlineEditor(t *testing.T, keys []string, onGetKey func() error) *multiline.Editor {
+	t.Helper()
+	ed := &multiline.Editor{}
+	ed.SetWriter(io.Discard)
+	ed.SetTty(&scriptedTTY{keys: keys, onGetKey: onGetKey})
+	return ed
 }
 
 func TestInitializeMultilineEditor(t *testing.T) {
-	t.Run("requires TTY", func(t *testing.T) {
-		cli := newReadlineTestCli(t)
-		_, _, err := initializeMultilineEditor(cli)
-		if err == nil || !strings.Contains(err.Error(), "stdout is not a terminal") {
-			t.Fatalf("error = %v, want missing TTY", err)
-		}
-	})
-
-	t.Run("bind key without controlling terminal", func(t *testing.T) {
-		if controllingTTYAvailable() {
-			t.Skip("controlling terminal is present")
-		}
-		cli := newReadlineTestCli(t)
-		attachTTYPipe(t, cli)
-		_, _, err := initializeMultilineEditor(cli)
-		if err == nil || !strings.Contains(err.Error(), "Tty.Open") {
-			t.Fatalf("error = %v, want readline Tty.Open failure", err)
-		}
-	})
-
-	t.Run("unknown fuzzy finder key still initializes", func(t *testing.T) {
-		requireControllingTTY(t)
-		cli := newReadlineTestCli(t)
-		attachTTYPipe(t, cli)
-		cli.SystemVariables.Feature.FuzzyFinderKey = "NOT_A_KEY"
-		ed, history, err := initializeMultilineEditor(cli)
-		if err != nil {
-			t.Fatalf("initializeMultilineEditor: %v", err)
-		}
-		if ed == nil || history == nil {
-			t.Fatal("editor and history must be non-nil")
-		}
-	})
-
-	t.Run("known fuzzy finder key", func(t *testing.T) {
-		requireControllingTTY(t)
-		cli := newReadlineTestCli(t)
-		attachTTYPipe(t, cli)
-		cli.SystemVariables.Feature.FuzzyFinderKey = "C_T"
-		ed, history, err := initializeMultilineEditor(cli)
-		if err != nil {
-			t.Fatalf("initializeMultilineEditor: %v", err)
-		}
-		if ed == nil || history == nil {
-			t.Fatal("editor and history must be non-nil")
-		}
-	})
-
-	t.Run("empty fuzzy finder key", func(t *testing.T) {
-		requireControllingTTY(t)
-		cli := newReadlineTestCli(t)
-		attachTTYPipe(t, cli)
-		cli.SystemVariables.Feature.FuzzyFinderKey = ""
-		if _, _, err := initializeMultilineEditor(cli); err != nil {
-			t.Fatalf("initializeMultilineEditor: %v", err)
-		}
-	})
-
-	t.Run("invalid history file", func(t *testing.T) {
-		requireControllingTTY(t)
-		cli := newReadlineTestCli(t)
-		attachTTYPipe(t, cli)
-		path := cli.SystemVariables.Display.HistoryFile
-		if err := os.WriteFile(path, []byte("broken\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err := initializeMultilineEditor(cli)
-		if err == nil || !strings.Contains(err.Error(), "history file format error") {
-			t.Fatalf("error = %v, want history format error", err)
-		}
-	})
+	cli := newReadlineTestCli(t)
+	_, _, err := initializeMultilineEditor(cli)
+	if err == nil || !strings.Contains(err.Error(), "stdout is not a terminal") {
+		t.Fatalf("error = %v, want missing TTY", err)
+	}
 }
 
 func TestReadInteractiveInput_cancelledContext(t *testing.T) {
-	requireControllingTTY(t)
 	cli := newReadlineTestCli(t)
-	attachTTYPipe(t, cli)
-	ed, _, err := initializeMultilineEditor(cli)
-	if err != nil {
-		t.Fatalf("initializeMultilineEditor: %v", err)
-	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
+	entered := make(chan struct{})
+	var once sync.Once
+	ed := newIsolatedReadlineEditor(t, []string{"x"}, func() error {
+		once.Do(func() { close(entered) })
+		<-ctx.Done()
+		return ctx.Err()
+	})
 
 	type result struct {
 		stmt *inputStatement
@@ -1500,19 +1454,26 @@ func TestReadInteractiveInput_cancelledContext(t *testing.T) {
 		done <- result{stmt: stmt, err: err}
 	}()
 
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("scripted TTY did not enter GetKey")
+	}
+	cancel()
+
 	var got result
 	select {
 	case got = <-done:
 	case <-time.After(3 * time.Second):
-		t.Fatal("readInputLine did not return after context timeout")
-	}
-	if got.err == nil {
-		t.Fatal("expected cancelled or read error")
+		t.Fatal("readInputLine did not return after context cancellation")
 	}
 	if got.stmt != nil {
-		t.Fatalf("statement = %+v, want nil on empty failed read", got.stmt)
+		t.Fatalf("statement = %+v, want nil on cancelled read", got.stmt)
 	}
-	if !errors.Is(got.err, context.DeadlineExceeded) && !strings.Contains(got.err.Error(), "failed to read input") {
-		t.Fatalf("error = %v, want failed to read input wrapping a deadline or similar read failure", got.err)
+	if !errors.Is(got.err, context.Canceled) {
+		t.Fatalf("error = %v, want failed to read input wrapping context.Canceled", got.err)
+	}
+	if !strings.Contains(got.err.Error(), "failed to read input") {
+		t.Fatalf("error = %v, want failed to read input wrapping context.Canceled", got.err)
 	}
 }

--- a/internal/mycli/meta_commands_test.go
+++ b/internal/mycli/meta_commands_test.go
@@ -832,6 +832,10 @@ func TestOutputRedirectAndDisable_Execute(t *testing.T) {
 
 	t.Run("redirect enables silent tee", func(t *testing.T) {
 		session, sysVars := createTestSession(t)
+		base, ok := sysVars.StreamManager.GetWriter().(*bytes.Buffer)
+		if !ok {
+			t.Fatal("test session should capture base output in a *bytes.Buffer")
+		}
 		path := filepath.Join(t.TempDir(), "out.log")
 		result, err := (&OutputRedirectMetaCommand{FilePath: path}).Execute(ctx, session)
 		if err != nil || result == nil {
@@ -840,15 +844,39 @@ func TestOutputRedirectAndDisable_Execute(t *testing.T) {
 		if !sysVars.StreamManager.IsInSilentTeeMode() {
 			t.Fatal("\\o should enable silent tee mode")
 		}
-		original := sysVars.StreamManager.GetWriter()
+
+		const redirected = "redirected-only\n"
+		if _, err := sysVars.StreamManager.GetWriter().Write([]byte(redirected)); err != nil {
+			t.Fatalf("write while redirected: %v", err)
+		}
+		if base.Len() != 0 {
+			t.Fatalf("silent redirect leaked to base output: %q", base.String())
+		}
+
 		if _, err := (&DisableOutputRedirectMetaCommand{}).Execute(ctx, session); err != nil {
 			t.Fatalf("disable: %v", err)
 		}
 		if sysVars.StreamManager.IsInSilentTeeMode() {
 			t.Fatal("\\O / disable should turn silent tee off")
 		}
-		if sysVars.StreamManager.GetWriter() == original && original == nil {
-			t.Fatal("writer should remain usable after disable")
+
+		const afterDisable = "after-disable\n"
+		w := sysVars.StreamManager.GetWriter()
+		if w != base {
+			t.Fatal("disable should restore the original base writer")
+		}
+		if _, err := w.Write([]byte(afterDisable)); err != nil {
+			t.Fatalf("write after disable: %v", err)
+		}
+		if base.String() != afterDisable {
+			t.Fatalf("base output after disable = %q, want %q", base.String(), afterDisable)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read redirect file: %v", err)
+		}
+		if string(got) != redirected {
+			t.Fatalf("redirect file = %q, want %q", got, redirected)
 		}
 	})
 

--- a/internal/mycli/meta_commands_test.go
+++ b/internal/mycli/meta_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -735,6 +736,159 @@ func TestDisableTeeMetaCommand_Execute(t *testing.T) {
 			finalWriter := sysVars.StreamManager.GetWriter()
 			if finalWriter != originalWriter {
 				t.Error("StreamManager writer should revert to original after disable")
+			}
+		})
+	}
+}
+
+func TestParseMetaCommand_quotingAndRedirectErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		input        string
+		wantErr      string
+		wantDisable  bool
+		wantRedirect string
+	}{
+		{name: "source unmatched quote", input: `\. "unclosed.sql`, wantErr: "invalid filename quoting"},
+		{name: "tee unmatched quote", input: `\T "unclosed.log`, wantErr: "invalid filename quoting"},
+		{name: "redirect unmatched quote", input: `\o "unclosed.log`, wantErr: "invalid filename quoting"},
+		{name: "redirect multiple files", input: `\o file1.log file2.log`, wantErr: "\\o requires exactly one filename"},
+		{name: "redirect disable", input: `\o`, wantDisable: true},
+		{name: "redirect path", input: `\o out.log`, wantRedirect: "out.log"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMetaCommand(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseMetaCommand(%q) error = %v, want %q", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseMetaCommand(%q) unexpected error: %v", tt.input, err)
+			}
+			if tt.wantDisable {
+				if _, ok := got.(*DisableOutputRedirectMetaCommand); !ok {
+					t.Fatalf("got %T, want DisableOutputRedirectMetaCommand", got)
+				}
+			}
+			if tt.wantRedirect != "" {
+				redirect, ok := got.(*OutputRedirectMetaCommand)
+				if !ok || redirect.FilePath != tt.wantRedirect {
+					t.Fatalf("got %#v, want OutputRedirect %q", got, tt.wantRedirect)
+				}
+			}
+		})
+	}
+}
+
+func TestShellMetaCommand_Execute_noOutputAndCancel(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("no output destination", func(t *testing.T) {
+		session := &Session{systemVariables: &systemVariables{}}
+		_, err := (&ShellMetaCommand{Command: "echo hello"}).Execute(ctx, session)
+		if err == nil || err.Error() != "internal error: no output destination configured" {
+			t.Fatalf("error = %v, want no output destination", err)
+		}
+	})
+
+	t.Run("cancelled context is a genuine execution error", func(t *testing.T) {
+		var output bytes.Buffer
+		sysVars := newSystemVariablesWithDefaults()
+		sysVars.StreamManager = streamio.NewStreamManager(os.Stdin, &output, io.Discard)
+		session := &Session{systemVariables: &sysVars}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := (&ShellMetaCommand{Command: "sleep 5"}).Execute(ctx, session)
+		if err == nil || !strings.Contains(err.Error(), "command failed") {
+			t.Fatalf("error = %v, want command failed wrapping context cancellation", err)
+		}
+	})
+}
+
+func TestSourceAndUseMetaCommand_ExecuteMustNotRun(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	session := &Session{}
+
+	_, err := (&SourceMetaCommand{FilePath: "x.sql"}).Execute(ctx, session)
+	if err == nil || !strings.Contains(err.Error(), "must be handled by the CLI") {
+		t.Fatalf("SourceMetaCommand.Execute error = %v", err)
+	}
+
+	_, err = (&UseDatabaseMetaCommand{Database: "db"}).Execute(ctx, session)
+	if err == nil || !strings.Contains(err.Error(), "must be handled by the SessionHandler") {
+		t.Fatalf("UseDatabaseMetaCommand.Execute error = %v", err)
+	}
+}
+
+func TestOutputRedirectAndDisable_Execute(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("redirect enables silent tee", func(t *testing.T) {
+		session, sysVars := createTestSession(t)
+		path := filepath.Join(t.TempDir(), "out.log")
+		result, err := (&OutputRedirectMetaCommand{FilePath: path}).Execute(ctx, session)
+		if err != nil || result == nil {
+			t.Fatalf("Execute error = %v result = %v", err, result)
+		}
+		if !sysVars.StreamManager.IsInSilentTeeMode() {
+			t.Fatal("\\o should enable silent tee mode")
+		}
+		original := sysVars.StreamManager.GetWriter()
+		if _, err := (&DisableOutputRedirectMetaCommand{}).Execute(ctx, session); err != nil {
+			t.Fatalf("disable: %v", err)
+		}
+		if sysVars.StreamManager.IsInSilentTeeMode() {
+			t.Fatal("\\O / disable should turn silent tee off")
+		}
+		if sysVars.StreamManager.GetWriter() == original && original == nil {
+			t.Fatal("writer should remain usable after disable")
+		}
+	})
+
+	t.Run("redirect to directory", func(t *testing.T) {
+		session, _ := createTestSession(t)
+		_, err := (&OutputRedirectMetaCommand{FilePath: t.TempDir()}).Execute(ctx, session)
+		if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+			t.Fatalf("error = %v, want regular file", err)
+		}
+	})
+}
+
+func TestTeeAndDisableOutput_missingInternals(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := "out.log"
+
+	for _, tt := range []struct {
+		name string
+		cmd  Statement
+		sess *Session
+		want string
+	}{
+		{name: "tee nil sysvars", cmd: &TeeOutputMetaCommand{FilePath: path}, sess: &Session{}, want: "system variables not initialized"},
+		{name: "tee nil stream manager", cmd: &TeeOutputMetaCommand{FilePath: path}, sess: &Session{systemVariables: &systemVariables{}}, want: "stream manager not initialized"},
+		{name: "redirect nil sysvars", cmd: &OutputRedirectMetaCommand{FilePath: path}, sess: &Session{}, want: "system variables not initialized"},
+		{name: "redirect nil stream manager", cmd: &OutputRedirectMetaCommand{FilePath: path}, sess: &Session{systemVariables: &systemVariables{}}, want: "stream manager not initialized"},
+		{name: "disable tee nil sysvars", cmd: &DisableTeeMetaCommand{}, sess: &Session{}, want: "system variables not initialized"},
+		{name: "disable redirect nil stream manager", cmd: &DisableOutputRedirectMetaCommand{}, sess: &Session{systemVariables: &systemVariables{}}, want: "stream manager not initialized"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, ok := tt.cmd.(interface {
+				Execute(context.Context, *Session) (*Result, error)
+			})
+			if !ok {
+				t.Fatal("statement is not executable")
+			}
+			_, err := exec.Execute(ctx, tt.sess)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #941.

Add regression tests for CLI input, source/startup execution errors, history persistence, meta-commands, and output redirection. Use an isolated readline TTY to verify EOF and cancellation without reading the caller's terminal; verify actual output before and after disabling redirection.

Only tests change. The full coverage scope and 80% CI floor remain unchanged.

Validation: make check passed before publication; targeted input and redirect tests passed 20 repetitions under the race detector. Final hosted CI is required before merge.

Integrated main `a54dbdfe34b581679cb42b84af4b5abfb6d6b0f9` already measures **85.5%** with `go tool cover -func` in [successful CI run 34705938952](https://github.com/apstndb/spanner-mycli/actions/runs/34705938952). This PR contains that main commit plus the reviewed CLI tests; it completes the active coverage wave. Additional candidates are deferred. The 80% acceptance floor is unchanged.
