### PR TITLE
Store automatic DML on its transaction context

### DIFF
--- a/dev-docs/architecture-guide.md
+++ b/dev-docs/architecture-guide.md
@@ -22,7 +22,8 @@ Key files in `internal/mycli`:
 - **session.go**: `Session` (Spanner clients, statement execution boundary) and
   `SessionHandler` (USE/DETACH database switching).
 - **transaction_manager.go**: `TransactionManager` (transaction state, mutex,
-  pending SET LOCAL restore). `transactionContext` owns active SET LOCAL undo.
+  pending SET LOCAL restore). `transactionContext` owns active SET LOCAL undo
+  and the automatic DML queue.
 - **statements.go / statements_*.go**: statement implementations grouped by
   area (schema, mutations, transactions, proto, LLM, dump, ...).
 - **client_side_statement_def.go**: **CRITICAL** - all client-side statement
@@ -53,7 +54,7 @@ code comments before changing anything nearby; do not re-document them here.
 - **Transactions and locking**: `TransactionManager` in
   `internal/mycli/transaction_manager.go` - mutex rationale, the mandatory
   closure-based access helpers, the `WithLock` / `Locked` method-suffix
-  convention, and SET LOCAL undo owned by `transactionContext`.
+  convention, and SET LOCAL undo and automatic DML owned by `transactionContext`.
 - **Statement timeouts**: `Session.getTimeoutForStatement` in
   `internal/mycli/session.go` - timeouts are applied exactly once, at the
   `ExecuteStatement` boundary.

--- a/internal/mycli/batch_manager.go
+++ b/internal/mycli/batch_manager.go
@@ -74,7 +74,7 @@ func (b *BatchManager) Current() Statement {
 }
 
 // SetCurrent directly sets the current batch statement.
