### PR TITLE
Preserve transactionContext identity across pending activation

### DIFF
--- a/dev-docs/architecture-guide.md
+++ b/dev-docs/architecture-guide.md
@@ -22,7 +22,7 @@ Key files in `internal/mycli`:
 - **session.go**: `Session` (Spanner clients, statement execution boundary) and
   `SessionHandler` (USE/DETACH database switching).
 - **transaction_manager.go**: `TransactionManager` (transaction state, mutex,
-  SET LOCAL undo log).
+  pending SET LOCAL restore). `transactionContext` owns active SET LOCAL undo.
 - **statements.go / statements_*.go**: statement implementations grouped by
   area (schema, mutations, transactions, proto, LLM, dump, ...).
 - **client_side_statement_def.go**: **CRITICAL** - all client-side statement
@@ -53,7 +53,7 @@ code comments before changing anything nearby; do not re-document them here.
 - **Transactions and locking**: `TransactionManager` in
   `internal/mycli/transaction_manager.go` - mutex rationale, the mandatory
   closure-based access helpers, the `WithLock` / `Locked` method-suffix
-  convention, and the SET LOCAL undo log.
+  convention, and SET LOCAL undo owned by `transactionContext`.
 - **Statement timeouts**: `Session.getTimeoutForStatement` in
   `internal/mycli/session.go` - timeouts are applied exactly once, at the
   `ExecuteStatement` boundary.

--- a/internal/mycli/heartbeat_owner_test.go
+++ b/internal/mycli/heartbeat_owner_test.go
@@ -45,13 +45,25 @@ type heartbeatRecord struct {
 	priority sppb.RequestOptions_Priority
 }
 