-// Automatic DML is stored on TransactionManager; this remains for tests and
+// Automatic DML is stored on transactionContext; this remains for tests and
 // any caller that must install a manual batch without Start.
 func (b *BatchManager) SetCurrent(stmt Statement) {
 	b.current = stmt

--- a/internal/mycli/execute_ddl_test.go
+++ b/internal/mycli/execute_ddl_test.go
@@ -155,7 +155,9 @@ func TestBufferOrExecuteDdlStatements(t *testing.T) {
 	t.Run("rejects queued automatic DML", func(t *testing.T) {
 		t.Parallel()
 		session := newSessionForLocalVarTest(t)
-		session.txn.autoDML = []spanner.Statement{{SQL: "INSERT INTO t (id) VALUES (1)"}}
+		session.txn.tc = &transactionContext{
+			autoDML: []spanner.Statement{{SQL: "INSERT INTO t (id) VALUES (1)"}},
+		}
 		_, err := bufferOrExecuteDdlStatements(t.Context(), session, []string{"CREATE TABLE t (id INT64) PRIMARY KEY (id)"})
 		if err == nil || !strings.Contains(err.Error(), "active batch DML") {
 			t.Fatalf("error = %v, want active batch DML", err)

--- a/internal/mycli/execute_dml_auto_batch_test.go
+++ b/internal/mycli/execute_dml_auto_batch_test.go
@@ -17,12 +17,14 @@ package mycli
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/spanner"
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -500,7 +502,6 @@ func TestEnqueueAutomaticDMLEnablesHeartbeat(t *testing.T) {
 		},
 	}
 	t.Cleanup(tm.tc.Close)
-	tm.autoDMLGeneration = 1
 	ok, err := tm.TryEnqueueAutomaticDML(spanner.NewStatement("INSERT INTO t (id) VALUES (1)"))
 	if err != nil || !ok {
 		t.Fatalf("TryEnqueueAutomaticDML: ok=%v err=%v", ok, err)
@@ -522,12 +523,204 @@ func TestAutomaticDMLDiscardedOnClear(t *testing.T) {
 	t.Parallel()
 	sysVars := newSystemVariablesWithDefaultsForTest()
 	tm := NewTransactionManager(nil, sysVars, spanner.ClientConfig{})
-	tm.autoDML = []spanner.Statement{{SQL: "INSERT INTO t (id) VALUES (1)"}}
-	tm.autoDMLOwner = 1
+	owner := &transactionContext{
+		attrs:   transactionAttributes{mode: transactionModeReadWrite},
+		autoDML: []spanner.Statement{{SQL: "INSERT INTO t (id) VALUES (1)"}},
+	}
+	tm.tc = owner
 	tm.clearTransactionContext()
 	if tm.HasAutomaticDML() {
 		t.Fatal("clearTransactionContext left automatic DML")
 	}
+	if len(owner.autoDML) != 0 {
+		t.Fatal("retired owner still held automatic DML")
+	}
+}
+
+func TestFlushAutomaticDMLEmptyDoesNotStartTransaction(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("idle manager", func(t *testing.T) {
+		t.Parallel()
+		sysVars := newSystemVariablesWithDefaultsForTest()
+		tm := NewTransactionManager(nil, sysVars, spanner.ClientConfig{})
+		res, err := tm.FlushAutomaticDML(ctx)
+		if err != nil || res != nil {
+			t.Fatalf("empty idle flush: res=%v err=%v", res, err)
+		}
+		if txnContext(tm) != nil {
+			t.Fatal("empty flush created a transaction")
+		}
+	})
+
+	t.Run("empty RW owner", func(t *testing.T) {
+		t.Parallel()
+		h := newHeartbeatHarness(t)
+		if err := h.tm.BeginReadWriteTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+			t.Fatal(err)
+		}
+		owner := txnContext(h.tm)
+		res, err := h.tm.FlushAutomaticDML(ctx)
+		if err != nil || res != nil {
+			t.Fatalf("empty RW flush: res=%v err=%v", res, err)
+		}
+		if txnContext(h.tm) != owner || owner.attrs.mode != transactionModeReadWrite {
+			t.Fatal("empty flush replaced or retired the RW owner")
+		}
+		if len(h.server.batchObservations()) != 0 {
+			t.Fatal("empty flush issued BatchUpdate")
+		}
+	})
+}
+
+func TestAutomaticDMLStaleWorkDoesNotCrossReplacementOwner(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	const staleSQL = "INSERT INTO AutoDMLStale (id) VALUES (1)"
+	injectedFlush := status.Error(codes.PermissionDenied, "injected automatic DML BatchUpdate failure")
+	injectedAbort := status.Error(codes.Aborted, "injected collector abort for automatic DML")
+
+	for _, tc := range []struct {
+		name         string
+		endA         func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness)
+		wantStaleOnA bool
+	}{
+		{
+			name: "commit",
+			endA: func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness) {
+				t.Helper()
+				if _, err := h.tm.CommitReadWriteTransaction(ctx); err != nil {
+					t.Fatalf("commit A: %v", err)
+				}
+			},
+			wantStaleOnA: true,
+		},
+		{
+			name: "rollback",
+			endA: func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness) {
+				t.Helper()
+				if err := h.tm.RollbackReadWriteTransaction(ctx); err != nil {
+					t.Fatalf("rollback A: %v", err)
+				}
+			},
+		},
+		{
+			name: "close",
+			endA: func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness) {
+				t.Helper()
+				session.txn.clearTransactionContext()
+			},
+		},
+		{
+			name: "abort",
+			endA: func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness) {
+				t.Helper()
+				if _, err := session.ExecuteStatement(ctx, &AbortBatchStatement{}); err != nil {
+					t.Fatalf("ABORT BATCH: %v", err)
+				}
+				if session.txn.HasAutomaticDML() {
+					t.Fatal("ABORT BATCH left automatic DML")
+				}
+				if txnContext(h.tm) == nil || txnContext(h.tm).attrs.mode != transactionModeReadWrite {
+					t.Fatal("ABORT BATCH retired the RW owner")
+				}
+				if _, err := h.tm.CommitReadWriteTransaction(ctx); err != nil {
+					t.Fatalf("commit after ABORT BATCH: %v", err)
+				}
+			},
+		},
+		{
+			name: "failure",
+			endA: func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness) {
+				t.Helper()
+				h.server.setFailBatchDML(injectedFlush)
+				_, err := h.tm.FlushAutomaticDML(ctx)
+				h.server.setFailBatchDML(nil)
+				if err == nil || !strings.Contains(err.Error(), "injected automatic DML BatchUpdate failure") {
+					t.Fatalf("flush failure: %v", err)
+				}
+			},
+			wantStaleOnA: true,
+		},
+		{
+			name: "query abort",
+			endA: func(t *testing.T, ctx context.Context, session *Session, h *heartbeatHarness) {
+				t.Helper()
+				h.tm.queryAfterCollectHook = func() error { return injectedAbort }
+				t.Cleanup(func() { h.tm.queryAfterCollectHook = nil })
+				_, err := execSQL(t, ctx, session, "SELECT 1")
+				h.tm.queryAfterCollectHook = nil
+				if spanner.ErrCode(err) != codes.Aborted {
+					t.Fatalf("query abort: %v", err)
+				}
+			},
+			wantStaleOnA: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := newHeartbeatHarness(t)
+			session := sessionForTM(t, h.tm)
+			if err := h.tm.BeginReadWriteTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+				t.Fatal(err)
+			}
+			ok, err := h.tm.TryEnqueueAutomaticDML(spanner.NewStatement(staleSQL))
+			if err != nil || !ok {
+				t.Fatalf("enqueue on A: ok=%v err=%v", ok, err)
+			}
+			ownerA := txnContext(h.tm)
+			if ownerA == nil {
+				t.Fatal("BEGIN RW did not allocate owner A")
+			}
+
+			tc.endA(t, ctx, session, h)
+			if h.tm.HasAutomaticDML() {
+				t.Fatal("A left replayable automatic DML")
+			}
+			if len(ownerA.autoDML) != 0 {
+				t.Fatal("retired or aborted owner A still held automatic DML")
+			}
+
+			beforeB := h.server.batchObservations()
+			if tc.wantStaleOnA != batchObsContainsSQL(beforeB, staleSQL) {
+				t.Fatalf("stale SQL on A before replacement: observed=%v want %v", batchObsContainsSQL(beforeB, staleSQL), tc.wantStaleOnA)
+			}
+
+			if err := h.tm.BeginReadWriteTransaction(ctx, sppb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, sppb.RequestOptions_PRIORITY_UNSPECIFIED); err != nil {
+				t.Fatal(err)
+			}
+			ownerB := txnContext(h.tm)
+			if ownerB == nil || ownerB == ownerA {
+				t.Fatal("replacement owner B reused A")
+			}
+			if h.tm.HasAutomaticDML() {
+				t.Fatal("B inherited automatic DML")
+			}
+
+			res, err := h.tm.FlushAutomaticDML(ctx)
+			if err != nil || res != nil {
+				t.Fatalf("empty flush on B: res=%v err=%v", res, err)
+			}
+			if _, err := h.tm.CommitReadWriteTransaction(ctx); err != nil {
+				t.Fatalf("commit B: %v", err)
+			}
+
+			afterB := h.server.batchObservations()[len(beforeB):]
+			if batchObsContainsSQL(afterB, staleSQL) {
+				t.Fatalf("stale work executed under replacement owner B: %v", afterB)
+			}
+		})
+	}
+}
+
+func batchObsContainsSQL(obs []batchDMLObservation, sql string) bool {
+	for _, o := range obs {
+		if slices.Contains(o.sqls, sql) {
+			return true
+		}
+	}
+	return false
 }
 
 func newAutoBatchSession(t *testing.T) *Session {

--- a/internal/mycli/heartbeat_owner_test.go
+++ b/internal/mycli/heartbeat_owner_test.go
@@ -53,17 +53,24 @@ type sqlObservation struct {
 	hadReadTs bool
 }
 
+type batchDMLObservation struct {
+	txnID string
+	sqls  []string
+}
+
 type heartbeatRPCServer struct {
 	sppb.UnimplementedSpannerServer
 
-	mu          sync.Mutex
-	next        atomic.Uint64
-	sqlTxn      map[string]string
-	roIDs       map[string]struct{}
-	rwIDs       map[string]struct{}
-	heartbeats  []heartbeatRecord
-	sqlObs      []sqlObservation
-	failROQuery error
+	mu           sync.Mutex
+	next         atomic.Uint64
+	sqlTxn       map[string]string
+	roIDs        map[string]struct{}
+	rwIDs        map[string]struct{}
+	heartbeats   []heartbeatRecord
+	sqlObs       []sqlObservation
+	batchObs     []batchDMLObservation
+	failROQuery  error
+	failBatchDML error
 
 	heartbeatStarted     chan struct{}
 	heartbeatStartedOnce sync.Once
@@ -133,6 +140,22 @@ func (s *heartbeatRPCServer) setFailROQuery(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.failROQuery = err
+}
+
+func (s *heartbeatRPCServer) setFailBatchDML(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failBatchDML = err
+}
+
+func (s *heartbeatRPCServer) batchObservations() []batchDMLObservation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]batchDMLObservation, len(s.batchObs))
+	for i, obs := range s.batchObs {
+		out[i] = batchDMLObservation{txnID: obs.txnID, sqls: slices.Clone(obs.sqls)}
+	}
+	return out
 }
 
 func (s *heartbeatRPCServer) sqlObservations() []sqlObservation {
@@ -234,6 +257,38 @@ func (s *heartbeatRPCServer) Rollback(context.Context, *sppb.RollbackRequest) (*
 
 func (s *heartbeatRPCServer) Commit(context.Context, *sppb.CommitRequest) (*sppb.CommitResponse, error) {
 	return &sppb.CommitResponse{CommitTimestamp: timestamppb.Now()}, nil
+}
+
+func (s *heartbeatRPCServer) ExecuteBatchDml(_ context.Context, r *sppb.ExecuteBatchDmlRequest) (*sppb.ExecuteBatchDmlResponse, error) {
+	var id []byte
+	if existing := r.GetTransaction().GetId(); len(existing) > 0 {
+		id = slices.Clone(existing)
+	} else {
+		id = s.newTxnID()
+		s.mu.Lock()
+		s.noteSelectorLocked(id, r.GetTransaction())
+		s.mu.Unlock()
+	}
+	sqls := make([]string, 0, len(r.GetStatements()))
+	for _, st := range r.GetStatements() {
+		sqls = append(sqls, st.GetSql())
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.batchObs = append(s.batchObs, batchDMLObservation{txnID: string(id), sqls: sqls})
+	if s.failBatchDML != nil {
+		return nil, s.failBatchDML
+	}
+	results := make([]*sppb.ResultSet, len(r.GetStatements()))
+	for i := range results {
+		results[i] = &sppb.ResultSet{
+			Stats: &sppb.ResultSetStats{
+				RowCount: &sppb.ResultSetStats_RowCountExact{RowCountExact: 1},
+			},
+		}
+	}
+	return &sppb.ExecuteBatchDmlResponse{ResultSets: results}, nil
 }
 
 func (s *heartbeatRPCServer) ExecuteSql(ctx context.Context, r *sppb.ExecuteSqlRequest) (*sppb.ResultSet, error) {

--- a/internal/mycli/session_transaction_context.go
+++ b/internal/mycli/session_transaction_context.go
@@ -46,6 +46,9 @@ type transactionContext struct {
 	// TransactionManager.pendingLocalVarRestore only when the context is
 	// retired.
 	localVarUndo []savedLocalVar
+	// autoDML is this transaction's automatic DML queue. Access it only under
+	// tm.mu. Manual START/RUN/ABORT BATCH state stays on Session.batch.
+	autoDML []spanner.Statement
 }
 
 // EnableHeartbeat enables sending periodic heartbeats for this transaction.

--- a/internal/mycli/transaction_manager.go
+++ b/internal/mycli/transaction_manager.go
@@ -135,14 +135,6 @@ type TransactionManager struct {
 	// calls do not acquire a new automatic restoration contract.
 	pendingLocalVarRestore []savedLocalVar
 
-	// autoDML is the transaction-owned automatic DML queue. Manual START/RUN/ABORT
-	// batches stay on Session.batch. The queue remains on TransactionManager
-	// with generation/owner guards so leftover statements cannot execute in a
-	// later RW owner.
-	autoDML           []spanner.Statement
-	autoDMLOwner      uint64
-	autoDMLGeneration uint64
-
 	// Test seams. Production remains nil.
 	// queryAfterCollectHook runs after the ordinary collector or PROFILE
 	// iterator consumer returns, so injected errors share those error branches.
@@ -370,19 +362,20 @@ func (tm *TransactionManager) restoreLocalVarsIfIdle() {
 }
 
 // retireTransactionContextLocked stops heartbeat, detaches SET LOCAL undo into
-// pendingLocalVarRestore, clears tc, and discards leftover automatic DML.
+// pendingLocalVarRestore, discards this owner's automatic DML, and clears tc.
 // Caller must hold tm.mu. Safe when tc is already nil. Does not call
 // registry setters.
 func (tm *TransactionManager) retireTransactionContextLocked() {
-	if tm.tc != nil {
-		tm.tc.Close()
-		if n := len(tm.tc.localVarUndo); n > 0 {
-			tm.pendingLocalVarRestore = append(tm.pendingLocalVarRestore, tm.tc.localVarUndo...)
-			tm.tc.localVarUndo = nil
-		}
-		tm.tc = nil
+	if tm.tc == nil {
+		return
 	}
-	tm.discardAutomaticDMLLocked()
+	tm.tc.Close()
+	if n := len(tm.tc.localVarUndo); n > 0 {
+		tm.pendingLocalVarRestore = append(tm.pendingLocalVarRestore, tm.tc.localVarUndo...)
+		tm.tc.localVarUndo = nil
+	}
+	tm.tc.autoDML = nil
+	tm.tc = nil
 }
 
 // activateTransactionLocked installs an SDK handle and resolved attributes on
@@ -675,12 +668,6 @@ func (tm *TransactionManager) BeginReadWriteTransactionLocked(ctx context.Contex
 	if tm.sysVars != nil {
 		tm.sysVars.Transaction.TransactionTag = ""
 	}
-
-	// A new RW owner must not inherit leftover automatic work. Pending
-	// activation is not a terminal discard of a live owner; any residual
-	// here is cross-owner and is dropped rather than replayed.
-	tm.autoDMLGeneration++
-	tm.discardAutomaticDMLLocked()
 
 	// Keep the pending pointer through activation. The heartbeat loop closes
 	// over this owner so a delayed tick cannot borrow a later replacement (#922).

--- a/internal/mycli/transaction_manager_auto_dml.go
+++ b/internal/mycli/transaction_manager_auto_dml.go
@@ -23,8 +23,9 @@ import (
 )
 
 func (tm *TransactionManager) discardAutomaticDMLLocked() {
-	tm.autoDML = nil
-	tm.autoDMLOwner = 0
+	if tm.tc != nil {
+		tm.tc.autoDML = nil
+	}
 }
 
 // DiscardAutomaticDML drops pending automatic DML without executing it.
@@ -37,21 +38,22 @@ func (tm *TransactionManager) DiscardAutomaticDML() {
 	})
 }
 
-// HasAutomaticDML reports whether automatic DML is waiting for this manager.
+// HasAutomaticDML reports whether automatic DML is waiting on the current
+// transaction context.
 func (tm *TransactionManager) HasAutomaticDML() bool {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
-	return len(tm.autoDML) > 0
+	return tm.tc != nil && len(tm.tc.autoDML) > 0
 }
 
 // AutomaticBatchInfo returns pending-automatic BatchInfo, or nil if the queue is empty.
 func (tm *TransactionManager) AutomaticBatchInfo() *BatchInfo {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
-	if len(tm.autoDML) == 0 {
+	if tm.tc == nil || len(tm.tc.autoDML) == 0 {
 		return nil
 	}
-	return &BatchInfo{Mode: batchModeDML, Size: len(tm.autoDML)}
+	return &BatchInfo{Mode: batchModeDML, Size: len(tm.tc.autoDML)}
 }
 
 // TryEnqueueAutomaticDML appends stmt to the current explicit RW transaction's
@@ -63,11 +65,7 @@ func (tm *TransactionManager) TryEnqueueAutomaticDML(stmt spanner.Statement) (bo
 		if tm.tc == nil || tm.tc.attrs.mode != transactionModeReadWrite {
 			return nil
 		}
-		if tm.autoDMLOwner != 0 && tm.autoDMLOwner != tm.autoDMLGeneration {
-			tm.discardAutomaticDMLLocked()
-		}
-		tm.autoDML = append(tm.autoDML, stmt)
-		tm.autoDMLOwner = tm.autoDMLGeneration
+		tm.tc.autoDML = append(tm.tc.autoDML, stmt)
 		// Queued automatic DML is uncommitted work on an already-started RW
 		// owner. Enable the existing keepalive now; waiting until flush is too
 		// late to cover the think/paste interval before COMMIT or a read.
@@ -99,22 +97,23 @@ func (tm *TransactionManager) FlushAutomaticDML(ctx context.Context) (*Result, e
 	return newBatchDMLResult(dmls, counts, &DMLResult{}), nil
 }
 
-// flushAutomaticDMLLocked takes the automatic queue then BatchUpdates it on the
-// current RW transaction. Caller must hold tm.mu. A generation mismatch or
-// missing RW owner discards without executing so stale work cannot open a new
-// implicit transaction.
+// flushAutomaticDMLLocked takes the current context's automatic queue then
+// BatchUpdates it on that same RW owner. Caller must hold tm.mu. The queue is
+// cleared before the RPC so a failure cannot replay work. A missing RW owner
+// or owner replacement discards without executing so stale work cannot open a
+// new implicit transaction.
 func (tm *TransactionManager) flushAutomaticDMLLocked(ctx context.Context) ([]spanner.Statement, []int64, error) {
-	if len(tm.autoDML) == 0 {
+	owner := tm.tc
+	if owner == nil || len(owner.autoDML) == 0 {
 		return nil, nil, nil
 	}
-	dmls := tm.autoDML
-	owner := tm.autoDMLOwner
-	tm.discardAutomaticDMLLocked()
+	dmls := owner.autoDML
+	owner.autoDML = nil
 
-	if owner != tm.autoDMLGeneration || tm.tc == nil || tm.tc.txn == nil || tm.tc.attrs.mode != transactionModeReadWrite {
+	if owner != tm.tc || owner.txn == nil || owner.attrs.mode != transactionModeReadWrite {
 		return nil, nil, nil
 	}
-	rwTxn, ok := tm.tc.txn.(*spanner.ReadWriteStmtBasedTransaction)
+	rwTxn, ok := owner.txn.(*spanner.ReadWriteStmtBasedTransaction)
 	if !ok {
 		return nil, nil, ErrNotInReadWriteTransaction
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #924.

Automatic DML now lives on the stable logical `transactionContext` and is accessed only under `tm.mu`. Manager-wide `autoDML`, `autoDMLOwner`, and `autoDMLGeneration` (and their increments/comparisons) are removed. Manual START/RUN/ABORT BATCH remains on `Session.batch`.

Flush captures the owning context, clears that owner's queue before `BatchUpdate`, and executes only if the same RW owner is still current. Ending a context discards its queue by ownership; a replacement context starts empty. Empty flush does not create an implicit transaction.

## Tests

- Adapted enqueue/clear/DDL-guard tests off the numeric owner/generation fields.
- `TestAutomaticDMLStaleWorkDoesNotCrossReplacementOwner` covers commit, rollback, close, ABORT BATCH, BatchUpdate failure, and query abort: A's queued SQL cannot `BatchUpdate` under replacement owner B.
- Empty flush (idle and empty RW) does not start or replace a transaction.

Validation (logs under `.tmp/cohesion-wave2/`):

```
go test -short ./internal/mycli/... -run 'AutomaticDML|AutoBatch|ReadOnlyGuard|Heartbeat'
make check-race
make check
```

No batching-policy, retry, parallel-ownership shim, CI-floor, or dependency changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4aa8f59-1f19-52a9-8598-f707b0c118e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4aa8f59-1f19-52a9-8598-f707b0c118e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