+type sqlObservation struct {
+	sql       string
+	reqTag    string
+	txnID     string
+	readOnly  bool
+	hadReadTs bool
+}
+
 type heartbeatRPCServer struct {
 	sppb.UnimplementedSpannerServer
 
-	mu         sync.Mutex
-	next       atomic.Uint64
-	sqlTxn     map[string]string
-	heartbeats []heartbeatRecord
+	mu          sync.Mutex
+	next        atomic.Uint64
+	sqlTxn      map[string]string
+	roIDs       map[string]struct{}
+	rwIDs       map[string]struct{}
+	heartbeats  []heartbeatRecord
+	sqlObs      []sqlObservation
+	failROQuery error
 
 	heartbeatStarted     chan struct{}
 	heartbeatStartedOnce sync.Once
@@ -64,10 +76,69 @@ func (s *heartbeatRPCServer) newTxnID() []byte {
 }
 
 func (s *heartbeatRPCServer) txnIDFor(r *sppb.ExecuteSqlRequest) []byte {
-	if id := r.GetTransaction().GetId(); len(id) > 0 {
+	sel := r.GetTransaction()
+	if id := sel.GetId(); len(id) > 0 {
 		return slices.Clone(id)
 	}
-	return s.newTxnID()
+	id := s.newTxnID()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.noteSelectorLocked(id, sel)
+	return id
+}
+
+func (s *heartbeatRPCServer) ensureTxnMapsLocked() {
+	if s.roIDs == nil {
+		s.roIDs = make(map[string]struct{})
+	}
+	if s.rwIDs == nil {
+		s.rwIDs = make(map[string]struct{})
+	}
+}
+
+func (s *heartbeatRPCServer) noteSelectorLocked(id []byte, sel *sppb.TransactionSelector) {
+	if sel == nil {
+		return
+	}
+	opts := sel.GetBegin()
+	if opts == nil {
+		opts = sel.GetSingleUse()
+	}
+	if opts == nil {
+		return
+	}
+	s.ensureTxnMapsLocked()
+	key := string(id)
+	switch {
+	case opts.GetReadOnly() != nil:
+		s.roIDs[key] = struct{}{}
+	case opts.GetReadWrite() != nil:
+		s.rwIDs[key] = struct{}{}
+	}
+}
+
+func (s *heartbeatRPCServer) isReadOnlyLocked(r *sppb.ExecuteSqlRequest, txnID []byte) bool {
+	sel := r.GetTransaction()
+	if sel.GetBegin().GetReadOnly() != nil || sel.GetSingleUse().GetReadOnly() != nil {
+		return true
+	}
+	if sel.GetBegin().GetReadWrite() != nil || sel.GetSingleUse().GetReadWrite() != nil {
+		return false
+	}
+	_, ok := s.roIDs[string(txnID)]
+	return ok
+}
+
+func (s *heartbeatRPCServer) setFailROQuery(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failROQuery = err
+}
+
+func (s *heartbeatRPCServer) sqlObservations() []sqlObservation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.sqlObs)
 }
 
 func (s *heartbeatRPCServer) noteSQL(r *sppb.ExecuteSqlRequest, txnID []byte) {
@@ -142,8 +213,19 @@ func (s *heartbeatRPCServer) DeleteSession(context.Context, *sppb.DeleteSessionR
 	return &emptypb.Empty{}, nil
 }
 
-func (s *heartbeatRPCServer) BeginTransaction(context.Context, *sppb.BeginTransactionRequest) (*sppb.Transaction, error) {
-	return &sppb.Transaction{Id: s.newTxnID()}, nil
+func (s *heartbeatRPCServer) BeginTransaction(_ context.Context, r *sppb.BeginTransactionRequest) (*sppb.Transaction, error) {
+	id := s.newTxnID()
+	txn := &sppb.Transaction{Id: id}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureTxnMapsLocked()
+	if r.GetOptions().GetReadOnly() != nil {
+		s.roIDs[string(id)] = struct{}{}
+		txn.ReadTimestamp = timestamppb.Now()
+	} else {
+		s.rwIDs[string(id)] = struct{}{}
+	}
+	return txn, nil
 }
 
 func (s *heartbeatRPCServer) Rollback(context.Context, *sppb.RollbackRequest) (*emptypb.Empty, error) {
@@ -155,24 +237,48 @@ func (s *heartbeatRPCServer) Commit(context.Context, *sppb.CommitRequest) (*sppb
 }
 
 func (s *heartbeatRPCServer) ExecuteSql(ctx context.Context, r *sppb.ExecuteSqlRequest) (*sppb.ResultSet, error) {
-	txnID := s.txnIDFor(r)
-	s.noteSQL(r, txnID)
-	if err := s.waitHeartbeatIfNeeded(ctx, r); err != nil {
+	txnID, readTs, err := s.prepareSQL(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-	return s.resultSet(txnID, readTimestampFor(r)), nil
+	return s.resultSet(txnID, readTs), nil
 }
 
 func (s *heartbeatRPCServer) ExecuteStreamingSql(r *sppb.ExecuteSqlRequest, stream sppb.Spanner_ExecuteStreamingSqlServer) error {
-	txnID := s.txnIDFor(r)
-	s.noteSQL(r, txnID)
-	if err := s.waitHeartbeatIfNeeded(stream.Context(), r); err != nil {
+	txnID, readTs, err := s.prepareSQL(stream.Context(), r)
+	if err != nil {
 		return err
 	}
 	return stream.Send(&sppb.PartialResultSet{
-		Metadata: s.resultSet(txnID, readTimestampFor(r)).Metadata,
+		Metadata: s.resultSet(txnID, readTs).Metadata,
 		Values:   []*structpb.Value{structpb.NewStringValue("1")},
 	})
+}
+
+func (s *heartbeatRPCServer) prepareSQL(ctx context.Context, r *sppb.ExecuteSqlRequest) ([]byte, *timestamppb.Timestamp, error) {
+	txnID := s.txnIDFor(r)
+	s.noteSQL(r, txnID)
+	if err := s.waitHeartbeatIfNeeded(ctx, r); err != nil {
+		return nil, nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ro := s.isReadOnlyLocked(r, txnID)
+	if ro && s.failROQuery != nil {
+		return nil, nil, s.failROQuery
+	}
+	var readTs *timestamppb.Timestamp
+	if ro {
+		readTs = timestamppb.Now()
+	}
+	s.sqlObs = append(s.sqlObs, sqlObservation{
+		sql:       r.GetSql(),
+		reqTag:    r.GetRequestOptions().GetRequestTag(),
+		txnID:     string(txnID),
+		readOnly:  ro,
+		hadReadTs: readTs != nil,
+	})
+	return txnID, readTs, nil
 }
 
 func (s *heartbeatRPCServer) waitHeartbeatIfNeeded(ctx context.Context, r *sppb.ExecuteSqlRequest) error {
@@ -196,15 +302,6 @@ func (s *heartbeatRPCServer) resultSet(txnID []byte, readTs *timestamppb.Timesta
 			Transaction: &sppb.Transaction{Id: txnID, ReadTimestamp: readTs},
 		},
 	}
-}
-
-func readTimestampFor(r *sppb.ExecuteSqlRequest) *timestamppb.Timestamp {
-	// ReadWriteStmtBasedTransaction.setTimestamp recurses if a read timestamp
-	// is present. Only the pending->RO SELECT 1 probe needs one.
-	if r.GetRequestOptions().GetRequestTag() == "spanner_mycli_heartbeat" || r.GetSql() != heartbeatSQL {
-		return nil
-	}
-	return timestamppb.Now()
 }
 
 type heartbeatHarness struct {
@@ -543,4 +640,60 @@ func TestHeartbeatPendingActivationKeepsOwner(t *testing.T) {
 		t.Fatalf("B heartbeat also hit A; heartbeats=%v A=%s B=%s", got, idA, idB)
 	}
 	assertHeartbeatMeta(t, h.server.heartbeatRecords())
+}
+
+func TestHeartbeatReadTimestampFollowsTransactionMode(t *testing.T) {
+	t.Parallel()
+	h := newHeartbeatHarness(t)
+	ctx := t.Context()
+
+	if err := h.tm.BeginReadWriteTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatalf("BeginReadWriteTransaction: %v", err)
+	}
+	iter, _, err := h.tm.RunQuery(ctx, spanner.NewStatement("SELECT 1"))
+	if err != nil {
+		t.Fatalf("RW SELECT 1: %v", err)
+	}
+	if _, _, _, _, err := consumeRowIterDiscard(iter); err != nil {
+		t.Fatalf("drain RW SELECT 1: %v", err)
+	}
+	var sawRW bool
+	for _, rec := range h.server.sqlObservations() {
+		if rec.sql != "SELECT 1" || rec.reqTag == "spanner_mycli_heartbeat" {
+			continue
+		}
+		if rec.readOnly {
+			t.Fatal("ordinary RW SELECT 1 classified as read-only")
+		}
+		if rec.hadReadTs {
+			t.Fatal("ordinary RW SELECT 1 received a read timestamp")
+		}
+		sawRW = true
+	}
+	if !sawRW {
+		t.Fatal("ordinary RW SELECT 1 was not observed")
+	}
+	if err := h.tm.RollbackReadWriteTransaction(ctx); err != nil {
+		t.Fatalf("rollback RW: %v", err)
+	}
+
+	if err := h.tm.BeginPendingTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tm.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatalf("pending RO activation: %v", err)
+	}
+	var sawRO bool
+	for _, rec := range h.server.sqlObservations() {
+		if !rec.readOnly {
+			continue
+		}
+		if !rec.hadReadTs {
+			t.Fatalf("RO query %q missing read timestamp", rec.sql)
+		}
+		sawRO = true
+	}
+	if !sawRO {
+		t.Fatal("RO activation query was not observed")
+	}
 }

--- a/internal/mycli/heartbeat_owner_test.go
+++ b/internal/mycli/heartbeat_owner_test.go
@@ -160,7 +160,7 @@ func (s *heartbeatRPCServer) ExecuteSql(ctx context.Context, r *sppb.ExecuteSqlR
 	if err := s.waitHeartbeatIfNeeded(ctx, r); err != nil {
 		return nil, err
 	}
-	return s.resultSet(txnID), nil
+	return s.resultSet(txnID, readTimestampFor(r)), nil
 }
 
 func (s *heartbeatRPCServer) ExecuteStreamingSql(r *sppb.ExecuteSqlRequest, stream sppb.Spanner_ExecuteStreamingSqlServer) error {
@@ -170,7 +170,7 @@ func (s *heartbeatRPCServer) ExecuteStreamingSql(r *sppb.ExecuteSqlRequest, stre
 		return err
 	}
 	return stream.Send(&sppb.PartialResultSet{
-		Metadata: s.resultSet(txnID).Metadata,
+		Metadata: s.resultSet(txnID, readTimestampFor(r)).Metadata,
 		Values:   []*structpb.Value{structpb.NewStringValue("1")},
 	})
 }
@@ -187,15 +187,24 @@ func (s *heartbeatRPCServer) waitHeartbeatIfNeeded(ctx context.Context, r *sppb.
 	}
 }
 
-func (s *heartbeatRPCServer) resultSet(txnID []byte) *sppb.ResultSet {
+func (s *heartbeatRPCServer) resultSet(txnID []byte, readTs *timestamppb.Timestamp) *sppb.ResultSet {
 	return &sppb.ResultSet{
 		Metadata: &sppb.ResultSetMetadata{
 			RowType: &sppb.StructType{Fields: []*sppb.StructType_Field{
 				{Name: "", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
 			}},
-			Transaction: &sppb.Transaction{Id: txnID},
+			Transaction: &sppb.Transaction{Id: txnID, ReadTimestamp: readTs},
 		},
 	}
+}
+
+func readTimestampFor(r *sppb.ExecuteSqlRequest) *timestamppb.Timestamp {
+	// ReadWriteStmtBasedTransaction.setTimestamp recurses if a read timestamp
+	// is present. Only the pending->RO SELECT 1 probe needs one.
+	if r.GetRequestOptions().GetRequestTag() == "spanner_mycli_heartbeat" || r.GetSql() != heartbeatSQL {
+		return nil
+	}
+	return timestamppb.Now()
 }
 
 type heartbeatHarness struct {
@@ -464,6 +473,74 @@ func TestHeartbeatInFlightAcquireStaysOnOriginalOwner(t *testing.T) {
 	got = h.server.heartbeatIDs()
 	if !slices.Equal(got, []string{idA, idB}) {
 		t.Fatalf("heartbeats=%v, want A then B (%s, %s)", got, idA, idB)
+	}
+	assertHeartbeatMeta(t, h.server.heartbeatRecords())
+}
+
+func TestHeartbeatPendingActivationKeepsOwner(t *testing.T) {
+	t.Parallel()
+	h := newHeartbeatHarness(t)
+	ctx := t.Context()
+	h.installBeforeAcquireBarrier()
+
+	if err := h.tm.BeginPendingTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatalf("BeginPendingTransaction: %v", err)
+	}
+	pending := txnContext(h.tm)
+	if _, err := h.tm.DetermineTransaction(ctx); err != nil {
+		t.Fatalf("pending activation: %v", err)
+	}
+	if txnContext(h.tm) != pending {
+		t.Fatal("pending activation replaced heartbeat owner identity")
+	}
+
+	iter, _, err := h.tm.RunQuery(ctx, spanner.NewStatement("SELECT 1 AS owner_a"))
+	if err != nil {
+		t.Fatalf("RunQuery: %v", err)
+	}
+	if _, _, _, _, err := consumeRowIterDiscard(iter); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if !h.tm.heartbeatEnabled() {
+		t.Fatal("first user operation did not enable heartbeat")
+	}
+	idA := h.server.txnIDForSQL("SELECT 1 AS owner_a")
+	if idA == "" {
+		t.Fatalf("no transaction id captured; records=%v", h.server.heartbeatRecords())
+	}
+
+	sendTick(t, h.ticks)
+	waitChan(t, h.arrived, "owner A eligibility snapshot")
+
+	if err := h.tm.RollbackReadWriteTransaction(ctx); err != nil {
+		t.Fatalf("rollback A: %v", err)
+	}
+	idB := beginRWAndProbe(t, ctx, h, "SELECT 1 AS owner_b")
+	if idA == idB {
+		t.Fatal("replacement owner reused transaction id A")
+	}
+	if txnContext(h.tm) == pending {
+		t.Fatal("replacement owner reused pending identity A")
+	}
+
+	close(h.release)
+	waitChan(t, h.attempt, "owner A delayed acquire attempt")
+
+	if got := h.server.heartbeatIDs(); slices.Contains(got, idB) {
+		t.Fatalf("delayed A tick issued SELECT 1 on replacement owner B (%s); heartbeats=%v A=%s B=%s", got, got, idA, idB)
+	}
+	if got := h.server.heartbeatIDs(); slices.Contains(got, idA) {
+		t.Fatalf("delayed A tick issued SELECT 1 after A ended; heartbeats=%v A=%s", got, idA)
+	}
+
+	sendTick(t, h.ticks)
+	waitChan(t, h.attempt, "owner B heartbeat attempt")
+	got := h.server.heartbeatIDs()
+	if !slices.Contains(got, idB) {
+		t.Fatalf("B heartbeat missing on B; heartbeats=%v B=%s", got, idB)
+	}
+	if slices.Contains(got, idA) {
+		t.Fatalf("B heartbeat also hit A; heartbeats=%v A=%s B=%s", got, idA, idB)
 	}
 	assertHeartbeatMeta(t, h.server.heartbeatRecords())
 }

--- a/internal/mycli/session_transaction_context.go
+++ b/internal/mycli/session_transaction_context.go
@@ -31,14 +31,21 @@ type transaction interface {
 	Query(ctx context.Context, statement spanner.Statement) *spanner.RowIterator
 }
 
-// transactionContext encapsulates the transaction state and attributes.
-// It provides safe access to the underlying transaction while maintaining
-// metadata about the transaction's mode and properties.
+// transactionContext is the logical transaction lifetime. It is allocated on
+// BEGIN (pending or direct RO/RW), kept as the same pointer through pending
+// activation, and retired only on a terminal path. Heartbeat, tag, and SET
+// LOCAL undo all live on this object so they cannot be split across replacement
+// owners.
 type transactionContext struct {
 	attrs           transactionAttributes
 	txn             transaction
 	heartbeatCancel context.CancelFunc
 	heartbeatFunc   func(ctx context.Context) // Function to run heartbeat
+	// localVarUndo is this transaction's SET LOCAL undo log. It survives
+	// pending activation and is detached into
+	// TransactionManager.pendingLocalVarRestore only when the context is
+	// retired.
+	localVarUndo []savedLocalVar
 }
 
 // EnableHeartbeat enables sending periodic heartbeats for this transaction.

--- a/internal/mycli/statements_set_local_test.go
+++ b/internal/mycli/statements_set_local_test.go
@@ -42,6 +42,22 @@ func mustGetVar(t *testing.T, session *Session, name string) string {
 	return value
 }
 
+func txnContext(tm *TransactionManager) *transactionContext {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	return tm.tc
+}
+
+func outstandingLocalUndo(tm *TransactionManager) int {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	n := len(tm.pendingLocalVarRestore)
+	if tm.tc != nil {
+		n += len(tm.tc.localVarUndo)
+	}
+	return n
+}
+
 func TestSetLocalRequiresTransaction(t *testing.T) {
 	t.Parallel()
 	session := newSessionForLocalVarTest(t)
@@ -343,11 +359,11 @@ func TestSessionCloseRestoresOutstandingLocal(t *testing.T) {
 		if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
 			t.Fatalf("Close lost session SET CLI_FORMAT: %q", got)
 		}
-		if n := len(session.txn.localVarUndo); n != 0 {
+		if n := outstandingLocalUndo(session.txn); n != 0 {
 			t.Fatalf("Close left %d stale undo entries", n)
 		}
 		session.Close()
-		if n := len(session.txn.localVarUndo); n != 0 {
+		if n := outstandingLocalUndo(session.txn); n != 0 {
 			t.Fatalf("repeated Close left %d undo entries", n)
 		}
 		if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
@@ -372,7 +388,7 @@ func TestSessionCloseRestoresOutstandingLocal(t *testing.T) {
 		if got := mustGetVar(t, session, "CLI_FORMAT"); got != "JSONL" {
 			t.Fatalf("Close left LOCAL over session SET: %q", got)
 		}
-		if n := len(session.txn.localVarUndo); n != 0 {
+		if n := outstandingLocalUndo(session.txn); n != 0 {
 			t.Fatalf("Close left %d stale undo entries", n)
 		}
 	})
@@ -410,7 +426,7 @@ func TestOrdinarySetSurvivesAutomaticQueryAbort(t *testing.T) {
 	if session.txn.InTransaction() {
 		t.Fatal("query abort left an active transaction")
 	}
-	if n := len(session.txn.localVarUndo); n != 0 {
+	if n := outstandingLocalUndo(session.txn); n != 0 {
 		t.Fatalf("query abort left %d stale undo entries", n)
 	}
 	if got := mustGetVar(t, session, "CLI_PROMPT"); got != wantPrompt {
@@ -432,7 +448,7 @@ func TestOrdinarySetSurvivesAutomaticQueryAbort(t *testing.T) {
 	if session.txn.InTransaction() {
 		t.Fatal("later ROLLBACK left an active transaction")
 	}
-	if n := len(session.txn.localVarUndo); n != 0 {
+	if n := outstandingLocalUndo(session.txn); n != 0 {
 		t.Fatalf("later transaction left %d undo entries", n)
 	}
 	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
@@ -466,6 +482,136 @@ func TestSetLocalTypeStylesRestoreDerivedState(t *testing.T) {
 	}
 	if session.systemVariables.typeStyles[sppb.TypeCode_STRING] != wantDerived {
 		t.Fatal("derived typeStyles not restored on LOCAL rollback")
+	}
+}
+
+func TestSetLocalOwnerADoesNotRestoreIntoB(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+	wantPrompt := mustGetVar(t, session, "CLI_PROMPT")
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	ownerA := txnContext(session.txn)
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &CommitStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("A COMMIT left LOCAL CLI_VERBOSE: %s", got)
+	}
+	if outstandingLocalUndo(session.txn) != 0 {
+		t.Fatal("A COMMIT left detached undo")
+	}
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	ownerB := txnContext(session.txn)
+	if ownerB == nil || ownerB == ownerA {
+		t.Fatal("B reused transaction A identity")
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_PROMPT", Value: "'B> '"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &CommitStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("A undo restored into B: CLI_VERBOSE=%s", got)
+	}
+	if got := mustGetVar(t, session, "CLI_PROMPT"); got != wantPrompt {
+		t.Fatalf("B LOCAL CLI_PROMPT not restored: %q want %q", got, wantPrompt)
+	}
+}
+
+func TestSetLocalNestedRunBatchDoesNotRestoreWhileActive(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	session.batch.SetCurrent(&ShowVariableStatement{VarName: "CLI_VERBOSE"})
+	if _, err := session.ExecuteStatement(ctx, &RunBatchStatement{}); err != nil {
+		t.Fatalf("nested RUN BATCH: %v", err)
+	}
+	if !session.txn.InTransaction() {
+		t.Fatal("nested RUN BATCH restored/retired an active transaction")
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("nested RUN BATCH restored LOCAL while A was active: %s", got)
+	}
+	if outstandingLocalUndo(session.txn) == 0 {
+		t.Fatal("nested RUN BATCH detached A's undo while A was active")
+	}
+	if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("ROLLBACK after nested RUN BATCH: %s", got)
+	}
+}
+
+func TestSetLocalNestedRunBatchEndThenBeginB(t *testing.T) {
+	t.Parallel()
+	session := newSessionForLocalVarTest(t)
+	ctx := t.Context()
+	wantPrompt := mustGetVar(t, session, "CLI_PROMPT")
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	ownerA := txnContext(session.txn)
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	session.batch.SetCurrent(&RollbackStatement{})
+	if _, err := session.ExecuteStatement(ctx, &RunBatchStatement{}); err != nil {
+		t.Fatalf("nested RUN BATCH ROLLBACK: %v", err)
+	}
+	if session.txn.InTransaction() {
+		t.Fatal("nested RUN BATCH ROLLBACK left a transaction")
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("nested ROLLBACK did not restore before next BEGIN: %s", got)
+	}
+	if outstandingLocalUndo(session.txn) != 0 {
+		t.Fatal("nested ROLLBACK left detached undo for B")
+	}
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	ownerB := txnContext(session.txn)
+	if ownerB == nil || ownerB == ownerA {
+		t.Fatal("B reused transaction A identity")
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_PROMPT", Value: "'B> '"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &CommitStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("A undo restored into B after nested RUN BATCH: CLI_VERBOSE=%s", got)
+	}
+	if got := mustGetVar(t, session, "CLI_PROMPT"); got != wantPrompt {
+		t.Fatalf("B LOCAL CLI_PROMPT: %q want %q", got, wantPrompt)
 	}
 }
 

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -93,8 +93,8 @@ func (s *SetStatement) Execute(ctx context.Context, session *Session) (*Result, 
 
 // SetLocalStatement implements `SET LOCAL <name> = <value>`: the change is
 // scoped to the current transaction. The previous value is recorded in the
-// transaction's undo log (TransactionManager.localVarUndo) and restored when
-// the transaction ends, whether by COMMIT, ROLLBACK, or CLOSE.
+// transactionContext undo log and restored when the transaction ends, whether
+// by COMMIT, ROLLBACK, or CLOSE.
 // Following java-spanner, SET LOCAL outside a transaction is an error.
 type SetLocalStatement struct {
 	VarName string

--- a/internal/mycli/transaction_context_cohesion_test.go
+++ b/internal/mycli/transaction_context_cohesion_test.go
@@ -1,6 +1,16 @@
 // Copyright 2026 apstndb
 //
-// Licensed under the MIT License.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package mycli
 
@@ -10,6 +20,8 @@ import (
 	"time"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestTransactionContextIdentityMatrix(t *testing.T) {
@@ -213,4 +225,77 @@ func TestTransactionContextPendingActivationReadOnlyKeepsIdentity(t *testing.T) 
 	if txnContext(h.tm) == pending {
 		t.Fatal("RO close reused the retired identity")
 	}
+}
+
+func sessionForTM(t *testing.T, tm *TransactionManager) *Session {
+	t.Helper()
+	tm.sysVars.ensureRegistry()
+	tm.sysVars.inTransaction = tm.InTransaction
+	return &Session{
+		mode:            DatabaseConnected,
+		systemVariables: tm.sysVars,
+		connection:      tm.sysVars.Connection,
+		txn:             tm,
+	}
+}
+
+func TestTransactionContextFailedROActivationPreservesPending(t *testing.T) {
+	t.Parallel()
+	h := newHeartbeatHarness(t)
+	ctx := t.Context()
+	session := sessionForTM(t, h.tm)
+	const injected = "injected RO activation failure for pending identity"
+
+	if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "TRANSACTION_TAG", Value: "'keep'"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	pending := txnContext(h.tm)
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	undoBefore := outstandingLocalUndo(h.tm)
+	if undoBefore == 0 {
+		t.Fatal("SET LOCAL did not record undo on the pending context")
+	}
+
+	h.server.setFailROQuery(status.Error(codes.PermissionDenied, injected))
+	_, err := h.tm.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, sppb.RequestOptions_PRIORITY_UNSPECIFIED)
+	if err == nil || !strings.Contains(err.Error(), injected) {
+		t.Fatalf("RO activation: %v", err)
+	}
+	if txnContext(h.tm) != pending {
+		t.Fatal("failed RO activation replaced pending identity")
+	}
+	if pending.attrs.mode != transactionModePending {
+		t.Fatalf("mode after failed RO = %q, want pending", pending.attrs.mode)
+	}
+	if pending.txn != nil {
+		t.Fatal("failed RO activation installed an SDK handle")
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("failed RO activation restored LOCAL: %s", got)
+	}
+	if outstandingLocalUndo(h.tm) != undoBefore {
+		t.Fatal("failed RO activation changed SET LOCAL undo")
+	}
+	assertTagSurfaces(t, session, "keep")
+
+	h.server.setFailROQuery(nil)
+	if _, err := h.tm.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatalf("RO retry: %v", err)
+	}
+	active := txnContext(h.tm)
+	if active != pending {
+		t.Fatal("successful RO retry replaced pending identity")
+	}
+	if active.attrs.mode != transactionModeReadOnly {
+		t.Fatalf("mode after RO retry = %q, want read-only", active.attrs.mode)
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("SET LOCAL did not survive RO retry: %s", got)
+	}
+	assertTagSurfaces(t, session, "keep")
 }

--- a/internal/mycli/transaction_context_cohesion_test.go
+++ b/internal/mycli/transaction_context_cohesion_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the MIT License.
+
+package mycli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+)
+
+func TestTransactionContextIdentityMatrix(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("idle to pending allocates", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		if txnContext(session.txn) != nil {
+			t.Fatal("idle session already had a transactionContext")
+		}
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		owner := txnContext(session.txn)
+		if owner == nil {
+			t.Fatal("BEGIN did not allocate a transactionContext")
+		}
+		if owner.attrs.mode != transactionModePending {
+			t.Fatalf("mode = %q, want pending", owner.attrs.mode)
+		}
+	})
+
+	t.Run("failed activation preserves pending identity state tag and undo", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		if _, err := session.ExecuteStatement(ctx, &SetStatement{VarName: "TRANSACTION_TAG", Value: "'keep'"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		pending := txnContext(session.txn)
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+			t.Fatal(err)
+		}
+		undoBefore := outstandingLocalUndo(session.txn)
+		if undoBefore == 0 {
+			t.Fatal("SET LOCAL did not record undo on the pending context")
+		}
+
+		err := session.txn.BeginReadWriteTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED)
+		if err == nil || !strings.Contains(err.Error(), "database operation requires a database connection") {
+			t.Fatalf("BEGIN RW: %v", err)
+		}
+		if txnContext(session.txn) != pending {
+			t.Fatal("failed RW activation replaced pending identity")
+		}
+		if pending.attrs.mode != transactionModePending {
+			t.Fatalf("mode after failed RW = %q, want pending", pending.attrs.mode)
+		}
+		if pending.txn != nil {
+			t.Fatal("failed RW activation installed an SDK handle")
+		}
+		if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+			t.Fatalf("failed RW activation restored LOCAL: %s", got)
+		}
+		if outstandingLocalUndo(session.txn) != undoBefore {
+			t.Fatal("failed RW activation changed SET LOCAL undo")
+		}
+		assertTagSurfaces(t, session, "keep")
+
+		_, err = session.txn.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, sppb.RequestOptions_PRIORITY_UNSPECIFIED)
+		if err == nil || !strings.Contains(err.Error(), "database operation requires a database connection") {
+			t.Fatalf("BEGIN RO: %v", err)
+		}
+		if txnContext(session.txn) != pending {
+			t.Fatal("failed RO activation replaced pending identity")
+		}
+		if pending.attrs.mode != transactionModePending {
+			t.Fatalf("mode after failed RO = %q, want pending", pending.attrs.mode)
+		}
+		if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+			t.Fatalf("failed RO activation restored LOCAL: %s", got)
+		}
+		assertTagSurfaces(t, session, "keep")
+
+		if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		if txnContext(session.txn) != nil {
+			t.Fatal("ROLLBACK left a transactionContext")
+		}
+		if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+			t.Fatalf("ROLLBACK after failed activation: %s", got)
+		}
+		assertTagSurfaces(t, session, "keep")
+	})
+
+	t.Run("active to idle retires exactly once and next begin is a new identity", func(t *testing.T) {
+		t.Parallel()
+		session := newSessionForLocalVarTest(t)
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		ownerA := txnContext(session.txn)
+		if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.ExecuteStatement(ctx, &RollbackStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		if txnContext(session.txn) != nil {
+			t.Fatal("terminal path left transactionContext")
+		}
+		if outstandingLocalUndo(session.txn) != 0 {
+			t.Fatal("terminal path left SET LOCAL undo")
+		}
+		session.txn.clearTransactionContext()
+		if txnContext(session.txn) != nil || outstandingLocalUndo(session.txn) != 0 {
+			t.Fatal("repeated retire was not a no-op")
+		}
+		if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+			t.Fatalf("repeated retire changed restored value: %s", got)
+		}
+
+		if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+			t.Fatal(err)
+		}
+		ownerB := txnContext(session.txn)
+		if ownerB == nil || ownerB == ownerA {
+			t.Fatal("idle-to-pending reused the previous identity")
+		}
+	})
+}
+
+func TestTransactionContextPendingActivationKeepsIdentityAndUndo(t *testing.T) {
+	t.Parallel()
+	h := newHeartbeatHarness(t)
+	ctx := t.Context()
+	session := &Session{
+		mode:            DatabaseConnected,
+		systemVariables: h.tm.sysVars,
+		connection:      h.tm.sysVars.Connection,
+		txn:             h.tm,
+	}
+	h.tm.sysVars.ensureRegistry()
+	h.tm.sysVars.inTransaction = h.tm.InTransaction
+
+	if _, err := session.ExecuteStatement(ctx, &BeginStatement{}); err != nil {
+		t.Fatal(err)
+	}
+	pending := txnContext(h.tm)
+	if _, err := session.ExecuteStatement(ctx, &SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tm.DetermineTransaction(ctx); err != nil {
+		t.Fatalf("pending activation: %v", err)
+	}
+	active := txnContext(h.tm)
+	if active != pending {
+		t.Fatal("pending activation replaced transactionContext")
+	}
+	if active.attrs.mode != transactionModeReadWrite {
+		t.Fatalf("mode after activation = %q, want read-write", active.attrs.mode)
+	}
+	if active.txn == nil {
+		t.Fatal("activation did not install an SDK handle")
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "TRUE" {
+		t.Fatalf("SET LOCAL did not survive pending activation: %s", got)
+	}
+	if outstandingLocalUndo(h.tm) == 0 {
+		t.Fatal("pending activation dropped SET LOCAL undo")
+	}
+
+	if err := h.tm.RollbackReadWriteTransaction(ctx); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	h.tm.restoreLocalVarsIfIdle()
+	if txnContext(h.tm) == pending {
+		t.Fatal("terminal path reused the retired identity")
+	}
+	if got := mustGetVar(t, session, "CLI_VERBOSE"); got != "FALSE" {
+		t.Fatalf("rollback after activation: %s", got)
+	}
+}
+
+func TestTransactionContextPendingActivationReadOnlyKeepsIdentity(t *testing.T) {
+	t.Parallel()
+	h := newHeartbeatHarness(t)
+	ctx := t.Context()
+	if err := h.tm.BeginPendingTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatal(err)
+	}
+	pending := txnContext(h.tm)
+	if _, err := h.tm.BeginReadOnlyTransaction(ctx, timestampBoundUnspecified, 0, time.Time{}, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+		t.Fatalf("pending RO activation: %v", err)
+	}
+	active := txnContext(h.tm)
+	if active != pending {
+		t.Fatal("pending RO activation replaced transactionContext")
+	}
+	if active.attrs.mode != transactionModeReadOnly {
+		t.Fatalf("mode after RO activation = %q, want read-only", active.attrs.mode)
+	}
+	if err := h.tm.CloseReadOnlyTransaction(); err != nil {
+		t.Fatalf("close RO: %v", err)
+	}
+	if txnContext(h.tm) == pending {
+		t.Fatal("RO close reused the retired identity")
+	}
+}

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -129,17 +129,16 @@ type TransactionManager struct {
 	sysVars      *systemVariables     // same pointer as Session.systemVariables
 	clientConfig spanner.ClientConfig // for directed read in tryQueryInTransaction
 
-	// localVarUndo records (name, previous value) pairs for system variables
-	// changed by SET LOCAL in the current transaction. Guarded by mu.
-	// It lives on the TransactionManager rather than on transactionContext so it
-	// survives the pending -> active context replacement in Begin*TransactionLocked.
-	localVarUndo []savedLocalVar
+	// pendingLocalVarRestore holds SET LOCAL undo detached from a retired
+	// transactionContext under tm.mu. Registry.Set replay happens only after
+	// unlocking, at Session.ExecuteStatement / Session.Close. Direct manager
+	// calls do not acquire a new automatic restoration contract.
+	pendingLocalVarRestore []savedLocalVar
 
 	// autoDML is the transaction-owned automatic DML queue. Manual START/RUN/ABORT
-	// batches stay on Session.batch. Do not store this list on transactionContext:
-	// that struct is replaced pending->active, owns the heartbeat, and sits behind
-	// non-reentrant mu. autoDMLGeneration identifies the RW transaction that
-	// accepted the work so leftover statements cannot execute in a later owner.
+	// batches stay on Session.batch. The queue remains on TransactionManager
+	// with generation/owner guards so leftover statements cannot execute in a
+	// later RW owner.
 	autoDML           []spanner.Statement
 	autoDMLOwner      uint64
 	autoDMLGeneration uint64
@@ -318,7 +317,7 @@ func (tm *TransactionManager) pushLocalVarUndo(name, oldValue string) error {
 		if *tcPtr == nil {
 			return ErrNoTransaction
 		}
-		tm.localVarUndo = append(tm.localVarUndo, savedLocalVar{name: name, oldValue: oldValue})
+		(*tcPtr).localVarUndo = append((*tcPtr).localVarUndo, savedLocalVar{name: name, oldValue: oldValue})
 		return nil
 	})
 }
@@ -329,30 +328,31 @@ func (tm *TransactionManager) pushLocalVarUndo(name, oldValue string) error {
 // inspect transaction state and tm.mu is not reentrant.
 func (tm *TransactionManager) retireLocalVarUndo(canonical string) {
 	_ = tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
-		if *tcPtr == nil || len(tm.localVarUndo) == 0 {
+		if *tcPtr == nil || len((*tcPtr).localVarUndo) == 0 {
 			return nil
 		}
-		tm.localVarUndo = slices.DeleteFunc(tm.localVarUndo, func(e savedLocalVar) bool {
+		(*tcPtr).localVarUndo = slices.DeleteFunc((*tcPtr).localVarUndo, func(e savedLocalVar) bool {
 			return e.name == canonical
 		})
 		return nil
 	})
 }
 
-// restoreLocalVarsIfIdle replays the SET LOCAL undo log once the transaction has
-// ended. SET LOCAL values revert on commit, rollback, and close alike, so instead
-// of hooking every transaction-ending site (including automatic rollback on
-// statement error), this runs after each statement execution and acts only when
-// no transaction context remains. Replay happens outside the lock because
-// variable setters may themselves inspect transaction state.
+// restoreLocalVarsIfIdle replays detached SET LOCAL undo once no transaction
+// context remains. SET LOCAL values revert on commit, rollback, and close
+// alike, so instead of hooking every transaction-ending site (including automatic
+// rollback on statement error), this runs after each statement execution and
+// acts only when idle. Replay happens outside the lock because variable
+// setters may themselves inspect transaction state. Nested ExecuteStatement
+// does not restore while a transaction is still active.
 func (tm *TransactionManager) restoreLocalVarsIfIdle() {
 	var entries []savedLocalVar
 	_ = tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
-		if *tcPtr != nil || len(tm.localVarUndo) == 0 {
+		if *tcPtr != nil || len(tm.pendingLocalVarRestore) == 0 {
 			return nil
 		}
-		entries = tm.localVarUndo
-		tm.localVarUndo = nil
+		entries = tm.pendingLocalVarRestore
+		tm.pendingLocalVarRestore = nil
 		return nil
 	})
 
@@ -369,16 +369,41 @@ func (tm *TransactionManager) restoreLocalVarsIfIdle() {
 	}
 }
 
+// retireTransactionContextLocked stops heartbeat, detaches SET LOCAL undo into
+// pendingLocalVarRestore, clears tc, and discards leftover automatic DML.
+// Caller must hold tm.mu. Safe when tc is already nil. Does not call
+// registry setters.
+func (tm *TransactionManager) retireTransactionContextLocked() {
+	if tm.tc != nil {
+		tm.tc.Close()
+		if n := len(tm.tc.localVarUndo); n > 0 {
+			tm.pendingLocalVarRestore = append(tm.pendingLocalVarRestore, tm.tc.localVarUndo...)
+			tm.tc.localVarUndo = nil
+		}
+		tm.tc = nil
+	}
+	tm.discardAutomaticDMLLocked()
+}
+
+// activateTransactionLocked installs an SDK handle and resolved attributes on
+// the existing pending context, or allocates a new context when idle. Pending
+// SET LOCAL undo is left on the object. Caller must hold tm.mu.
+func (tm *TransactionManager) activateTransactionLocked(attrs transactionAttributes, txn transaction) *transactionContext {
+	owner := tm.tc
+	if owner == nil {
+		owner = &transactionContext{}
+		tm.tc = owner
+	}
+	owner.attrs = attrs
+	owner.txn = txn
+	return owner
+}
+
 // clearTransactionContext atomically clears the transaction context.
 // This is equivalent to setTransactionContext(nil) but more expressive.
 func (tm *TransactionManager) clearTransactionContext() {
 	_ = tm.withTransactionContextWithLock(func(tcPtr **transactionContext) error {
-		// Close the transaction context to stop any running heartbeat
-		if *tcPtr != nil {
-			(*tcPtr).Close()
-		}
-		*tcPtr = nil
-		tm.discardAutomaticDMLLocked()
+		tm.retireTransactionContextLocked()
 		return nil
 	})
 }
@@ -641,9 +666,8 @@ func (tm *TransactionManager) BeginReadWriteTransactionLocked(ctx context.Contex
 		return fmt.Errorf("%s transaction is already running", tm.tc.attrs.mode)
 	}
 
-	oldTc := tm.tc
-
-	// Create the new transaction
+	// Construct/validate the SDK handle before mutating the pending object.
+	// Failure retains identity, SET LOCAL undo, and the next-owner tag slot.
 	txn, err := spanner.NewReadWriteStmtBasedTransactionWithOptions(ctx, tm.client, opts)
 	if err != nil {
 		return err
@@ -652,32 +676,23 @@ func (tm *TransactionManager) BeginReadWriteTransactionLocked(ctx context.Contex
 		tm.sysVars.Transaction.TransactionTag = ""
 	}
 
-	// Cleanup old transaction context if it's being replaced
-	if oldTc != nil {
-		oldTc.Close()
-	}
-
-	// A new RW owner must not inherit leftover automatic work. Pending->active
-	// replacement is not a terminal discard of a live owner; any residual here
-	// is cross-owner and is dropped rather than replayed.
+	// A new RW owner must not inherit leftover automatic work. Pending
+	// activation is not a terminal discard of a live owner; any residual
+	// here is cross-owner and is dropped rather than replayed.
 	tm.autoDMLGeneration++
 	tm.discardAutomaticDMLLocked()
 
-	// Set new transaction context. The heartbeat loop closes over this owner so
-	// a delayed tick cannot borrow a later replacement in tm.tc (#922).
-	tc := &transactionContext{
-		attrs: transactionAttributes{
-			mode:           transactionModeReadWrite,
-			tag:            tag,
-			priority:       resolvedPriority,
-			isolationLevel: resolvedIsolationLevel,
-		},
-		txn: txn,
+	// Keep the pending pointer through activation. The heartbeat loop closes
+	// over this owner so a delayed tick cannot borrow a later replacement (#922).
+	owner := tm.activateTransactionLocked(transactionAttributes{
+		mode:           transactionModeReadWrite,
+		tag:            tag,
+		priority:       resolvedPriority,
+		isolationLevel: resolvedIsolationLevel,
+	}, txn)
+	owner.heartbeatFunc = func(ctx context.Context) {
+		tm.startHeartbeat(ctx, owner)
 	}
-	tc.heartbeatFunc = func(ctx context.Context) {
-		tm.startHeartbeat(ctx, tc)
-	}
-	tm.tc = tc
 
 	// Heartbeat will be started by EnableHeartbeat() after the first operation.
 	// For implicit transactions, they commit immediately so heartbeat isn't needed.
@@ -716,12 +731,10 @@ func (tm *TransactionManager) CommitReadWriteTransactionLocked(ctx context.Conte
 		resp, err = rwTxn.CommitWithReturnResp(ctx)
 	}
 
-	// Always clear transaction context after commit attempt.
+	// Always retire the transaction context after commit attempt.
 	// A failed commit invalidates the transaction on the server,
-	// so we must clear the context regardless of the outcome.
-	tm.tc.Close()
-	tm.tc = nil
-	tm.discardAutomaticDMLLocked()
+	// so we must retire regardless of the outcome.
+	tm.retireTransactionContextLocked()
 
 	// Return the response and error as-is, preserving any partial commit info
 	return resp, err
@@ -752,10 +765,7 @@ func (tm *TransactionManager) RollbackReadWriteTransactionLocked(ctx context.Con
 
 	rwTxn.Rollback(ctx)
 
-	// Clear transaction context after rollback
-	tm.tc.Close()
-	tm.tc = nil
-	tm.discardAutomaticDMLLocked()
+	tm.retireTransactionContextLocked()
 
 	return nil
 }
@@ -800,7 +810,6 @@ func (tm *TransactionManager) BeginReadOnlyTransactionLocked(ctx context.Context
 		return time.Time{}, fmt.Errorf("%s transaction is already running", tm.tc.attrs.mode)
 	}
 
-	oldTc := tm.tc
 	txn := tm.client.ReadOnlyTransaction().WithTimestampBound(tb)
 
 	// Because google-cloud-go/spanner defers calling BeginTransaction RPC until an actual query is run,
@@ -821,19 +830,10 @@ func (tm *TransactionManager) BeginReadOnlyTransactionLocked(ctx context.Context
 		return time.Time{}, err
 	}
 
-	// Cleanup old transaction context if it's being replaced
-	if oldTc != nil {
-		oldTc.Close()
-	}
-
-	// Set new transaction context
-	tm.tc = &transactionContext{
-		attrs: transactionAttributes{
-			mode:     transactionModeReadOnly,
-			priority: resolvedPriority,
-		},
-		txn: txn,
-	}
+	tm.activateTransactionLocked(transactionAttributes{
+		mode:     transactionModeReadOnly,
+		priority: resolvedPriority,
+	}, txn)
 
 	return resultTimestamp, nil
 }
@@ -875,10 +875,7 @@ func (tm *TransactionManager) closeTransactionWithMode(mode transactionMode, clo
 			}
 		}
 
-		// Close and clear the transaction context
-		(*tcPtr).Close()
-		*tcPtr = nil
-		tm.discardAutomaticDMLLocked()
+		tm.retireTransactionContextLocked()
 		return nil
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #923. Tracking: #911.

Pending BEGIN currently allocates a `transactionContext`, then RO/RW activation replaces it. SET LOCAL undo therefore lived on `TransactionManager` so it could survive that replacement, while heartbeat/tag state lived on the replaced object.

This PR treats `transactionContext` as the logical transaction lifetime: allocate on BEGIN (pending or direct RO/RW), keep the same pointer through successful activation, and retire it only on a terminal path. SDK handles are constructed/validated before the pending object's active fields change. Failure keeps pending identity, SET LOCAL undo, and the next-owner tag slot.

## Behavior

- Idle → pending/RO/RW allocates; pending → RO/RW keeps identity; failed activation preserves pending identity/state/tag/undo; active → idle retires exactly once; idle → a new transaction never reuses the previous identity.
- SET LOCAL undo lives on the context, survives pending activation, detaches exactly once at terminal sites under `tm.mu` into `pendingLocalVarRestore`, and restores through `Registry.Set` only after unlock at `Session.ExecuteStatement` / `Session.Close`.
- Through `Session.ExecuteStatement`, undo from owner A cannot restore into B, including nested `RUN BATCH`. Nested execution does not restore while a transaction is still active.
- Automatic-DML generation/owner guards, heartbeat owner proofs, `SetClient` rejection while any context exists, and existing RW callback/commit lock scopes are unchanged.

## Review follow-up

- Apache-2.0 header on `transaction_context_cohesion_test.go`.
- Heartbeat fake attaches a read timestamp from the transaction selector/mode, not SQL text. Ordinary RW `SELECT 1` gets none; the RO activation query does.
- Failed RO activation is injected at the SELECT 1 RPC. Pending pointer, mode, undo, and next-owner tag stay intact; a successful retry keeps the same pointer.

## Validation

```sh
go test -short ./internal/mycli/... -run 'Transaction|SetLocal|AutomaticDML|Heartbeat'
make check-race
make check
```

All three completed with exit 0. Coverage floor remains 80%.

## Changed files

- `internal/mycli/session_transaction_context.go` — undo log on the logical context
- `internal/mycli/transaction_manager.go` — in-place activation; retirement helper; pending restore slice
- `internal/mycli/statements_system_variable.go` — comment
- `internal/mycli/statements_set_local_test.go` — A/B isolation and nested RUN BATCH
- `internal/mycli/transaction_context_cohesion_test.go` — identity matrix, pending activation, failed RO RPC
- `internal/mycli/heartbeat_owner_test.go` — pending activation keeps heartbeat owner; selector-based RO timestamps
- `dev-docs/architecture-guide.md` — undo ownership note

Deleted: pending-replacement `Close` in `Begin*Locked`; manager-wide `localVarUndo`.

No automatic-DML guard deletion, RPC lock-scope change, dependency upgrades, coverage-floor change, or unrelated cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4aa8f59-1f19-52a9-8598-f707b0c118e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4aa8f59-1f19-52a9-8598-f707b0c118e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

