### PR TITLE
Pass operation output explicitly through statement execution

### DIFF
--- a/internal/mycli/cli.go
+++ b/internal/mycli/cli.go
@@ -596,7 +596,7 @@ func (c *Cli) executeStatement(ctx context.Context, stmt Statement, interactive 
 		defer sink.abort()
 		outW = sink
 	}
-	out := outputContext{
+	out := OperationOutput{
 		w: outW,
 		// Resolve the width against the caller's writer, not the sink: the
 		// pager pipe is never a terminal.

--- a/internal/mycli/cli_input_test.go
+++ b/internal/mycli/cli_input_test.go
@@ -342,7 +342,7 @@ type abortStatement struct{}
 
 func (abortStatement) isDetachedCompatible() {}
 
-func (abortStatement) Execute(context.Context, *Session) (*Result, error) {
+func (abortStatement) Execute(context.Context, *Session, OperationOutput) (*Result, error) {
 	return nil, spanner.ToSpannerError(status.Error(codes.Aborted, "txn aborted"))
 }
 
@@ -430,7 +430,7 @@ type timestampResultStatement struct{ ts time.Time }
 
 func (timestampResultStatement) isDetachedCompatible() {}
 
-func (s timestampResultStatement) Execute(context.Context, *Session) (*Result, error) {
+func (s timestampResultStatement) Execute(context.Context, *Session, OperationOutput) (*Result, error) {
 	return &Result{
 		ReadTimestamp:   s.ts,
 		CommitTimestamp: s.ts,
@@ -542,7 +542,7 @@ type keepVariablesStatement struct{}
 
 func (keepVariablesStatement) isDetachedCompatible() {}
 
-func (keepVariablesStatement) Execute(context.Context, *Session) (*Result, error) {
+func (keepVariablesStatement) Execute(context.Context, *Session, OperationOutput) (*Result, error) {
 	return &Result{
 		KeepVariables: true,
 		ReadTimestamp: time.Date(2026, 9, 12, 0, 0, 0, 0, time.UTC),

--- a/internal/mycli/cli_mcp_cancellation_test.go
+++ b/internal/mycli/cli_mcp_cancellation_test.go
@@ -33,7 +33,7 @@ type mcpAdmissionBlockingStatement struct {
 	release <-chan struct{}
 }
 
-func (s *mcpAdmissionBlockingStatement) Execute(ctx context.Context, _ *Session) (*Result, error) {
+func (s *mcpAdmissionBlockingStatement) Execute(ctx context.Context, _ *Session, out OperationOutput) (*Result, error) {
 	close(s.entered)
 	select {
 	case <-s.release:

--- a/internal/mycli/cli_output_error_test.go
+++ b/internal/mycli/cli_output_error_test.go
@@ -149,8 +149,8 @@ type resultErrorStatement struct{ cause error }
 
 func (resultErrorStatement) isDetachedCompatible() {}
 
-func (s resultErrorStatement) Execute(_ context.Context, session *Session) (*Result, error) {
-	if _, err := io.WriteString(session.outputWriter(), "BODY\n"); err != nil {
+func (s resultErrorStatement) Execute(_ context.Context, _ *Session, out OperationOutput) (*Result, error) {
+	if _, err := io.WriteString(out.Writer(), "BODY\n"); err != nil {
 		return nil, err
 	}
 	return nil, s.cause

--- a/internal/mycli/cli_progress_test.go
+++ b/internal/mycli/cli_progress_test.go
@@ -495,8 +495,8 @@ type streamThenErrorStatement struct{}
 
 func (streamThenErrorStatement) isDetachedCompatible() {}
 
-func (streamThenErrorStatement) Execute(_ context.Context, session *Session) (*Result, error) {
-	w := session.outputWriter()
+func (streamThenErrorStatement) Execute(_ context.Context, _ *Session, out OperationOutput) (*Result, error) {
+	w := out.Writer()
 	if w == nil {
 		return nil, errors.New("no output writer")
 	}

--- a/internal/mycli/directed_read_acceptance_test.go
+++ b/internal/mycli/directed_read_acceptance_test.go
@@ -226,7 +226,7 @@ func TestDirectedReadSelectedROPathsABClear(t *testing.T) {
 			}
 			srv.takeRequests()
 			srv.takePartitionQueries()
-			result, err := runPartitionedQuery(ctx, session, "SELECT 'observed'")
+			result, err := runPartitionedQuery(ctx, session, "SELECT 'observed'", session.resolveOperationOutput(OperationOutput{}))
 			if err != nil || result == nil || result.AffectedRows != 1 || result.PartitionCount != 1 {
 				t.Fatalf("%s partition result=%v error=%v", sel.name, result, err)
 			}

--- a/internal/mycli/directed_read_matrix_test.go
+++ b/internal/mycli/directed_read_matrix_test.go
@@ -553,7 +553,7 @@ func TestDirectedReadDumpSnapshotWire(t *testing.T) {
 					}
 					srv.takeRequests()
 					srv.takeBegins()
-					result, err := executeDump(ctx, session, dumpModeTables, []tableID{{Name: "T"}})
+					result, err := executeDump(ctx, session, dumpModeTables, []tableID{{Name: "T"}}, OperationOutput{w: writer})
 					if mode == "cyclic reject" {
 						if err == nil || !strings.Contains(err.Error(), dumpCyclicInsertUnsupported) || result != nil || out.Len() != 0 {
 							t.Fatalf("cyclic safety result=%v output=%q error=%v", result, out.String(), err)

--- a/internal/mycli/dump_proto_replay_test.go
+++ b/internal/mycli/dump_proto_replay_test.go
@@ -65,12 +65,9 @@ func TestDumpProtoDescriptorReplay(t *testing.T) {
 					var result *Result
 					var err error
 					if streamed {
-						err = source.withOutput(outputContext{w: &out}, func() error {
-							result, err = executeDump(t.Context(), source, mode, nil)
-							return err
-						})
+						result, err = executeDump(t.Context(), source, mode, nil, OperationOutput{w: &out})
 					} else {
-						result, err = executeDump(t.Context(), source, mode, nil)
+						result, err = executeDump(t.Context(), source, mode, nil, OperationOutput{})
 						if err == nil {
 							_, _ = out.Write(result.preparedOutput())
 						}
@@ -313,18 +310,13 @@ func tryDumpProto(t *testing.T, session *Session, mode dumpMode, streamed bool, 
 	var out bytes.Buffer
 	var result *Result
 	var err error
-	run := func() error {
-		var inner error
-		result, inner = executeDump(t.Context(), session, mode, tables)
-		return inner
-	}
+	var opOut OperationOutput
 	if streamed {
-		err = session.withOutput(outputContext{w: &out}, run)
-	} else {
-		err = run()
-		if result != nil {
-			_, _ = out.Write(result.preparedOutput())
-		}
+		opOut = OperationOutput{w: &out}
+	}
+	result, err = executeDump(t.Context(), session, mode, tables, opOut)
+	if err == nil && !streamed && result != nil {
+		_, _ = out.Write(result.preparedOutput())
 	}
 	return out.String(), result, err
 }

--- a/internal/mycli/execute_dml_test.go
+++ b/internal/mycli/execute_dml_test.go
@@ -135,7 +135,7 @@ func TestThenReturnRenderFailureAbortsImplicitCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid statement: %v", err)
 	}
-	if _, execErr := stmt.Execute(ctx, session); execErr == nil {
+	if _, execErr := stmt.Execute(ctx, session, OperationOutput{}); execErr == nil {
 		t.Fatalf("expected THEN RETURN render failure, got nil error")
 	}
 
@@ -146,7 +146,7 @@ func TestThenReturnRenderFailureAbortsImplicitCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid select: %v", err)
 	}
-	res, err := sel.Execute(ctx, session)
+	res, err := sel.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("verification select failed: %v", err)
 	}

--- a/internal/mycli/execute_partitioned.go
+++ b/internal/mycli/execute_partitioned.go
@@ -18,7 +18,11 @@ import (
 	"github.com/sourcegraph/conc/pool"
 )
 
-func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Result, error) {
+func runPartitionedQuery(ctx context.Context, session *Session, sql string, out OperationOutput) (*Result, error) {
+	// Direct Execute tests often pass a zero OperationOutput after swapping
+	// StreamManager. Resolve here so a nil writer still uses StreamManager,
+	// without mutating Session. Caller-provided writers still win.
+	out = session.resolveOperationOutput(out)
 	sysVars := session.systemVariables
 	render, err := prepareFormatConfig(sql, sysVars, queryRenderingFrom(sysVars))
 	if err != nil {
@@ -45,7 +49,7 @@ func runPartitionedQuery(ctx context.Context, session *Session, sql string) (*Re
 
 	// Formats backed by a spanvalue RowIteratorWriter (CSV, JSONL, SQL_INSERT*)
 	// stream merged partition rows without buffering, like the query path.
-	result, handled, err := streamPartitionedQuery(ctx, session.outputWriter(), batchROTx, partitions, parallelism, render.Export, render.Spanvalue, render.ValueFmtMode)
+	result, handled, err := streamPartitionedQuery(ctx, out.Writer(), batchROTx, partitions, parallelism, render.Export, render.Spanvalue, render.ValueFmtMode)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -287,14 +287,16 @@ func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, s
 
 // rollbackReadWriteIfAborted rolls back a live RW owner when err is Aborted so
 // RecreateClient can replace the session. The initiating error is preserved.
-func rollbackReadWriteIfAborted(ctx context.Context, session *Session, err error, out OperationOutput) error {
+// Rollback emits no statement output, so this calls the transaction manager
+// directly instead of manufacturing a nested Statement.Execute destination.
+func rollbackReadWriteIfAborted(ctx context.Context, session *Session, err error) error {
 	if err == nil || session == nil || session.txn == nil {
 		return err
 	}
 	if !session.txn.InReadWriteTransaction() || spanner.ErrCode(err) != codes.Aborted {
 		return err
 	}
-	if _, rollbackErr := (&RollbackStatement{}).Execute(ctx, session, out); rollbackErr != nil {
+	if rollbackErr := session.txn.RollbackReadWriteTransaction(ctx); rollbackErr != nil {
 		return errors.Join(err, fmt.Errorf("error on rollback: %w", rollbackErr))
 	}
 	return err
@@ -354,7 +356,7 @@ func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql st
 	}
 	if err != nil {
 		if rollbackActiveTransactionOnAbort {
-			return nil, rollbackReadWriteIfAborted(ctx, session, err, out)
+			return nil, rollbackReadWriteIfAborted(ctx, session, err)
 		}
 		return nil, err
 	}

--- a/internal/mycli/execute_sql.go
+++ b/internal/mycli/execute_sql.go
@@ -84,21 +84,21 @@ func (r queryRendering) withExecuteOverrides(mode enums.DisplayMode, streaming e
 }
 
 // executeSQLWithFormatAndTxn executes SQL with specific format settings and
-// within a given transaction. out, when non-nil, is the explicit destination
-// for streaming output instead of the session's statement-level destination.
+// within a given transaction. out is the operation destination; DUMP overrides
+// a local copy's writer for internal buffering while keeping the outer width.
 // dro is the caller's captured directed-read option for this read-only request.
-func executeSQLWithFormatAndTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, format enums.DisplayMode, streamingMode enums.StreamingMode, sqlTableName string, dro *sppb.DirectedReadOptions, out io.Writer) (*Result, error) {
+func executeSQLWithFormatAndTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, format enums.DisplayMode, streamingMode enums.StreamingMode, sqlTableName string, dro *sppb.DirectedReadOptions, out OperationOutput) (*Result, error) {
 	render := queryRenderingFrom(session.systemVariables).withExecuteOverrides(format, streamingMode, sqlTableName)
 	return executeSQLImplWithTxn(ctx, session, txn, sql, render, dro, out)
 }
 
-func executeSQL(ctx context.Context, session *Session, sql string) (*Result, error) {
-	return executeSQLImpl(ctx, session, sql)
+func executeSQL(ctx context.Context, session *Session, sql string, out OperationOutput) (*Result, error) {
+	return executeSQLImpl(ctx, session, sql, out)
 }
 
 // executeSQLImpl delegates to executeSQLImplWithVars with the session's system variables
-func executeSQLImpl(ctx context.Context, session *Session, sql string) (*Result, error) {
-	return executeSQLImplWithVars(ctx, session, sql, session.systemVariables)
+func executeSQLImpl(ctx context.Context, session *Session, sql string, out OperationOutput) (*Result, error) {
+	return executeSQLImplWithVars(ctx, session, sql, session.systemVariables, out)
 }
 
 // prepareFormatConfig fills the spanvalue formatter, value-format mode, and
@@ -185,7 +185,7 @@ func finalizeMetrics(m *metrics.ExecutionMetrics, sysVars *systemVariables) {
 // avoiding 9+ individual parameters through executeAndCollect and its downstream functions.
 type queryExecution struct {
 	Session     *Session
-	Output      io.Writer
+	Out         OperationOutput
 	Iter        *spanner.RowIterator
 	ReadOnlyTxn *spanner.ReadOnlyTransaction
 	SQL         string
@@ -201,10 +201,7 @@ type queryExecution struct {
 }
 
 func (qe *queryExecution) outputWriter() io.Writer {
-	if qe.Output != nil {
-		return qe.Output
-	}
-	return qe.Session.outputWriter()
+	return qe.Out.Writer()
 }
 
 // executeAndCollect runs the query iterator (streaming or buffered) and attaches metrics to the result.
@@ -242,7 +239,7 @@ func executeAndCollect(ctx context.Context, qe *queryExecution) (*Result, error)
 // executeSQLImplWithTxn executes SQL within a given transaction using live
 // session settings for parameters, Mode/Priority, and metrics. render carries
 // DUMP format/streaming/table/header overrides; dro is captured for the DUMP request.
-func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, render queryRendering, dro *sppb.DirectedReadOptions, out io.Writer) (*Result, error) {
+func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.ReadOnlyTransaction, sql string, render queryRendering, dro *sppb.DirectedReadOptions, out OperationOutput) (*Result, error) {
 	sysVars := session.systemVariables
 	m := newMetrics(sysVars)
 
@@ -267,7 +264,7 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 
 	return executeAndCollect(ctx, &queryExecution{
 		Session:        session,
-		Output:         out,
+		Out:            out,
 		Iter:           iter,
 		ReadOnlyTxn:    txn,
 		SQL:            sql,
@@ -281,23 +278,23 @@ func executeSQLImplWithTxn(ctx context.Context, session *Session, txn *spanner.R
 // executeSQLImplWithVars runs SQL against the live settings object (Params,
 // QueryMode, cache destination, metrics). Per-query display overrides live on
 // queryRendering, not a copy of sysVars.
-func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, sysVars *systemVariables) (*Result, error) {
+func executeSQLImplWithVars(ctx context.Context, session *Session, sql string, sysVars *systemVariables, out OperationOutput) (*Result, error) {
 	if _, err := session.txn.FlushAutomaticDML(ctx); err != nil {
 		return nil, err
 	}
-	return executeSQLImplWithQueryRunner(ctx, session, sql, sysVars, session.txn.RunQueryWithStats, true)
+	return executeSQLImplWithQueryRunner(ctx, session, sql, sysVars, session.txn.RunQueryWithStats, true, out)
 }
 
 // rollbackReadWriteIfAborted rolls back a live RW owner when err is Aborted so
 // RecreateClient can replace the session. The initiating error is preserved.
-func rollbackReadWriteIfAborted(ctx context.Context, session *Session, err error) error {
+func rollbackReadWriteIfAborted(ctx context.Context, session *Session, err error, out OperationOutput) error {
 	if err == nil || session == nil || session.txn == nil {
 		return err
 	}
 	if !session.txn.InReadWriteTransaction() || spanner.ErrCode(err) != codes.Aborted {
 		return err
 	}
-	if _, rollbackErr := (&RollbackStatement{}).Execute(ctx, session); rollbackErr != nil {
+	if _, rollbackErr := (&RollbackStatement{}).Execute(ctx, session, out); rollbackErr != nil {
 		return errors.Join(err, fmt.Errorf("error on rollback: %w", rollbackErr))
 	}
 	return err
@@ -306,16 +303,20 @@ func rollbackReadWriteIfAborted(ctx context.Context, session *Session, err error
 // executeSQLImplSingleUse executes SQL outside the session's explicit
 // transaction while preserving normal query options and one-shot request-tag
 // consumption.
-func executeSQLImplSingleUse(ctx context.Context, session *Session, sql string, sysVars *systemVariables) (*Result, error) {
+func executeSQLImplSingleUse(ctx context.Context, session *Session, sql string, sysVars *systemVariables, out OperationOutput) (*Result, error) {
 	run := func(ctx context.Context, stmt spanner.Statement, _ bool, mode sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error) {
 		return session.txn.RunSingleUseQueryWithStats(ctx, stmt, mode)
 	}
-	return executeSQLImplWithQueryRunner(ctx, session, sql, sysVars, run, false)
+	return executeSQLImplWithQueryRunner(ctx, session, sql, sysVars, run, false, out)
 }
 
 type queryWithStatsRunner func(context.Context, spanner.Statement, bool, sppb.ExecuteSqlRequest_QueryMode) (*spanner.RowIterator, *spanner.ReadOnlyTransaction, error)
 
-func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql string, sysVars *systemVariables, run queryWithStatsRunner, rollbackActiveTransactionOnAbort bool) (*Result, error) {
+func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql string, sysVars *systemVariables, run queryWithStatsRunner, rollbackActiveTransactionOnAbort bool, out OperationOutput) (*Result, error) {
+	// Direct Execute tests often pass a zero OperationOutput after swapping
+	// StreamManager. Resolve here so a nil writer still uses StreamManager,
+	// without mutating Session. Caller-provided writers still win.
+	out = session.resolveOperationOutput(out)
 	m := newMetrics(sysVars)
 
 	// Capture the caller's cache slot before prepareFormatConfig fills
@@ -339,6 +340,7 @@ func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql st
 
 	result, err := executeAndCollect(ctx, &queryExecution{
 		Session:        session,
+		Out:            out,
 		Iter:           iter,
 		ReadOnlyTxn:    roTxn,
 		SQL:            sql,
@@ -352,7 +354,7 @@ func executeSQLImplWithQueryRunner(ctx context.Context, session *Session, sql st
 	}
 	if err != nil {
 		if rollbackActiveTransactionOnAbort {
-			return nil, rollbackReadWriteIfAborted(ctx, session, err)
+			return nil, rollbackReadWriteIfAborted(ctx, session, err, out)
 		}
 		return nil, err
 	}
@@ -381,7 +383,7 @@ func decideExecutionMode(qe *queryExecution) (bool, RowProcessor, error) {
 		return true, nil, nil
 	}
 
-	screenWidth := qe.Session.displayWidthFor()
+	screenWidth := qe.Out.ScreenWidth()
 
 	// Try to create streaming processor based on settings
 	processor, err := streamingProcessorFor(qe.Render, outStream, screenWidth)

--- a/internal/mycli/execute_sql_test.go
+++ b/internal/mycli/execute_sql_test.go
@@ -415,7 +415,7 @@ func TestStreamingProcessorForAndDecideExecutionMode(t *testing.T) {
 
 	t.Run("CSV streams without a RowProcessor", func(t *testing.T) {
 		useStreaming, proc, err := decideExecutionMode(&queryExecution{
-			Output: &out,
+			Out:    OperationOutput{w: &out},
 			Render: queryRendering{CLIFormat: enums.DisplayModeCSV},
 		})
 		if err != nil {
@@ -430,7 +430,7 @@ func TestStreamingProcessorForAndDecideExecutionMode(t *testing.T) {
 		session := &Session{systemVariables: sv}
 		useStreaming, proc, err := decideExecutionMode(&queryExecution{
 			Session: session,
-			Output:  &out,
+			Out:     OperationOutput{w: &out},
 			Render:  queryRenderingFrom(sv).withExecuteOverrides(enums.DisplayModeTab, enums.StreamingModeTrue, ""),
 		})
 		if err != nil {
@@ -444,7 +444,7 @@ func TestStreamingProcessorForAndDecideExecutionMode(t *testing.T) {
 	t.Run("unsupported format fails decideExecutionMode", func(t *testing.T) {
 		useStreaming, proc, err := decideExecutionMode(&queryExecution{
 			Session: &Session{systemVariables: sv},
-			Output:  &out,
+			Out:     OperationOutput{w: &out},
 			Render:  queryRendering{CLIFormat: enums.DisplayMode(999)},
 		})
 		if err == nil || !strings.Contains(err.Error(), "unsupported streaming mode") {
@@ -460,17 +460,14 @@ func TestQueryExecutionOutputWriter(t *testing.T) {
 	t.Parallel()
 
 	explicit := &bytes.Buffer{}
-	qe := &queryExecution{Output: explicit}
+	qe := &queryExecution{Out: OperationOutput{w: explicit}}
 	if qe.outputWriter() != explicit {
 		t.Fatal("outputWriter did not return the explicit destination")
 	}
 
-	sv := newSystemVariablesWithDefaultsForTest()
-	sessionOut := &bytes.Buffer{}
-	sv.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), sessionOut, io.Discard)
-	qe = &queryExecution{Session: &Session{systemVariables: sv}}
-	if qe.outputWriter() != sessionOut {
-		t.Fatal("outputWriter did not fall back to the session destination")
+	qe = &queryExecution{}
+	if qe.outputWriter() != nil {
+		t.Fatal("zero OperationOutput should not invent a writer")
 	}
 }
 
@@ -505,29 +502,29 @@ func TestRollbackReadWriteIfAborted(t *testing.T) {
 	aborted := status.Error(codes.Aborted, "injected abort")
 	other := errors.New("not aborted")
 
-	if got := rollbackReadWriteIfAborted(t.Context(), nil, nil); got != nil {
+	if got := rollbackReadWriteIfAborted(t.Context(), nil, nil, OperationOutput{}); got != nil {
 		t.Errorf("nil err = %v, want nil", got)
 	}
-	if got := rollbackReadWriteIfAborted(t.Context(), nil, aborted); !errors.Is(got, aborted) {
+	if got := rollbackReadWriteIfAborted(t.Context(), nil, aborted, OperationOutput{}); !errors.Is(got, aborted) {
 		t.Errorf("nil session = %v, want original abort", got)
 	}
 
 	sv := newSystemVariablesWithDefaultsForTest()
 	session := &Session{systemVariables: sv}
-	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted); !errors.Is(got, aborted) {
+	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted, OperationOutput{}); !errors.Is(got, aborted) {
 		t.Errorf("nil txn = %v, want original abort", got)
 	}
 
 	session.txn = NewTransactionManager(nil, sv, spanner.ClientConfig{})
-	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted); !errors.Is(got, aborted) {
+	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted, OperationOutput{}); !errors.Is(got, aborted) {
 		t.Errorf("not in RW = %v, want original abort", got)
 	}
-	if got := rollbackReadWriteIfAborted(t.Context(), session, other); !errors.Is(got, other) {
+	if got := rollbackReadWriteIfAborted(t.Context(), session, other, OperationOutput{}); !errors.Is(got, other) {
 		t.Errorf("non-aborted = %v, want original error", got)
 	}
 
 	session.txn.tc = &transactionContext{attrs: transactionAttributes{mode: transactionModeReadWrite}}
-	got := rollbackReadWriteIfAborted(t.Context(), session, aborted)
+	got := rollbackReadWriteIfAborted(t.Context(), session, aborted, OperationOutput{})
 	if !errors.Is(got, aborted) {
 		t.Fatalf("rollback-join missing abort: %v", got)
 	}
@@ -560,7 +557,7 @@ func TestExecuteSQLImplWithQueryRunnerErrorContracts(t *testing.T) {
 		if want == nil {
 			t.Fatal("setup: prepareFormatConfig error = nil, want proto descriptor failure")
 		}
-		_, err := executeSQLImplWithQueryRunner(t.Context(), session, "SELECT 1", session.systemVariables, mustNotInvokeQueryRunner(t), true)
+		_, err := executeSQLImplWithQueryRunner(t.Context(), session, "SELECT 1", session.systemVariables, mustNotInvokeQueryRunner(t), true, OperationOutput{})
 		if err == nil || err.Error() != want.Error() {
 			t.Fatalf("error = %v, want %v", err, want)
 		}
@@ -574,7 +571,7 @@ func TestExecuteSQLImplWithQueryRunnerErrorContracts(t *testing.T) {
 		if want == nil {
 			t.Fatal("setup: newStatement error = nil, want statement parse failure")
 		}
-		_, err := executeSQLImplWithQueryRunner(t.Context(), session, sql, session.systemVariables, mustNotInvokeQueryRunner(t), true)
+		_, err := executeSQLImplWithQueryRunner(t.Context(), session, sql, session.systemVariables, mustNotInvokeQueryRunner(t), true, OperationOutput{})
 		if err == nil || err.Error() != want.Error() {
 			t.Fatalf("error = %v, want %v", err, want)
 		}
@@ -583,7 +580,7 @@ func TestExecuteSQLImplWithQueryRunnerErrorContracts(t *testing.T) {
 	t.Run("runner error", func(t *testing.T) {
 		t.Parallel()
 		session := newSessionForLocalVarTest(t)
-		_, err := executeSQLImplWithQueryRunner(t.Context(), session, "SELECT 1", session.systemVariables, runFail, true)
+		_, err := executeSQLImplWithQueryRunner(t.Context(), session, "SELECT 1", session.systemVariables, runFail, true, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "injected runner failure") {
 			t.Fatalf("error = %v, want injected runner failure", err)
 		}
@@ -601,7 +598,7 @@ func TestExecuteSQLImplWithQueryRunnerErrorContracts(t *testing.T) {
 			iter = it
 			return it, roTxn, err
 		}
-		_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, run, true)
+		_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, run, true, OperationOutput{w: &buf})
 		if err == nil || !strings.Contains(err.Error(), "unsupported streaming mode") {
 			t.Fatalf("error = %v, want unsupported streaming mode", err)
 		}
@@ -620,7 +617,7 @@ func TestExecuteSQLImplWithQueryRunnerErrorContracts(t *testing.T) {
 		injected := errors.New("after collect failed")
 		session.txn.queryAfterCollectHook = func() error { return injected }
 		t.Cleanup(func() { session.txn.queryAfterCollectHook = nil })
-		_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, false)
+		_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, false, OperationOutput{})
 		if !errors.Is(err, injected) {
 			t.Fatalf("error = %v, want after collect failed", err)
 		}
@@ -640,7 +637,7 @@ func TestExecuteSQLBufferedAndStreamingEmptyResults(t *testing.T) {
 		t.Parallel()
 		session, live := newEmptySQLRPCSession(t, plan, stats)
 		live.Display.CLIFormat = enums.DisplayModeTable
-		result, err := executeSQL(t.Context(), session, sqlExportSelectUsers)
+		result, err := executeSQL(t.Context(), session, sqlExportSelectUsers, OperationOutput{})
 		if err != nil {
 			t.Fatalf("executeSQL: %v", err)
 		}
@@ -667,7 +664,7 @@ func TestExecuteSQLBufferedAndStreamingEmptyResults(t *testing.T) {
 		var buf bytes.Buffer
 		live.Display.CLIFormat = enums.DisplayModeTab
 		live.StreamManager = streamio.NewStreamManager(io.NopCloser(strings.NewReader("")), &buf, io.Discard)
-		result, err := executeSQL(t.Context(), session, sqlExportSelectUsers)
+		result, err := executeSQL(t.Context(), session, sqlExportSelectUsers, OperationOutput{w: &buf})
 		if err != nil {
 			t.Fatalf("executeSQL: %v", err)
 		}
@@ -686,7 +683,7 @@ func TestExecuteSQLBufferedAndStreamingEmptyResults(t *testing.T) {
 		t.Parallel()
 		session, live := newEmptySQLRPCSession(t, plan, stats)
 		live.Display.CLIFormat = enums.DisplayModeSQLInsert
-		result, err := executeSQLImplWithVars(t.Context(), session, sqlExportSelectUsers, live)
+		result, err := executeSQLImplWithVars(t.Context(), session, sqlExportSelectUsers, live, OperationOutput{})
 		if err != nil {
 			t.Fatalf("executeSQLImplWithVars: %v", err)
 		}
@@ -698,7 +695,7 @@ func TestExecuteSQLBufferedAndStreamingEmptyResults(t *testing.T) {
 	t.Run("single-use empty SELECT", func(t *testing.T) {
 		t.Parallel()
 		session, live := newEmptySQLRPCSession(t, plan, stats)
-		result, err := executeSQLImplSingleUse(t.Context(), session, sqlExportSelectUsers, live)
+		result, err := executeSQLImplSingleUse(t.Context(), session, sqlExportSelectUsers, live, OperationOutput{})
 		if err != nil {
 			t.Fatalf("executeSQLImplSingleUse: %v", err)
 		}
@@ -715,7 +712,7 @@ func TestExecuteSQLBufferedAndStreamingEmptyResults(t *testing.T) {
 		session, live := newQueryCacheRPCSession(t, plan, stats, status.Error(codes.Internal, "iterator failed"))
 		seed := seedQueryCacheA()
 		live.LastResult.QueryCache = seed
-		_, err := executeSQLImplSingleUse(t.Context(), session, sqlExportSelectUsers, live)
+		_, err := executeSQLImplSingleUse(t.Context(), session, sqlExportSelectUsers, live, OperationOutput{})
 		if err == nil {
 			t.Fatal("executeSQLImplSingleUse error = nil, want iterator failure")
 		}

--- a/internal/mycli/execute_sql_test.go
+++ b/internal/mycli/execute_sql_test.go
@@ -502,29 +502,29 @@ func TestRollbackReadWriteIfAborted(t *testing.T) {
 	aborted := status.Error(codes.Aborted, "injected abort")
 	other := errors.New("not aborted")
 
-	if got := rollbackReadWriteIfAborted(t.Context(), nil, nil, OperationOutput{}); got != nil {
+	if got := rollbackReadWriteIfAborted(t.Context(), nil, nil); got != nil {
 		t.Errorf("nil err = %v, want nil", got)
 	}
-	if got := rollbackReadWriteIfAborted(t.Context(), nil, aborted, OperationOutput{}); !errors.Is(got, aborted) {
+	if got := rollbackReadWriteIfAborted(t.Context(), nil, aborted); !errors.Is(got, aborted) {
 		t.Errorf("nil session = %v, want original abort", got)
 	}
 
 	sv := newSystemVariablesWithDefaultsForTest()
 	session := &Session{systemVariables: sv}
-	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted, OperationOutput{}); !errors.Is(got, aborted) {
+	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted); !errors.Is(got, aborted) {
 		t.Errorf("nil txn = %v, want original abort", got)
 	}
 
 	session.txn = NewTransactionManager(nil, sv, spanner.ClientConfig{})
-	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted, OperationOutput{}); !errors.Is(got, aborted) {
+	if got := rollbackReadWriteIfAborted(t.Context(), session, aborted); !errors.Is(got, aborted) {
 		t.Errorf("not in RW = %v, want original abort", got)
 	}
-	if got := rollbackReadWriteIfAborted(t.Context(), session, other, OperationOutput{}); !errors.Is(got, other) {
+	if got := rollbackReadWriteIfAborted(t.Context(), session, other); !errors.Is(got, other) {
 		t.Errorf("non-aborted = %v, want original error", got)
 	}
 
 	session.txn.tc = &transactionContext{attrs: transactionAttributes{mode: transactionModeReadWrite}}
-	got := rollbackReadWriteIfAborted(t.Context(), session, aborted, OperationOutput{})
+	got := rollbackReadWriteIfAborted(t.Context(), session, aborted)
 	if !errors.Is(got, aborted) {
 		t.Fatalf("rollback-join missing abort: %v", got)
 	}

--- a/internal/mycli/feature/bigquery/bigquery.go
+++ b/internal/mycli/feature/bigquery/bigquery.go
@@ -216,7 +216,7 @@ func (c *clientCache) get(ctx context.Context, session *mycli.Session) (*bq.Clie
 }
 
 // Execute runs the BigQuery SQL and returns the result rows as display strings.
-func (s *BigQueryStatement) Execute(ctx context.Context, session *mycli.Session) (*mycli.Result, error) {
+func (s *BigQueryStatement) Execute(ctx context.Context, session *mycli.Session, out mycli.OperationOutput) (*mycli.Result, error) {
 	cache, err := mycli.FeatureState(ctx, session, clientStateKey,
 		func(context.Context, *mycli.Session) (*clientCache, error) {
 			return &clientCache{cfg: s.cfg}, nil

--- a/internal/mycli/feature/bigquery/client_offline_test.go
+++ b/internal/mycli/feature/bigquery/client_offline_test.go
@@ -85,7 +85,7 @@ func TestBigQueryExecuteRequiresProject(t *testing.T) {
 
 	session := &mycli.Session{}
 	stmt := newBigQueryStatement("SELECT 1", &config{})
-	_, err := stmt.Execute(t.Context(), session)
+	_, err := stmt.Execute(t.Context(), session, mycli.OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "CLI_BIGQUERY_PROJECT") {
 		t.Fatalf("Execute() error = %v, want project configuration error", err)
 	}
@@ -142,7 +142,7 @@ func TestBigQueryExecuteFakeClient(t *testing.T) {
 	}
 
 	stmt := newBigQueryStatement("SELECT col FROM t", cfg)
-	got, err := stmt.Execute(t.Context(), session)
+	got, err := stmt.Execute(t.Context(), session, mycli.OperationOutput{})
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -212,7 +212,7 @@ func TestBigQueryExecuteFakeClientReadError(t *testing.T) {
 		t.Fatalf("FeatureState: %v", err)
 	}
 
-	_, err = newBigQueryStatement("SELECT 1", cfg).Execute(t.Context(), session)
+	_, err = newBigQueryStatement("SELECT 1", cfg).Execute(t.Context(), session, mycli.OperationOutput{})
 	if err == nil {
 		t.Fatal("Execute() error = nil, want query read failure")
 	}

--- a/internal/mycli/feature/cql/cql.go
+++ b/internal/mycli/feature/cql/cql.go
@@ -159,7 +159,7 @@ func (h *cqlSessionHolder) get(session *mycli.Session) (*gocql.Session, error) {
 
 // Execute runs the CQL statement and returns the result rows as display
 // strings.
-func (cs *CQLStatement) Execute(ctx context.Context, session *mycli.Session) (result *mycli.Result, err error) {
+func (cs *CQLStatement) Execute(ctx context.Context, session *mycli.Session, out mycli.OperationOutput) (result *mycli.Result, err error) {
 	holder, err := mycli.FeatureState(ctx, session, sessionStateKey,
 		func(context.Context, *mycli.Session) (*cqlSessionHolder, error) {
 			return &cqlSessionHolder{}, nil

--- a/internal/mycli/feature/llm/llm.go
+++ b/internal/mycli/feature/llm/llm.go
@@ -259,7 +259,7 @@ type GeminiStatement struct {
 	cfg  *config
 }
 
-func (s *GeminiStatement) Execute(ctx context.Context, session *mycli.Session) (*mycli.Result, error) {
+func (s *GeminiStatement) Execute(ctx context.Context, session *mycli.Session, out mycli.OperationOutput) (*mycli.Result, error) {
 	totalStart := time.Now()
 
 	ddlStart := time.Now()

--- a/internal/mycli/feature_seam_test.go
+++ b/internal/mycli/feature_seam_test.go
@@ -49,7 +49,7 @@ type featureStatement struct {
 	mycli.MarksDetachedCompatible
 }
 
-func (*featureStatement) Execute(ctx context.Context, s *mycli.Session) (*mycli.Result, error) {
+func (*featureStatement) Execute(ctx context.Context, s *mycli.Session, out mycli.OperationOutput) (*mycli.Result, error) {
 	return nil, nil
 }
 

--- a/internal/mycli/fuzzy_plan_node_test.go
+++ b/internal/mycli/fuzzy_plan_node_test.go
@@ -114,7 +114,7 @@ func TestPlanNodeCompletionCandidates(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result, err := stmt.Execute(t.Context(), session)
+		result, err := stmt.Execute(t.Context(), session, OperationOutput{})
 		if err != nil || result == nil {
 			t.Fatalf("SHOW %s: result=%v err=%v", id, result, err)
 		}

--- a/internal/mycli/integration_dump_catalog_test.go
+++ b/internal/mycli/integration_dump_catalog_test.go
@@ -53,7 +53,7 @@ func fourParentCatalogDDL() []string {
 
 func dumpSQL(t *testing.T, session *Session, stmt Statement) string {
 	t.Helper()
-	result, err := stmt.Execute(t.Context(), session)
+	result, err := stmt.Execute(t.Context(), session, OperationOutput{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func dumpStreamingSQL(t *testing.T, session *Session, stmt Statement) string {
 		original.GetErrStream(),
 	)
 	defer func() { session.systemVariables.StreamManager = original }()
-	result, err := stmt.Execute(t.Context(), session)
+	result, err := stmt.Execute(t.Context(), session, OperationOutput{w: &buf})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestDumpCatalogNamedUsersBufferedStreamingReplay(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result, err := stmt.Execute(t.Context(), dest)
+		result, err := stmt.Execute(t.Context(), dest, OperationOutput{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -258,7 +258,7 @@ func replayDumpSQL(t *testing.T, dest *Session, sql string) {
 		if err != nil {
 			t.Fatalf("replay parse %q: %v", stripped, err)
 		}
-		if _, err := stmt.Execute(t.Context(), dest); err != nil {
+		if _, err := stmt.Execute(t.Context(), dest, OperationOutput{}); err != nil {
 			t.Fatalf("replay exec %q: %v", stripped, err)
 		}
 	}
@@ -332,7 +332,7 @@ func TestDumpCatalogConditionalGetDdlAndPermission(t *testing.T) {
 	var buf strings.Builder
 	original := session.systemVariables.StreamManager
 	session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
-	_, err := (&DumpTablesStatement{Tables: []tableID{tidn("Beta", "CrossChild"), tidn("Alpha", "Parent")}}).Execute(t.Context(), session)
+	_, err := (&DumpTablesStatement{Tables: []tableID{tidn("Beta", "CrossChild"), tidn("Alpha", "Parent")}}).Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "spanner.databases.getDdl") {
 		t.Fatalf("PermissionDenied = %v", err)
 	}
@@ -401,11 +401,11 @@ func TestDumpCatalogCrossSchemaFKAndView(t *testing.T) {
 		t.Fatalf("absent FK parent was added:\n%s", childOnly)
 	}
 
-	_, err = (&DumpTablesStatement{Tables: []tableID{tid("V")}}).Execute(t.Context(), session)
+	_, err = (&DumpTablesStatement{Tables: []tableID{tid("V")}}).Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "not a base table") {
 		t.Fatalf("view dump error = %v", err)
 	}
-	_, err = (&DumpTablesStatement{Tables: []tableID{tid("Missing")}}).Execute(t.Context(), session)
+	_, err = (&DumpTablesStatement{Tables: []tableID{tid("Missing")}}).Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("missing dump error = %v", err)
 	}
@@ -419,7 +419,7 @@ func TestDumpPlanSkipsNoWritableColumns(t *testing.T) {
 	var result *Result
 	err := session.txn.withReadOnlyTransactionOrStart(t.Context(), func(txn *spanner.ReadOnlyTransaction) error {
 		var err error
-		result, err = executeDumpBufferedWithTxn(t.Context(), session, dumpModeTables, plan, txn, nil)
+		result, err = executeDumpBufferedWithTxn(t.Context(), session, dumpModeTables, plan, txn, nil, OperationOutput{})
 		return err
 	})
 	if err != nil {
@@ -513,7 +513,7 @@ func TestDumpSameReadTransaction(t *testing.T) {
 					if mode == "tables" {
 						stmt = &DumpTablesStatement{Tables: []tableID{tid("Parent"), tid("Child")}}
 					}
-					result, err := stmt.Execute(t.Context(), session)
+					result, err := stmt.Execute(t.Context(), session, OperationOutput{})
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -559,7 +559,7 @@ func TestDumpInvalidSameBasenameCandidateDoesNotGetDdl(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name+"_buffered", func(t *testing.T) {
-			_, err := (&DumpTablesStatement{Tables: tt.tables}).Execute(t.Context(), session)
+			_, err := (&DumpTablesStatement{Tables: tt.tables}).Execute(t.Context(), session, OperationOutput{})
 			if err == nil || !strings.Contains(err.Error(), tt.errSub) {
 				t.Fatalf("error = %v, want %q", err, tt.errSub)
 			}
@@ -569,7 +569,7 @@ func TestDumpInvalidSameBasenameCandidateDoesNotGetDdl(t *testing.T) {
 			original := session.systemVariables.StreamManager
 			session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
 			defer func() { session.systemVariables.StreamManager = original }()
-			_, err := (&DumpTablesStatement{Tables: tt.tables}).Execute(t.Context(), session)
+			_, err := (&DumpTablesStatement{Tables: tt.tables}).Execute(t.Context(), session, OperationOutput{})
 			if err == nil || !strings.Contains(err.Error(), tt.errSub) {
 				t.Fatalf("error = %v, want %q", err, tt.errSub)
 			}
@@ -618,7 +618,7 @@ func TestDumpDDLRewriteFailureBeforeOutput(t *testing.T) {
 				if streaming {
 					session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
 				}
-				result, err := statement.Execute(t.Context(), session)
+				result, err := statement.Execute(t.Context(), session, OperationOutput{})
 				session.systemVariables.StreamManager = original
 				if err == nil || result != nil || buf.Len() != 0 {
 					t.Fatalf("%T streaming=%v: result=%+v error=%v output=%q; want error before any output", statement, streaming, result, err, buf.String())

--- a/internal/mycli/integration_dump_cycle_safety_test.go
+++ b/internal/mycli/integration_dump_cycle_safety_test.go
@@ -46,7 +46,7 @@ func parentChildOtherDDL() []string {
 
 func dumpExpectCycleReject(t *testing.T, session *Session, stmt Statement) {
 	t.Helper()
-	_, err := stmt.Execute(t.Context(), session)
+	_, err := stmt.Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), dumpCyclicInsertUnsupported) {
 		t.Fatalf("error = %v, want %q", err, dumpCyclicInsertUnsupported)
 	}
@@ -58,7 +58,7 @@ func dumpExpectCycleRejectStreaming(t *testing.T, session *Session, stmt Stateme
 	original := session.systemVariables.StreamManager
 	session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
 	defer func() { session.systemVariables.StreamManager = original }()
-	_, err := stmt.Execute(t.Context(), session)
+	_, err := stmt.Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), dumpCyclicInsertUnsupported) {
 		t.Fatalf("error = %v, want %q", err, dumpCyclicInsertUnsupported)
 	}
@@ -204,7 +204,7 @@ func TestDumpNotEnforcedCycleDoesNotReject(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := stmt.Execute(t.Context(), session); err != nil {
+		if _, err := stmt.Execute(t.Context(), session, OperationOutput{}); err != nil {
 			t.Skipf("emulator did not accept NOT ENFORCED foreign keys: %v", err)
 		}
 	}
@@ -260,7 +260,7 @@ func TestDumpCyclePreflightOrchestrationErrorIsZeroOutput(t *testing.T) {
 	original := session.systemVariables.StreamManager
 	session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
 	defer func() { session.systemVariables.StreamManager = original }()
-	_, err := (&DumpDatabaseStatement{}).Execute(t.Context(), session)
+	_, err := (&DumpDatabaseStatement{}).Execute(t.Context(), session, OperationOutput{})
 	if !errors.Is(err, injected) {
 		t.Fatalf("error = %v, want injected", err)
 	}
@@ -290,7 +290,7 @@ func TestDumpCycleRowQueryCanceled(t *testing.T) {
 				session.systemVariables.StreamManager = streamio.NewStreamManager(original.GetInStream(), &buf, original.GetErrStream())
 				defer func() { session.systemVariables.StreamManager = original }()
 			}
-			_, err := (&DumpDatabaseStatement{}).Execute(ctx, session)
+			_, err := (&DumpDatabaseStatement{}).Execute(ctx, session, OperationOutput{})
 			t.Logf("row-query cancel error chain: %v", err)
 			for e := err; e != nil; e = errors.Unwrap(e) {
 				t.Logf("unwrap %T: %v grpc=%v", e, e, status.Code(e))
@@ -344,7 +344,7 @@ func TestDumpMixedEnforcementOrdersAndReplays(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := stmt.Execute(t.Context(), target); err != nil {
+		if _, err := stmt.Execute(t.Context(), target, OperationOutput{}); err != nil {
 			t.Fatalf("%s: %v", text, err)
 		}
 	}
@@ -540,7 +540,7 @@ func TestDumpCyclicMutateSubsetKeepsTargetConstraints(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					if _, replayErr = stmt.Execute(t.Context(), target); replayErr != nil {
+					if _, replayErr = stmt.Execute(t.Context(), target, OperationOutput{}); replayErr != nil {
 						break
 					}
 				}
@@ -723,12 +723,11 @@ func TestDumpCyclicMutatePlanningFailures(t *testing.T) {
 					var out strings.Builder
 					var result *Result
 					var err error
-					run := func() error { result, err = (&DumpDatabaseStatement{}).Execute(ctx, source); return err }
+					var opOut OperationOutput
 					if streaming {
-						err = source.withOutput(outputContext{w: &out}, run)
-					} else {
-						err = run()
+						opOut = OperationOutput{w: &out}
 					}
+					result, err = (&DumpDatabaseStatement{}).Execute(ctx, source, opOut)
 					if err == nil {
 						t.Fatal("expected pre-output failure")
 					}
@@ -780,7 +779,7 @@ func TestDumpCyclicMutateSecondCommitFailure(t *testing.T) {
 		if isCommit {
 			commits++
 		}
-		if _, err := stmt.Execute(t.Context(), target); err != nil {
+		if _, err := stmt.Execute(t.Context(), target, OperationOutput{}); err != nil {
 			if !isCommit || commits != 2 {
 				t.Fatalf("failure before second COMMIT: %s: %v", part.statement, err)
 			}

--- a/internal/mycli/integration_dump_cyclic_wire_test.go
+++ b/internal/mycli/integration_dump_cyclic_wire_test.go
@@ -174,12 +174,11 @@ func TestDumpCyclicMutateWireFailureBeforeOutput(t *testing.T) {
 					}
 					var out strings.Builder
 					var result *Result
-					run := func() error { result, err = (&DumpDatabaseStatement{}).Execute(t.Context(), session); return err }
+					var opOut OperationOutput
 					if streaming {
-						err = session.withOutput(outputContext{w: &out}, run)
-					} else {
-						err = run()
+						opOut = OperationOutput{w: &out}
 					}
+					result, err = (&DumpDatabaseStatement{}).Execute(t.Context(), session, opOut)
 					if writeCalls.Load() != 0 {
 						t.Fatalf("DUMP attempted %d source write RPCs: %v", writeCalls.Load(), err)
 					}

--- a/internal/mycli/integration_dump_test.go
+++ b/internal/mycli/integration_dump_test.go
@@ -63,7 +63,7 @@ func TestDumpStatements(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DDL statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to create test table: %v", err)
 		}
 	}
@@ -84,7 +84,7 @@ func TestDumpStatements(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DML statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to insert test data: %v", err)
 		}
 	}
@@ -125,7 +125,7 @@ func TestDumpStatements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.stmt.Execute(ctx, session)
+			result, err := tt.stmt.Execute(ctx, session, OperationOutput{})
 			if err != nil {
 				t.Fatalf("Execute failed: %v", err)
 			}
@@ -187,7 +187,7 @@ func TestDumpTablesWithInvalidTable(t *testing.T) {
 	_, session := initializeWithRandomDB(t, nil, nil)
 
 	stmt := &DumpTablesStatement{Tables: []tableID{tid("NonExistentTable")}}
-	_, err := stmt.Execute(ctx, session)
+	_, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err == nil {
 		t.Fatalf("Expected error for non-existent table")
 	}
@@ -206,7 +206,7 @@ func TestDumpEmptyDatabase(t *testing.T) {
 	_, session := initializeWithRandomDB(t, nil, nil)
 
 	stmt := &DumpDatabaseStatement{}
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestDumpWithStreaming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to build DDL statement: %v", err)
 	}
-	if _, err := stmt.Execute(ctx, session); err != nil {
+	if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 		t.Fatalf("Failed to create test table: %v", err)
 	}
 
@@ -249,7 +249,7 @@ func TestDumpWithStreaming(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DML statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to insert test data: %v", err)
 		}
 	}
@@ -267,7 +267,7 @@ func TestDumpWithStreaming(t *testing.T) {
 	)
 
 	dumpStmt := &DumpTablesStatement{Tables: []tableID{tid("StreamTest")}}
-	result, err := dumpStmt.Execute(ctx, session)
+	result, err := dumpStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestDumpWithForeignKeys(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DDL statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to create test table: %v", err)
 		}
 	}
@@ -342,14 +342,14 @@ func TestDumpWithForeignKeys(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DML statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to insert test data: %v", err)
 		}
 	}
 
 	// Test DUMP TABLES with FK dependencies
 	dumpStmt := &DumpTablesStatement{Tables: []tableID{tid("Concerts"), tid("Venues"), tid("Artists")}}
-	result, err := dumpStmt.Execute(ctx, session)
+	result, err := dumpStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestDumpWithMixedDependencies(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DDL statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to create test table: %v", err)
 		}
 	}
@@ -451,14 +451,14 @@ func TestDumpWithMixedDependencies(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to build DML statement: %v", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("Failed to insert test data: %v", err)
 		}
 	}
 
 	// Test DUMP DATABASE with mixed dependencies
 	dumpStmt := &DumpDatabaseStatement{}
-	result, err := dumpStmt.Execute(ctx, session)
+	result, err := dumpStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestDumpWithGeneratedColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to build DDL statement: %v", err)
 	}
-	if _, err := stmt.Execute(ctx, session); err != nil {
+	if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 		t.Fatalf("Failed to create test table: %v", err)
 	}
 
@@ -526,13 +526,13 @@ func TestDumpWithGeneratedColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to build INSERT statement: %v", err)
 	}
-	if _, err := insertStmt.Execute(ctx, session); err != nil {
+	if _, err := insertStmt.Execute(ctx, session, OperationOutput{}); err != nil {
 		t.Fatalf("Failed to insert test data: %v", err)
 	}
 
 	// Execute DUMP TABLES
 	dumpStmt := &DumpTablesStatement{Tables: []tableID{tid("Users")}}
-	result, err := dumpStmt.Execute(ctx, session)
+	result, err := dumpStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("DUMP TABLES failed: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestDumpFloat32NegativeZeroReplay(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result, err := stmt.Execute(t.Context(), session)
+		result, err := stmt.Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("execute %s: %v", sql, err)
 		}

--- a/internal/mycli/integration_mutate_prefix_test.go
+++ b/internal/mycli/integration_mutate_prefix_test.go
@@ -33,7 +33,7 @@ func TestMutateQuotedNamedSchemaAndLowercaseDelete(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := stmt.Execute(t.Context(), session); err != nil {
+		if _, err := stmt.Execute(t.Context(), session, OperationOutput{}); err != nil {
 			t.Fatalf("%s: %v", sql, err)
 		}
 	}
@@ -49,7 +49,7 @@ func TestMutateQuotedNamedSchemaAndLowercaseDelete(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res, err := stmt.Execute(t.Context(), session)
+		res, err := stmt.Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/mycli/integration_sql_export_test.go
+++ b/internal/mycli/integration_sql_export_test.go
@@ -31,7 +31,7 @@ func executeSQLExportForTest(t *testing.T, ctx context.Context, session *Session
 		t.Fatalf("Failed to build export statement: %v", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	return result, buf.String(), err
 }
 
@@ -145,7 +145,7 @@ CREATE TABLE DestTable (
 			if err != nil {
 				t.Fatalf("Failed to build count statement: %v", err)
 			}
-			countResult, err := countStmt.Execute(ctx, session)
+			countResult, err := countStmt.Execute(ctx, session, OperationOutput{})
 			if err != nil {
 				t.Fatalf("Failed to count source data: %v", err)
 			}
@@ -193,7 +193,7 @@ CREATE TABLE DestTable (
 				if err != nil {
 					t.Fatalf("Failed to build INSERT statement: %v\nSQL: %s", err, sqlStmt)
 				}
-				_, err = insertStmt.Execute(ctx, session)
+				_, err = insertStmt.Execute(ctx, session, OperationOutput{})
 				if err != nil {
 					t.Fatalf("Failed to execute generated SQL: %v\nSQL: %s", err, sqlStmt)
 				}
@@ -294,7 +294,7 @@ CREATE TABLE ComplexDest (
 		if err != nil {
 			t.Fatalf("Failed to build INSERT statement: %v\nSQL: %s", err, sqlStmt)
 		}
-		_, err = insertStmt.Execute(ctx, session)
+		_, err = insertStmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Failed to execute generated SQL: %v\nSQL: %s", err, sqlStmt)
 		}
@@ -454,7 +454,7 @@ CREATE TABLE TestTable (
 			}
 
 			// Execute will stream directly to the buffer via StreamManager
-			result, err := stmt.Execute(ctx, session)
+			result, err := stmt.Execute(ctx, session, OperationOutput{})
 			if err != nil {
 				t.Fatalf("Failed to execute query: %v", err)
 			}
@@ -639,7 +639,7 @@ func TestSQLExportWithUnnamedColumns(t *testing.T) {
 			t.Fatalf("Failed to build statement: %v", err)
 		}
 
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 
 		t.Logf("Streaming mode test:")
 		t.Logf("Query: %s", query)
@@ -682,7 +682,7 @@ func TestSQLExportWithUnnamedColumns(t *testing.T) {
 			t.Fatalf("Failed to build statement: %v", err)
 		}
 
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 
 		t.Logf("Streaming mode test with named columns:")
 		t.Logf("Query: %s", query)

--- a/internal/mycli/integration_test.go
+++ b/internal/mycli/integration_test.go
@@ -375,7 +375,7 @@ func TestSelect(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -404,7 +404,7 @@ func TestDml(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -449,7 +449,7 @@ func buildAndExecute(t *testing.T, ctx context.Context, session *Session, s stri
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -1054,7 +1054,7 @@ func TestShowStatements(t *testing.T) {
 			stmtResults: []stmtResult{
 				{
 					"HELP",
-					lo.Must((&HelpStatement{}).Execute(t.Context(), nil)),
+					lo.Must((&HelpStatement{}).Execute(t.Context(), nil, OperationOutput{})),
 				},
 			},
 		},
@@ -1063,7 +1063,7 @@ func TestShowStatements(t *testing.T) {
 			stmtResults: []stmtResult{
 				{
 					"HELP VARIABLES",
-					lo.Must((&HelpVariablesStatement{}).Execute(context.Background(), nil)),
+					lo.Must((&HelpVariablesStatement{}).Execute(context.Background(), nil, OperationOutput{})),
 				},
 			},
 		},
@@ -1730,7 +1730,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1745,7 +1745,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(ctx, session)
+		result, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1761,7 +1761,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(ctx, session)
+		result, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1810,7 +1810,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1825,7 +1825,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(ctx, session)
+		result, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1841,7 +1841,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(ctx, session)
+		result, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1872,7 +1872,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -1881,7 +1881,7 @@ func TestReadWriteTransaction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -1954,7 +1954,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1969,7 +1969,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(ctx, session)
+		result, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -1988,7 +1988,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(ctx, session)
+		result, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -2015,14 +2015,14 @@ func TestReadOnlyTransaction(t *testing.T) {
 			if err != nil {
 				return false, err
 			}
-			if _, err := stmt.Execute(ctx, session); err != nil {
+			if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 				return false, err
 			}
 			// Always close the read-only transaction before the next attempt,
 			// including when the staleness timestamp predates the table.
 			defer func() {
 				if closeStmt, err := BuildStatement("CLOSE"); err == nil {
-					_, _ = closeStmt.Execute(ctx, session)
+					_, _ = closeStmt.Execute(ctx, session, OperationOutput{})
 				}
 			}()
 
@@ -2030,7 +2030,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			if err != nil {
 				return false, err
 			}
-			result, err := stmt.Execute(ctx, session)
+			result, err := stmt.Execute(ctx, session, OperationOutput{})
 			if err != nil {
 				// Typically "Table not found" because now-5s predates creation.
 				return false, err
@@ -2048,7 +2048,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -2058,7 +2058,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		if _, err := stmt.Execute(ctx, session); err != nil {
+		if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -2068,7 +2068,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -2088,7 +2088,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		_, err = stmt.Execute(ctx, session)
+		_, err = stmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -2110,7 +2110,7 @@ func TestShowCreateTable(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -2139,7 +2139,7 @@ func TestShowColumns(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -2169,7 +2169,7 @@ func TestShowIndexes(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(ctx, session)
+	result, err := stmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -2198,7 +2198,7 @@ func TestTruncateTable(t *testing.T) {
 		t.Fatalf("invalid statement: %v", err)
 	}
 
-	if _, err := stmt.Execute(ctx, session); err != nil {
+	if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 		t.Fatalf("execution failed: %v", err)
 	}
 
@@ -2231,7 +2231,7 @@ func TestPartitionedDML(t *testing.T) {
 		t.Fatalf("invalid statement: %v", err)
 	}
 
-	if _, err := stmt.Execute(ctx, session); err != nil {
+	if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 		t.Fatalf("execution failed: %v", err)
 	}
 
@@ -2262,7 +2262,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid DDL statement: %v", err)
 	}
 
-	if _, err := stmt.Execute(ctx, session); err != nil {
+	if _, err := stmt.Execute(ctx, session, OperationOutput{}); err != nil {
 		t.Fatalf("DDL execution failed: %v", err)
 	}
 
@@ -2272,7 +2272,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid SHOW SCHEMA UPDATE OPERATIONS statement: %v", err)
 	}
 
-	result, err := showOpsStmt.Execute(ctx, session)
+	result, err := showOpsStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("SHOW SCHEMA UPDATE OPERATIONS execution failed: %v", err)
 	}
@@ -2306,7 +2306,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid SHOW OPERATION statement: %v", err)
 	}
 
-	opResult, err := showOpStmt.Execute(ctx, session)
+	opResult, err := showOpStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("SHOW OPERATION execution failed: %v", err)
 	}
@@ -2362,7 +2362,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid SHOW OPERATION statement with full name: %v", err)
 	}
 
-	fullOpResult, err := showOpFullStmt.Execute(ctx, session)
+	fullOpResult, err := showOpFullStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("SHOW OPERATION execution with full name failed: %v", err)
 	}
@@ -2379,7 +2379,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid SHOW OPERATION statement for non-existent ID: %v", err)
 	}
 
-	_, err = nonExistentStmt.Execute(ctx, session)
+	_, err = nonExistentStmt.Execute(ctx, session, OperationOutput{})
 	if err == nil {
 		t.Error("Expected error for non-existent operation ID, but got none")
 	}
@@ -2391,7 +2391,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid SHOW OPERATION SYNC statement: %v", err)
 	}
 
-	syncResult, err := syncStmt.Execute(ctx, session)
+	syncResult, err := syncStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("SHOW OPERATION SYNC execution failed: %v", err)
 	}
@@ -2408,7 +2408,7 @@ func TestShowOperation(t *testing.T) {
 		t.Fatalf("invalid SHOW OPERATION ASYNC statement: %v", err)
 	}
 
-	asyncResult, err := asyncStmt.Execute(ctx, session)
+	asyncResult, err := asyncStmt.Execute(ctx, session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("SHOW OPERATION ASYNC execution failed: %v", err)
 	}

--- a/internal/mycli/meta_commands.go
+++ b/internal/mycli/meta_commands.go
@@ -32,7 +32,7 @@ var _ MetaCommandStatement = (*ShellMetaCommand)(nil)
 func (s *ShellMetaCommand) isMetaCommand() {}
 
 // Execute runs the shell command
-func (s *ShellMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShellMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Check if system commands are disabled
 	if session.systemVariables.Config.SkipSystemCommand {
 		return nil, errors.New("system commands are disabled")
@@ -50,7 +50,7 @@ func (s *ShellMetaCommand) Execute(ctx context.Context, session *Session) (*Resu
 	// The raw command text is intentionally not logged: it can contain
 	// sensitive data, and this is an internal invariant violation where the
 	// command content is irrelevant to diagnosis.
-	stdout := session.outputWriter()
+	stdout := session.resolveOperationOutput(out).Writer()
 	if stdout == nil {
 		slog.Error("no output destination configured, cannot execute shell command")
 		return nil, errors.New("internal error: no output destination configured")
@@ -190,7 +190,7 @@ var _ MetaCommandStatement = (*SourceMetaCommand)(nil)
 func (s *SourceMetaCommand) isMetaCommand() {}
 
 // Execute is not used for SourceMetaCommand as it's handled specially in CLI
-func (s *SourceMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SourceMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// This should not be called as SourceMetaCommand is handled in handleSpecialStatements.
 	// While panic might be more appropriate for this logic error, we follow the
 	// codebase convention of avoiding panics and return an error instead.
@@ -209,7 +209,7 @@ var _ MetaCommandStatement = (*PromptMetaCommand)(nil)
 func (p *PromptMetaCommand) isMetaCommand() {}
 
 // Execute updates the CLI_PROMPT system variable
-func (p *PromptMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (p *PromptMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Add a trailing space to the prompt for better UX (separation between prompt and input)
 	// This ensures compatibility with Google Cloud Spanner CLI behavior
 	promptWithSpace := p.PromptString + " "
@@ -238,7 +238,7 @@ func (s *UseDatabaseMetaCommand) isMetaCommand() {}
 func (s *UseDatabaseMetaCommand) isDetachedCompatible() {}
 
 // Execute is required by Statement interface but the actual logic is handled in SessionHandler
-func (s *UseDatabaseMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *UseDatabaseMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// This should not be called as UseDatabaseMetaCommand is handled in SessionHandler.
 	// While panic might be more appropriate for this logic error, we follow the
 	// codebase convention of avoiding panics and return an error instead.
@@ -268,7 +268,7 @@ var _ MetaCommandStatement = (*TeeOutputMetaCommand)(nil)
 func (t *TeeOutputMetaCommand) isMetaCommand() {}
 
 // Execute enables tee output to the specified file (both screen and file)
-func (t *TeeOutputMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (t *TeeOutputMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Validate that we have system variables and stream manager available
 	if session.systemVariables == nil {
 		return nil, errors.New("internal error: system variables not initialized")
@@ -292,7 +292,7 @@ var _ MetaCommandStatement = (*OutputRedirectMetaCommand)(nil)
 func (o *OutputRedirectMetaCommand) isMetaCommand() {}
 
 // Execute enables output redirect to the specified file (file only)
-func (o *OutputRedirectMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (o *OutputRedirectMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Validate that we have system variables and stream manager available
 	if session.systemVariables == nil {
 		return nil, errors.New("internal error: system variables not initialized")
@@ -344,11 +344,11 @@ func disableOutput(session *Session) (*Result, error) {
 }
 
 // Execute disables tee output
-func (d *DisableTeeMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (d *DisableTeeMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return disableOutput(session)
 }
 
 // Execute disables output redirect (returns to stdout)
-func (d *DisableOutputRedirectMetaCommand) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (d *DisableOutputRedirectMetaCommand) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return disableOutput(session)
 }

--- a/internal/mycli/meta_commands_test.go
+++ b/internal/mycli/meta_commands_test.go
@@ -354,7 +354,7 @@ func TestShellMetaCommand_Execute(t *testing.T) {
 		}
 
 		cmd := &ShellMetaCommand{Command: "echo hello"}
-		_, err := cmd.Execute(ctx, session)
+		_, err := cmd.Execute(ctx, session, OperationOutput{})
 		if err == nil {
 			t.Error("Execute() should fail when system commands are disabled")
 		}
@@ -374,7 +374,7 @@ func TestShellMetaCommand_Execute(t *testing.T) {
 		}
 
 		cmd := &ShellMetaCommand{Command: "echo hello"}
-		result, err := cmd.Execute(ctx, session)
+		result, err := cmd.Execute(ctx, session, OperationOutput{w: &output})
 		if err != nil {
 			t.Errorf("Execute() error = %v, want nil", err)
 		}
@@ -399,14 +399,14 @@ func TestShellMetaCommand_Execute(t *testing.T) {
 
 		// Test case: Command that exits with non-zero status (should not return error)
 		cmd := &ShellMetaCommand{Command: "exit 1"}
-		_, err := cmd.Execute(ctx, session)
+		_, err := cmd.Execute(ctx, session, OperationOutput{w: &output})
 		if err != nil {
 			t.Errorf("Execute() should not return error for exit status: %v", err)
 		}
 
 		// Test case: Command that fails (should also not return error since it's ExitError)
 		cmd2 := &ShellMetaCommand{Command: "ls /nonexistent/directory"}
-		_, err2 := cmd2.Execute(ctx, session)
+		_, err2 := cmd2.Execute(ctx, session, OperationOutput{w: &output})
 		if err2 != nil {
 			t.Errorf("Execute() should not return error for command that exits with error status: %v", err2)
 		}
@@ -506,7 +506,7 @@ func TestPromptMetaCommand_Execute(t *testing.T) {
 			}
 
 			cmd := &PromptMetaCommand{PromptString: tt.promptString}
-			result, err := cmd.Execute(ctx, session)
+			result, err := cmd.Execute(ctx, session, OperationOutput{})
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
@@ -659,7 +659,7 @@ func TestTeeOutputMetaCommand_Execute(t *testing.T) {
 			originalWriter := sysVars.StreamManager.GetWriter()
 
 			cmd := &TeeOutputMetaCommand{FilePath: path}
-			result, err := cmd.Execute(ctx, session)
+			result, err := cmd.Execute(ctx, session, OperationOutput{})
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
@@ -724,7 +724,7 @@ func TestDisableTeeMetaCommand_Execute(t *testing.T) {
 			}
 
 			cmd := &DisableTeeMetaCommand{}
-			result, err := cmd.Execute(ctx, session)
+			result, err := cmd.Execute(ctx, session, OperationOutput{})
 			if err != nil {
 				t.Errorf("Execute() error = %v, want nil", err)
 			}
@@ -790,7 +790,7 @@ func TestShellMetaCommand_Execute_noOutputAndCancel(t *testing.T) {
 
 	t.Run("no output destination", func(t *testing.T) {
 		session := &Session{systemVariables: &systemVariables{}}
-		_, err := (&ShellMetaCommand{Command: "echo hello"}).Execute(ctx, session)
+		_, err := (&ShellMetaCommand{Command: "echo hello"}).Execute(ctx, session, OperationOutput{})
 		if err == nil || err.Error() != "internal error: no output destination configured" {
 			t.Fatalf("error = %v, want no output destination", err)
 		}
@@ -803,7 +803,7 @@ func TestShellMetaCommand_Execute_noOutputAndCancel(t *testing.T) {
 		session := &Session{systemVariables: &sysVars}
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := (&ShellMetaCommand{Command: "sleep 5"}).Execute(ctx, session)
+		_, err := (&ShellMetaCommand{Command: "sleep 5"}).Execute(ctx, session, OperationOutput{w: &output})
 		if err == nil || !strings.Contains(err.Error(), "command failed") {
 			t.Fatalf("error = %v, want command failed wrapping context cancellation", err)
 		}
@@ -815,12 +815,12 @@ func TestSourceAndUseMetaCommand_ExecuteMustNotRun(t *testing.T) {
 	ctx := context.Background()
 	session := &Session{}
 
-	_, err := (&SourceMetaCommand{FilePath: "x.sql"}).Execute(ctx, session)
+	_, err := (&SourceMetaCommand{FilePath: "x.sql"}).Execute(ctx, session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "must be handled by the CLI") {
 		t.Fatalf("SourceMetaCommand.Execute error = %v", err)
 	}
 
-	_, err = (&UseDatabaseMetaCommand{Database: "db"}).Execute(ctx, session)
+	_, err = (&UseDatabaseMetaCommand{Database: "db"}).Execute(ctx, session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "must be handled by the SessionHandler") {
 		t.Fatalf("UseDatabaseMetaCommand.Execute error = %v", err)
 	}
@@ -837,7 +837,7 @@ func TestOutputRedirectAndDisable_Execute(t *testing.T) {
 			t.Fatal("test session should capture base output in a *bytes.Buffer")
 		}
 		path := filepath.Join(t.TempDir(), "out.log")
-		result, err := (&OutputRedirectMetaCommand{FilePath: path}).Execute(ctx, session)
+		result, err := (&OutputRedirectMetaCommand{FilePath: path}).Execute(ctx, session, OperationOutput{})
 		if err != nil || result == nil {
 			t.Fatalf("Execute error = %v result = %v", err, result)
 		}
@@ -853,7 +853,7 @@ func TestOutputRedirectAndDisable_Execute(t *testing.T) {
 			t.Fatalf("silent redirect leaked to base output: %q", base.String())
 		}
 
-		if _, err := (&DisableOutputRedirectMetaCommand{}).Execute(ctx, session); err != nil {
+		if _, err := (&DisableOutputRedirectMetaCommand{}).Execute(ctx, session, OperationOutput{}); err != nil {
 			t.Fatalf("disable: %v", err)
 		}
 		if sysVars.StreamManager.IsInSilentTeeMode() {
@@ -882,7 +882,7 @@ func TestOutputRedirectAndDisable_Execute(t *testing.T) {
 
 	t.Run("redirect to directory", func(t *testing.T) {
 		session, _ := createTestSession(t)
-		_, err := (&OutputRedirectMetaCommand{FilePath: t.TempDir()}).Execute(ctx, session)
+		_, err := (&OutputRedirectMetaCommand{FilePath: t.TempDir()}).Execute(ctx, session, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
 			t.Fatalf("error = %v, want regular file", err)
 		}
@@ -909,12 +909,12 @@ func TestTeeAndDisableOutput_missingInternals(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			exec, ok := tt.cmd.(interface {
-				Execute(context.Context, *Session) (*Result, error)
+				Execute(context.Context, *Session, OperationOutput) (*Result, error)
 			})
 			if !ok {
 				t.Fatal("statement is not executable")
 			}
-			_, err := exec.Execute(ctx, tt.sess)
+			_, err := exec.Execute(ctx, tt.sess, OperationOutput{})
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}

--- a/internal/mycli/mutation_typed_keys_test.go
+++ b/internal/mycli/mutation_typed_keys_test.go
@@ -93,7 +93,7 @@ func TestMutationTypedDeleteKeysIntegration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := stmt.Execute(t.Context(), session); err != nil {
+		if _, err := stmt.Execute(t.Context(), session, OperationOutput{}); err != nil {
 			t.Fatalf("%s: %v", sql, err)
 		}
 	}
@@ -164,7 +164,7 @@ func TestMutationTypedCompositeDeleteTransaction(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := stmt.Execute(t.Context(), session); err != nil {
+		if _, err := stmt.Execute(t.Context(), session, OperationOutput{}); err != nil {
 			t.Fatalf("%s: %v", sql, err)
 		}
 	}

--- a/internal/mycli/output_context.go
+++ b/internal/mycli/output_context.go
@@ -17,86 +17,93 @@ package mycli
 import (
 	"context"
 	"io"
+	"math"
 )
 
-// outputContext is the per-statement output destination for streamed results
-// (streaming formats, DUMP). It is resolved once at the statement entry point
-// (Cli.executeStatement, which also serves the MCP handler through its writer
-// argument) and carried by the Session for the duration of one statement.
+// OperationOutput is the per-statement output destination for streamed results
+// (streaming formats, DUMP, shell). It is resolved once at the statement entry
+// point (Cli.executeStatement, which also serves the MCP handler through its
+// writer argument, and Session.ExecuteStatement for direct callers) and
+// carried through Execute and every nested execution path.
 //
 // Before this type existed, streaming paths wrote to the process-global
 // StreamManager writer regardless of which writer the caller passed to
 // Cli.executeStatement. Under --mcp that writer is the JSON-RPC stdout, so
-// any streamed statement corrupted the protocol stream. Routing all statement
-// output through the session's outputContext makes the caller-provided writer
-// authoritative on every path.
-type outputContext struct {
-	// w receives streamed statement output. When nil, the session falls back
-	// to the StreamManager writer (direct Session.ExecuteStatement callers,
-	// e.g. tests).
+// any streamed statement corrupted the protocol stream. The caller-provided
+// writer is authoritative on every path. A statement that does not emit
+// output ignores the value.
+type OperationOutput struct {
+	// w receives streamed statement output. When nil after entry-point
+	// resolution, streaming paths treat it as "buffer instead".
 	w io.Writer
 
 	// screenWidth resolves the display width for streamed table rendering.
 	// It is a function rather than a value so the terminal size is read when
-	// rendering starts, not when the statement was submitted. When nil, the
-	// session falls back to displayScreenWidth on the live settings.
+	// rendering starts, not when the statement was submitted. Width is
+	// resolved against the original destination, not a pager pipe.
 	screenWidth func() int
 }
 
-// outputWriter returns the destination for streamed statement output: the
-// per-statement outputContext writer when one is set, otherwise the
-// StreamManager writer. May return nil (no output destination); streaming
-// paths treat nil as "buffer instead".
-func (s *Session) outputWriter() io.Writer {
-	if s.output.w != nil {
-		return s.output.w
-	}
-	if s.systemVariables != nil && s.systemVariables.StreamManager != nil {
-		return s.systemVariables.StreamManager.GetWriter()
-	}
-	return nil
+// Writer returns the destination for streamed statement output. Nil means
+// streaming paths should buffer instead.
+func (o OperationOutput) Writer() io.Writer {
+	return o.w
 }
 
-// displayWidthFor returns the screen width for streamed rendering. Width
-// comes from the live session settings (AutoWrap/FixedWidth/StreamManager)
-// or the per-statement outputContext override.
-func (s *Session) displayWidthFor() int {
-	if s.output.screenWidth != nil {
-		return s.output.screenWidth()
+// ScreenWidth returns the screen width for streamed rendering. When no
+// resolver is set, wrapping is disabled.
+func (o OperationOutput) ScreenWidth() int {
+	if o.screenWidth != nil {
+		return o.screenWidth()
 	}
-	return displayScreenWidth(s.systemVariables)
+	return math.MaxInt
 }
 
-// withOutput runs fn with the session's per-statement output redirected to
-// out, restoring the previous destination afterwards. Statement execution is
-// serialized per session (single-goroutine REPL/batch loops; the MCP handler
-// holds a mutex around each call), so plain save/restore is safe here.
-func (s *Session) withOutput(out outputContext, fn func() error) error {
-	prev := s.output
-	s.output = out
-	defer func() {
-		s.output = prev
-	}()
-	return fn()
+// withWriter returns a copy that writes to w while keeping the original lazy
+// width resolver. DUMP uses this for internal buffering so the outer
+// publication destination and width stay those of the caller.
+func (o OperationOutput) withWriter(w io.Writer) OperationOutput {
+	o.w = w
+	return o
+}
+
+// resolveOperationOutput fills a nil writer from StreamManager and a nil
+// width resolver from the live session settings. Caller-provided fields win.
+// Width stays lazy so the terminal is measured at render time against the
+// original destination. Streaming helpers also call this so a direct
+// Execute with a zero OperationOutput still sees StreamManager, matching
+// the former session.outputWriter() fallback without mutating Session.
+func (s *Session) resolveOperationOutput(out OperationOutput) OperationOutput {
+	if out.w == nil && s != nil && s.systemVariables != nil && s.systemVariables.StreamManager != nil {
+		out.w = s.systemVariables.StreamManager.GetWriter()
+	}
+	if out.screenWidth == nil {
+		var sysVars *systemVariables
+		if s != nil {
+			sysVars = s.systemVariables
+		}
+		out.screenWidth = func() int {
+			if sysVars == nil {
+				return math.MaxInt
+			}
+			return displayScreenWidth(sysVars)
+		}
+	}
+	return out
 }
 
 // ExecuteStatementWithOutput executes stmt with out as the per-statement
-// output destination. Statements executed re-entrantly during stmt (e.g.
-// RUN BATCH re-entering ExecuteStatement) inherit the same destination.
-func (s *Session) ExecuteStatementWithOutput(ctx context.Context, stmt Statement, out outputContext) (*Result, error) {
-	var result *Result
-	err := s.withOutput(out, func() error {
-		var err error
-		result, err = s.ExecuteStatement(ctx, stmt)
-		return err
-	})
-	return result, err
+// output destination. Fallback writer and width are resolved here; nested
+// execution (e.g. RUN BATCH) must forward the same value rather than re-entering
+// ExecuteStatement, which would rebuild a default destination.
+func (s *Session) ExecuteStatementWithOutput(ctx context.Context, stmt Statement, out OperationOutput) (*Result, error) {
+	return s.executeStatement(ctx, stmt, s.resolveOperationOutput(out))
 }
 
 // ExecuteStatementWithOutput executes a statement like ExecuteStatement,
 // routing streamed output to out. Session-changing statements (USE/DETACH)
 // produce no streamed output and take their normal path.
-func (h *SessionHandler) ExecuteStatementWithOutput(ctx context.Context, stmt Statement, out outputContext) (*Result, error) {
+func (h *SessionHandler) ExecuteStatementWithOutput(ctx context.Context, stmt Statement, out OperationOutput) (*Result, error) {
 	switch stmt.(type) {
 	case *UseStatement, *UseDatabaseMetaCommand, *DetachStatement:
 		return h.ExecuteStatement(ctx, stmt)

--- a/internal/mycli/output_context_test.go
+++ b/internal/mycli/output_context_test.go
@@ -58,6 +58,14 @@ func newDetachedTestSession(global io.Writer) *Session {
 	return session
 }
 
+// newClientlessDatabaseSession is a client-less DatabaseConnected session.
+// RUN BATCH is not DetachedCompatible, so nested-dispatch tests use this.
+func newClientlessDatabaseSession(global io.Writer) *Session {
+	session := newDetachedTestSession(global)
+	session.mode = DatabaseConnected
+	return session
+}
+
 // TestExecuteStatementWithOutput_routesStreamedOutput is the regression test
 // for the MCP protocol corruption bug: streamed statement output (here, SHOW
 // VARIABLES under CLI_FORMAT=CSV) must go to the per-statement writer, not to
@@ -106,23 +114,120 @@ func TestExecuteStatement_fallsBackToStreamManager(t *testing.T) {
 	}
 }
 
-// TestOperationOutput_nestedWriterOverride verifies that nested execution
-// forwards an explicit OperationOutput and that a local writer override
-// (DUMP internal buffering) does not mutate the caller's value.
-func TestOperationOutput_nestedWriterOverride(t *testing.T) {
+// TestOperationOutput_nestedRunBatchDispatch covers the #918 forwarding
+// boundary: RUN BATCH must re-enter ExecuteStatementWithOutput with the
+// caller destination. Dropping that value (ExecuteStatement) sends streamed
+// rows to StreamManager instead. Subtests share no session; each is sequential
+// so the next-statement default destination is deterministic.
+func TestOperationOutput_nestedRunBatchDispatch(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("success then default next statement", func(t *testing.T) {
+		t.Parallel()
+
+		var global, caller bytes.Buffer
+		session := newClientlessDatabaseSession(&global)
+		t.Cleanup(session.Close)
+		session.batch.SetCurrent(&ShowVariablesStatement{})
+		callerOut := OperationOutput{w: &caller}
+
+		result, err := session.ExecuteStatementWithOutput(ctx, &RunBatchStatement{}, callerOut)
+		if err != nil {
+			t.Fatalf("RUN BATCH: %v", err)
+		}
+		if !result.alreadyDelivered() {
+			t.Errorf("Streamed = false, want true (CSV should stream)")
+		}
+		if caller.Len() == 0 || !strings.Contains(caller.String(), "CLI_FORMAT") {
+			t.Errorf("caller writer got %q, want CSV rows including CLI_FORMAT", caller.String())
+		}
+		if global.Len() != 0 {
+			t.Errorf("StreamManager writer got %q, want empty during nested RUN BATCH", global.String())
+		}
+
+		callerLen := caller.Len()
+		next, err := session.ExecuteStatement(ctx, &ShowVariablesStatement{})
+		if err != nil {
+			t.Fatalf("next ExecuteStatement: %v", err)
+		}
+		if !next.alreadyDelivered() {
+			t.Errorf("next Streamed = false, want true")
+		}
+		if global.Len() == 0 || !strings.Contains(global.String(), "CLI_FORMAT") {
+			t.Errorf("next statement StreamManager writer got %q, want CSV rows", global.String())
+		}
+		if caller.Len() != callerLen {
+			t.Errorf("caller writer grew from %d to %d after next statement", callerLen, caller.Len())
+		}
+	})
+
+	t.Run("nested error then default next statement", func(t *testing.T) {
+		t.Parallel()
+
+		var global, caller bytes.Buffer
+		session := newClientlessDatabaseSession(&global)
+		t.Cleanup(session.Close)
+		session.batch.SetCurrent(&SetLocalStatement{VarName: "CLI_VERBOSE", Value: "TRUE"})
+		callerOut := OperationOutput{w: &caller}
+
+		_, err := session.ExecuteStatementWithOutput(ctx, &RunBatchStatement{}, callerOut)
+		if err == nil || !strings.Contains(err.Error(), "SET LOCAL requires an active transaction") {
+			t.Fatalf("RUN BATCH nested error = %v, want SET LOCAL transaction error", err)
+		}
+		if global.Len() != 0 {
+			t.Errorf("StreamManager writer got %q, want empty on nested error", global.String())
+		}
+		if caller.Len() != 0 {
+			t.Errorf("caller writer got %q, want empty on nested SET LOCAL error", caller.String())
+		}
+		if session.batch.IsActive() {
+			t.Error("batch still active after nested error; TakeForExecution should have consumed it")
+		}
+
+		next, err := session.ExecuteStatement(ctx, &ShowVariablesStatement{})
+		if err != nil {
+			t.Fatalf("next ExecuteStatement: %v", err)
+		}
+		if !next.alreadyDelivered() {
+			t.Errorf("next Streamed = false, want true")
+		}
+		if global.Len() == 0 || !strings.Contains(global.String(), "CLI_FORMAT") {
+			t.Errorf("next statement StreamManager writer got %q, want CSV rows", global.String())
+		}
+		if caller.Len() != 0 {
+			t.Errorf("caller writer got %q after next statement, want unchanged empty", caller.String())
+		}
+	})
+}
+
+// TestDumpBuffered_isolatesLocalWriter checks DUMP internal buffering: the
+// caller's OperationOutput writer stays unused and unmutated while the
+// prepared body receives the dumped bytes.
+func TestDumpBuffered_isolatesLocalWriter(t *testing.T) {
 	t.Parallel()
 
-	var outer, inner bytes.Buffer
-	outerOut := OperationOutput{w: &outer}
-	if got := outerOut.Writer(); got != &outer {
-		t.Errorf("Writer() = %v, want outer buffer", got)
+	var caller bytes.Buffer
+	session := newDetachedTestSession(io.Discard)
+	t.Cleanup(session.Close)
+	out := OperationOutput{w: &caller}
+	ddl := []byte("CREATE TABLE T (Id INT64) PRIMARY KEY(Id);\n")
+	result, err := executeDumpBufferedWithTxn(t.Context(), session, dumpModeSchema, &dumpPlan{DDL: ddl}, nil, nil, out)
+	if err != nil {
+		t.Fatalf("executeDumpBufferedWithTxn: %v", err)
 	}
-	innerOut := outerOut.withWriter(&inner)
-	if got := innerOut.Writer(); got != &inner {
-		t.Errorf("withWriter().Writer() = %v, want inner buffer", got)
+	if caller.Len() != 0 {
+		t.Errorf("caller writer got %q, want empty (DUMP buffers locally)", caller.String())
 	}
-	if got := outerOut.Writer(); got != &outer {
-		t.Errorf("original Writer() = %v after withWriter, want outer buffer", got)
+	if got := out.Writer(); got != &caller {
+		t.Errorf("caller OperationOutput.Writer() = %v after DUMP, want original buffer", got)
+	}
+	got, ok := result.Body.PreparedBytes()
+	if !ok {
+		t.Fatalf("result body kind = %v, want prepared bytes", result.Body)
+	}
+	if !bytes.Equal(got, ddl) {
+		t.Errorf("prepared body = %q, want %q", got, ddl)
 	}
 }
 

--- a/internal/mycli/output_context_test.go
+++ b/internal/mycli/output_context_test.go
@@ -68,7 +68,7 @@ func TestExecuteStatementWithOutput_routesStreamedOutput(t *testing.T) {
 	var global, perCall bytes.Buffer
 	session := newDetachedTestSession(&global)
 
-	result, err := session.ExecuteStatementWithOutput(context.Background(), &ShowVariablesStatement{}, outputContext{w: &perCall})
+	result, err := session.ExecuteStatementWithOutput(context.Background(), &ShowVariablesStatement{}, OperationOutput{w: &perCall})
 	if err != nil {
 		t.Fatalf("ExecuteStatementWithOutput: %v", err)
 	}
@@ -82,13 +82,10 @@ func TestExecuteStatementWithOutput_routesStreamedOutput(t *testing.T) {
 	if global.Len() != 0 {
 		t.Errorf("StreamManager writer got %q, want empty (rows must not leak to the global stream)", global.String())
 	}
-	if session.output.w != nil || session.output.screenWidth != nil {
-		t.Errorf("session.output not restored after execution: %+v", session.output)
-	}
 }
 
 // TestExecuteStatement_fallsBackToStreamManager pins the fallback behavior:
-// without a per-statement outputContext (direct Session.ExecuteStatement
+// without a per-statement OperationOutput writer (direct Session.ExecuteStatement
 // callers), streamed output still goes to the StreamManager writer.
 func TestExecuteStatement_fallsBackToStreamManager(t *testing.T) {
 	t.Parallel()
@@ -109,31 +106,23 @@ func TestExecuteStatement_fallsBackToStreamManager(t *testing.T) {
 	}
 }
 
-// TestWithOutput_nestedRestore verifies that nested withOutput calls (e.g.
-// buffered DUMP capturing SQL export while a per-statement destination is
-// active) restore the previous destination on unwind.
-func TestWithOutput_nestedRestore(t *testing.T) {
+// TestOperationOutput_nestedWriterOverride verifies that nested execution
+// forwards an explicit OperationOutput and that a local writer override
+// (DUMP internal buffering) does not mutate the caller's value.
+func TestOperationOutput_nestedWriterOverride(t *testing.T) {
 	t.Parallel()
 
 	var outer, inner bytes.Buffer
-	session := newDetachedTestSession(io.Discard)
-
-	err := session.withOutput(outputContext{w: &outer}, func() error {
-		if got := session.outputWriter(); got != &outer {
-			t.Errorf("outputWriter() = %v, want outer buffer", got)
-		}
-		return session.withOutput(outputContext{w: &inner}, func() error {
-			if got := session.outputWriter(); got != &inner {
-				t.Errorf("outputWriter() = %v, want inner buffer", got)
-			}
-			return nil
-		})
-	})
-	if err != nil {
-		t.Fatalf("withOutput: %v", err)
+	outerOut := OperationOutput{w: &outer}
+	if got := outerOut.Writer(); got != &outer {
+		t.Errorf("Writer() = %v, want outer buffer", got)
 	}
-	if session.output.w != nil || session.output.screenWidth != nil {
-		t.Errorf("session.output not restored after nested withOutput: %+v", session.output)
+	innerOut := outerOut.withWriter(&inner)
+	if got := innerOut.Writer(); got != &inner {
+		t.Errorf("withWriter().Writer() = %v, want inner buffer", got)
+	}
+	if got := outerOut.Writer(); got != &outer {
+		t.Errorf("original Writer() = %v after withWriter, want outer buffer", got)
 	}
 }
 

--- a/internal/mycli/query_cache_test.go
+++ b/internal/mycli/query_cache_test.go
@@ -68,7 +68,7 @@ func TestQueryCachePublicationSQLExportNames(t *testing.T) {
 			seed := seedQueryCacheA()
 			live.LastResult.QueryCache = seed
 
-			if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true); err != nil {
+			if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true, OperationOutput{}); err != nil {
 				t.Fatalf("executeSQLImplWithQueryRunner: %v", err)
 			}
 			if live.Display.SQLTableName != tt.sqlTableName {
@@ -86,7 +86,7 @@ func TestQueryCachePublicationSQLExportNames(t *testing.T) {
 			live.Display.CLIFormat = enums.DisplayModeSQLInsert
 			live.Display.SQLTableName = sqlTableName
 			live.LastResult.QueryCache = seedQueryCacheA()
-			if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true); err != nil {
+			if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true, OperationOutput{}); err != nil {
 				t.Fatalf("sqlTableName=%q: %v", sqlTableName, err)
 			}
 			published[i] = live.LastResult.QueryCache
@@ -135,14 +135,16 @@ func TestQueryCachePublicationBufferedAndStreamingEmitters(t *testing.T) {
 			session, live := newQueryCacheRPCSession(t, planB, statsB, nil)
 			live.Display.CLIFormat = tt.format
 			live.Display.SQLTableName = tt.sqlTableName
-			if tt.streaming {
-				var buf bytes.Buffer
-				live.StreamManager = streamio.NewStreamManager(io.NopCloser(strings.NewReader("")), &buf, io.Discard)
-			}
 			seed := seedQueryCacheA()
 			live.LastResult.QueryCache = seed
 
-			result, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true)
+			var out OperationOutput
+			if tt.streaming {
+				var buf bytes.Buffer
+				live.StreamManager = streamio.NewStreamManager(io.NopCloser(strings.NewReader("")), &buf, io.Discard)
+				out = OperationOutput{w: &buf}
+			}
+			result, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true, out)
 			if err != nil {
 				t.Fatalf("executeSQLImplWithQueryRunner: %v", err)
 			}
@@ -174,7 +176,7 @@ func TestQueryCachePublicationNilDestinationLeavesLiveCache(t *testing.T) {
 	txn := session.client.ReadOnlyTransaction()
 	t.Cleanup(txn.Close)
 	if _, err := executeSQLWithFormatAndTxn(t.Context(), session, txn, sqlExportSelectUsers,
-		enums.DisplayModeSQLInsert, enums.StreamingModeTrue, "Users", nil, &buf); err != nil {
+		enums.DisplayModeSQLInsert, enums.StreamingModeTrue, "Users", nil, OperationOutput{w: &buf}); err != nil {
 		t.Fatalf("executeSQLWithFormatAndTxn: %v", err)
 	}
 	if live.LastResult.QueryCache != seed {
@@ -217,7 +219,7 @@ func TestQueryCachePublicationParseFailureLeavesOldCache(t *testing.T) {
 	seed := seedQueryCacheA()
 	live.LastResult.QueryCache = seed
 
-	_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true)
+	_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true, OperationOutput{})
 	if err == nil {
 		t.Fatal("executeSQLImplWithQueryRunner error = nil, want iterator failure")
 	}
@@ -239,7 +241,7 @@ func TestQueryCachePublicationAppendixFailureKeepsPublishedCache(t *testing.T) {
 	seed := seedQueryCacheA()
 	live.LastResult.QueryCache = seed
 
-	_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true)
+	_, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true, OperationOutput{})
 	if err == nil {
 		t.Fatal("executeSQLImplWithQueryRunner error = nil, want appendix rendering failure")
 	}
@@ -261,11 +263,11 @@ func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 	}
 	live.LastResult.QueryCache = seed
 
-	if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true); err != nil {
+	if _, err := executeSQLImplWithQueryRunner(t.Context(), session, sqlExportSelectUsers, live, session.txn.RunQueryWithStats, true, OperationOutput{}); err != nil {
 		t.Fatalf("executeSQLImplWithQueryRunner: %v", err)
 	}
 
-	explain, err := (&ExplainLastQueryStatement{}).Execute(t.Context(), session)
+	explain, err := (&ExplainLastQueryStatement{}).Execute(t.Context(), session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("EXPLAIN LAST QUERY: %v", err)
 	}
@@ -289,7 +291,7 @@ func TestQueryCachePublicationExplainLastQueryAndPlanNodes(t *testing.T) {
 		t.Errorf("EXPLAIN LAST QUERY still showed the seed plan; rows=%v", explain.presentationRows())
 	}
 
-	show, err := (&ShowPlanNodeStatement{NodeID: 1}).Execute(t.Context(), session)
+	show, err := (&ShowPlanNodeStatement{NodeID: 1}).Execute(t.Context(), session, OperationOutput{})
 	if err != nil {
 		t.Fatalf("SHOW PLAN NODE 1: %v", err)
 	}

--- a/internal/mycli/query_mode_test.go
+++ b/internal/mycli/query_mode_test.go
@@ -76,7 +76,7 @@ func TestExportDataStatementRejectsPlanMode(t *testing.T) {
 	session := newSessionForLocalVarTest(t)
 	session.systemVariables.Query.QueryMode = sppb.ExecuteSqlRequest_PLAN.Enum()
 
-	_, err := (&ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS SELECT 1"}).Execute(t.Context(), session)
+	_, err := (&ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "CLI_QUERY_MODE=PLAN") {
 		t.Fatalf("ExportDataStatement.Execute() error = %v, want PLAN-mode rejection", err)
 	}
@@ -88,7 +88,7 @@ func TestExportDataStatementRejectsTryPartitionQuery(t *testing.T) {
 	session := newSessionForLocalVarTest(t)
 	session.systemVariables.Query.TryPartitionQuery = true
 
-	_, err := (&ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS SELECT 1"}).Execute(t.Context(), session)
+	_, err := (&ExportDataStatement{SQL: "EXPORT DATA OPTIONS (...) AS SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 	if err == nil || !strings.Contains(err.Error(), "CLI_TRY_PARTITION_QUERY=TRUE") {
 		t.Fatalf("ExportDataStatement.Execute() error = %v, want partition-probe rejection", err)
 	}

--- a/internal/mycli/result_sink.go
+++ b/internal/mycli/result_sink.go
@@ -30,7 +30,7 @@ import (
 )
 
 // resultSink is the per-statement output sink shared by streamed rows (via
-// outputContext) and buffered display (via printResult). It owns the output
+// OperationOutput) and buffered display (via printResult). It owns the output
 // decorations (CLI_MARKDOWN_CODEBLOCK fence, CLI_ECHO_INPUT echo) and the
 // CLI_USE_PAGER pager so both apply in the correct order regardless of
 // whether the statement streams.

--- a/internal/mycli/result_sink_pager_test.go
+++ b/internal/mycli/result_sink_pager_test.go
@@ -412,14 +412,14 @@ func TestResultSinkRepeatedFinishAbort(t *testing.T) {
 }
 
 // largeStreamStatement writes a payload larger than a typical OS pipe
-// buffer through the session output writer, which executeStatement binds
-// to the resultSink. It exists only to exercise the streamed pager path.
+// buffer through OperationOutput, which executeStatement binds to the
+// resultSink. It exists only to exercise the streamed pager path.
 type largeStreamStatement struct{}
 
 func (largeStreamStatement) isDetachedCompatible() {}
 
-func (largeStreamStatement) Execute(_ context.Context, session *Session) (*Result, error) {
-	w := session.outputWriter()
+func (largeStreamStatement) Execute(_ context.Context, _ *Session, out OperationOutput) (*Result, error) {
+	w := out.Writer()
 	if w == nil {
 		return nil, errors.New("no output writer")
 	}

--- a/internal/mycli/session.go
+++ b/internal/mycli/session.go
@@ -163,12 +163,6 @@ type Session struct {
 	// through the Feature seam (issue #778). Values implementing io.Closer are
 	// closed at the end of Close in reverse creation order.
 	featureState featureStore
-
-	// output is the per-statement output destination for streamed results,
-	// set for the duration of one statement execution via withOutput /
-	// ExecuteStatementWithOutput. See outputContext in output_context.go.
-	// Zero value means "fall back to the StreamManager writer".
-	output outputContext
 }
 
 // SchemaGeneration returns the current schema generation counter.
@@ -844,9 +838,16 @@ func (s *Session) failStatementIfReadOnly() error {
 	return nil
 }
 
-// ExecuteStatement executes stmt.
+// ExecuteStatement executes stmt with the session's default output destination
+// (StreamManager writer, or nil so streaming paths buffer). Nested execution
+// that must keep a caller-provided destination should use
+// ExecuteStatementWithOutput instead.
 // If stmt is a MutationStatement, pending transaction is determined and fails if there is an active read-only transaction.
-func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result *Result, err error) {
+func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (*Result, error) {
+	return s.ExecuteStatementWithOutput(ctx, stmt, OperationOutput{})
+}
+
+func (s *Session) executeStatement(ctx context.Context, stmt Statement, out OperationOutput) (result *Result, err error) {
 	// Validate statement compatibility with current session mode
 	if err := s.ValidateStatementExecution(stmt); err != nil {
 		return nil, err
@@ -878,7 +879,7 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 		if _, err := s.txn.DetermineTransaction(ctx); err != nil {
 			return result, err
 		}
-		return stmt.Execute(ctx, s)
+		return stmt.Execute(ctx, s, out)
 	}
 
 	if _, ok := stmt.(nonTransactionalMutationStatement); ok {
@@ -896,7 +897,7 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt Statement) (result 
 		}
 	}
 
-	return stmt.Execute(ctx, s)
+	return stmt.Execute(ctx, s, out)
 }
 
 // createAuthClientOptions builds credential-related client options.

--- a/internal/mycli/session_modes_unit_test.go
+++ b/internal/mycli/session_modes_unit_test.go
@@ -51,7 +51,7 @@ func TestDetachedSessionSystemVariables(t *testing.T) {
 	// Just test that SHOW VARIABLES works without error
 	t.Run("SHOW VARIABLES works in AdminOnly session", func(t *testing.T) {
 		stmt := &ShowVariablesStatement{}
-		result, err := stmt.Execute(ctx, session)
+		result, err := stmt.Execute(ctx, session, OperationOutput{})
 
 		if err != nil {
 			t.Errorf("SHOW VARIABLES failed: %v", err)
@@ -68,14 +68,14 @@ func TestDetachedSessionSystemVariables(t *testing.T) {
 	t.Run("SET/SHOW PARAMS work in AdminOnly session", func(t *testing.T) {
 		// Set param type
 		typeStmt := &SetParamTypeStatement{Name: "p1", Type: "STRING"}
-		_, err := typeStmt.Execute(ctx, session)
+		_, err := typeStmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Errorf("SET PARAM TYPE failed: %v", err)
 		}
 
 		// Verify with SHOW PARAMS
 		showStmt := &ShowParamsStatement{}
-		result, err := showStmt.Execute(ctx, session)
+		result, err := showStmt.Execute(ctx, session, OperationOutput{})
 		if err != nil {
 			t.Errorf("SHOW PARAMS failed: %v", err)
 		} else if result == nil {

--- a/internal/mycli/spancodec_bridge.go
+++ b/internal/mycli/spancodec_bridge.go
@@ -67,15 +67,17 @@ func clientSideFormatContext(sysVars *systemVariables) (*spanvalue.FormatConfig,
 // results when the current format has one, or as a buffered Result otherwise.
 // session may be nil (e.g., HELP without a connection); defaults apply and
 // the result is buffered.
-func executeStructRows[T any](enc *spancodec.RowEncoder[T], items []T, session *Session) (*Result, error) {
+func executeStructRows[T any](enc *spancodec.RowEncoder[T], items []T, session *Session, out OperationOutput) (*Result, error) {
 	var sysVars *systemVariables
-	var out io.Writer
 	if session != nil {
 		sysVars = session.systemVariables
-		out = session.outputWriter()
+		// Direct Execute tests often pass a zero OperationOutput after swapping
+		// StreamManager. Resolve here so a nil writer still uses StreamManager,
+		// without mutating Session. Caller-provided writers still win.
+		out = session.resolveOperationOutput(out)
 	}
 
-	result, handled, err := streamStructRows(enc, items, sysVars, out)
+	result, handled, err := streamStructRows(enc, items, sysVars, out.Writer())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mycli/spancodec_bridge_test.go
+++ b/internal/mycli/spancodec_bridge_test.go
@@ -273,7 +273,7 @@ func TestExecuteStructRows_streaming(t *testing.T) {
 			var buf bytes.Buffer
 			sysVars.StreamManager = streamio.NewStreamManager(io.NopCloser(bytes.NewReader(nil)), &buf, &buf)
 
-			result, err := executeStructRows(nameValueRowEncoder, items, &Session{systemVariables: &sysVars})
+			result, err := executeStructRows(nameValueRowEncoder, items, &Session{systemVariables: &sysVars}, OperationOutput{w: &buf})
 			if err != nil {
 				t.Fatalf("executeStructRows: %v", err)
 			}

--- a/internal/mycli/statement_processing.go
+++ b/internal/mycli/statement_processing.go
@@ -39,7 +39,7 @@ import (
 )
 
 type Statement interface {
-	Execute(ctx context.Context, session *Session) (*Result, error)
+	Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error)
 }
 
 // MutationStatement is a marker interface for mutation statements.

--- a/internal/mycli/statements.go
+++ b/internal/mycli/statements.go
@@ -56,7 +56,7 @@ func (s *SelectStatement) String() string {
 	return s.Query
 }
 
-func (s *SelectStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SelectStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Single lock acquisition for both DetermineTransaction and InTransaction check
 	_, inTransaction, err := session.txn.DetermineTransactionAndState(ctx)
 	if err != nil {
@@ -66,7 +66,7 @@ func (s *SelectStatement) Execute(ctx context.Context, session *Session) (*Resul
 	qm := session.systemVariables.Query.QueryMode
 	switch {
 	case session.systemVariables.Query.TryPartitionQuery:
-		return (&TryPartitionedQueryStatement{SQL: s.Query}).Execute(ctx, session)
+		return (&TryPartitionedQueryStatement{SQL: s.Query}).Execute(ctx, session, out)
 	case qm != nil && *qm == sppb.ExecuteSqlRequest_PLAN:
 		return executeExplain(ctx, session, s.Query, false, enums.ExplainFormatUnspecified, 0, nil)
 	case qm != nil && *qm == sppb.ExecuteSqlRequest_PROFILE:
@@ -76,9 +76,9 @@ func (s *SelectStatement) Execute(ctx context.Context, session *Session) (*Resul
 		// effectiveQueryMode() resolves the request-level mode and
 		// finalizeQueryResult() adjusts stats/plan rendering.
 		if !inTransaction && session.systemVariables.Query.AutoPartitionMode {
-			return runPartitionedQuery(ctx, session, s.Query)
+			return runPartitionedQuery(ctx, session, s.Query, out)
 		}
-		return executeSQL(ctx, session, s.Query)
+		return executeSQL(ctx, session, s.Query, out)
 	}
 }
 
@@ -98,7 +98,7 @@ func (s *ExportDataStatement) String() string {
 
 func (ExportDataStatement) isNonTransactionalMutationStatement() {}
 
-func (s *ExportDataStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ExportDataStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.systemVariables.Query.TryPartitionQuery {
 		return nil, errors.New("EXPORT DATA cannot be executed with CLI_TRY_PARTITION_QUERY=TRUE")
 	}
@@ -110,7 +110,7 @@ func (s *ExportDataStatement) Execute(ctx context.Context, session *Session) (*R
 		return nil, errors.New("EXPORT DATA cannot be executed with CLI_QUERY_MODE=PLAN")
 	}
 
-	return executeSQLImplSingleUse(ctx, session, s.SQL, session.systemVariables)
+	return executeSQLImplSingleUse(ctx, session, s.SQL, session.systemVariables, out)
 }
 
 type DmlStatement struct {
@@ -123,10 +123,10 @@ func (s *DmlStatement) String() string {
 
 func (DmlStatement) isMutationStatement() {}
 
-func (s *DmlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *DmlStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	switch {
 	case session.systemVariables.Query.TryPartitionQuery:
-		return (&TryPartitionedQueryStatement{SQL: s.Dml}).Execute(ctx, session)
+		return (&TryPartitionedQueryStatement{SQL: s.Dml}).Execute(ctx, session, out)
 	case lo.FromPtr(session.systemVariables.Query.QueryMode) == sppb.ExecuteSqlRequest_PLAN:
 		return executeExplain(ctx, session, s.Dml, true, enums.ExplainFormatUnspecified, 0, nil)
 	case lo.FromPtr(session.systemVariables.Query.QueryMode) == sppb.ExecuteSqlRequest_PROFILE:
@@ -148,7 +148,7 @@ func (s *DdlStatement) String() string {
 
 func (DdlStatement) isMutationStatement() {}
 
-func (s *DdlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *DdlStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return bufferOrExecuteDdlStatements(ctx, session, []string{s.Ddl})
 }
 
@@ -164,7 +164,7 @@ func (CreateDatabaseStatement) isMutationStatement() {}
 
 func (s *CreateDatabaseStatement) isDetachedCompatible() {}
 
-func (s *CreateDatabaseStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *CreateDatabaseStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	op, err := session.adminClient.CreateDatabase(ctx, &databasepb.CreateDatabaseRequest{
 		Parent:          session.InstancePath(),
 		CreateStatement: s.CreateStatement,
@@ -212,7 +212,7 @@ func (DropDatabaseStatement) isMutationStatement() {}
 
 func (s *DropDatabaseStatement) isDetachedCompatible() {}
 
-func (s *DropDatabaseStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *DropDatabaseStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if err := session.adminClient.DropDatabase(ctx, &databasepb.DropDatabaseRequest{
 		Database: databasePath(session.connection.Project, session.connection.Instance, s.DatabaseId),
 	}); err != nil {
@@ -235,7 +235,7 @@ type databaseNameRow struct {
 
 var showDatabasesRowEncoder = spancodec.MustNewRowEncoder[databaseNameRow]()
 
-func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	dbIter := session.adminClient.ListDatabases(ctx, &databasepb.ListDatabasesRequest{
 		Parent: session.InstancePath(),
 	})
@@ -253,7 +253,7 @@ func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) 
 		items = append(items, databaseNameRow{Database: matched[1]})
 	}
 
-	return executeStructRows(showDatabasesRowEncoder, items, session)
+	return executeStructRows(showDatabasesRowEncoder, items, session, out)
 }
 
 // Split Points
@@ -264,7 +264,7 @@ func (s *ShowDatabasesStatement) Execute(ctx context.Context, session *Session) 
 
 type ShowSchemaUpdateOperations struct{}
 
-func (s *ShowSchemaUpdateOperations) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowSchemaUpdateOperations) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	num := 0
 
 	var rows []Row
@@ -319,7 +319,7 @@ type ShowOperationStatement struct {
 	Mode        string // "ASYNC" or "SYNC"
 }
 
-func (s *ShowOperationStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowOperationStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Check mode support
 	if s.Mode == "SYNC" {
 		return s.executeSyncMode(ctx, session)
@@ -605,7 +605,7 @@ type TruncateTableStatement struct {
 
 func (TruncateTableStatement) isMutationStatement() {}
 
-func (s *TruncateTableStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *TruncateTableStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InReadWriteTransaction() {
 		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
 		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-write transaction`)
@@ -634,7 +634,7 @@ type PartitionedDmlStatement struct {
 
 func (PartitionedDmlStatement) isMutationStatement() {}
 
-func (s *PartitionedDmlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *PartitionedDmlStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InReadWriteTransaction() {
 		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
 		return nil, errors.New(`partitioned DML statement can not be run in a read-write transaction`)
@@ -670,7 +670,7 @@ func (s *BulkDdlStatement) String() string {
 
 func (BulkDdlStatement) isMutationStatement() {}
 
-func (s *BulkDdlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *BulkDdlStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return executeDdlStatements(ctx, session, s.Ddls)
 }
 
@@ -680,7 +680,7 @@ type BatchDMLStatement struct {
 
 func (BatchDMLStatement) isMutationStatement() {}
 
-func (s *BatchDMLStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *BatchDMLStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return executeBatchDML(ctx, session, s.DMLs)
 }
 
@@ -688,7 +688,7 @@ type StartBatchStatement struct {
 	Mode batchMode
 }
 
-func (s *StartBatchStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *StartBatchStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn != nil && session.txn.HasAutomaticDML() {
 		return nil, fmt.Errorf("already in batch, you should execute ABORT BATCH")
 	}
@@ -700,7 +700,7 @@ func (s *StartBatchStatement) Execute(ctx context.Context, session *Session) (*R
 
 type AbortBatchStatement struct{}
 
-func (s *AbortBatchStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *AbortBatchStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	session.batch.Abort()
 	if session.txn != nil {
 		session.txn.DiscardAutomaticDML()
@@ -710,11 +710,11 @@ func (s *AbortBatchStatement) Execute(ctx context.Context, session *Session) (*R
 
 type RunBatchStatement struct{}
 
-func (s *RunBatchStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	return runBatch(ctx, session)
+func (s *RunBatchStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
+	return runBatch(ctx, session, out)
 }
 
-func runBatch(ctx context.Context, session *Session) (*Result, error) {
+func runBatch(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if err := session.failStatementIfReadOnly(); err != nil {
 		return nil, err
 	}
@@ -724,7 +724,7 @@ func runBatch(ctx context.Context, session *Session) (*Result, error) {
 			return nil, err
 		}
 
-		result, err := session.ExecuteStatement(ctx, batch)
+		result, err := session.ExecuteStatementWithOutput(ctx, batch, out)
 		if err != nil {
 			return nil, err
 		}
@@ -772,7 +772,7 @@ type helpRow struct {
 
 var helpRowEncoder = spancodec.MustNewRowEncoder[helpRow]()
 
-func (s *HelpStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *HelpStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	var items []helpRow
 	for _, stmt := range activeStatementDefs {
 		for _, desc := range stmt.Descriptions {
@@ -781,7 +781,7 @@ func (s *HelpStatement) Execute(ctx context.Context, session *Session) (*Result,
 	}
 
 	// session is nil when HELP is rendered without a connection.
-	result, err := executeStructRows(helpRowEncoder, items, session)
+	result, err := executeStructRows(helpRowEncoder, items, session, out)
 	if err != nil {
 		return nil, err
 	}
@@ -797,7 +797,7 @@ func (s *ExitStatement) isDetachedCompatible() {}
 
 type NopStatement struct{}
 
-func (s *NopStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *NopStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// do nothing
 	return &Result{}, nil
 }

--- a/internal/mycli/statements_dump.go
+++ b/internal/mycli/statements_dump.go
@@ -20,16 +20,16 @@ import (
 // It exports both DDL and data for all tables in the database
 type DumpDatabaseStatement struct{}
 
-func (s *DumpDatabaseStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	return executeDump(ctx, session, dumpModeDatabase, nil)
+func (s *DumpDatabaseStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
+	return executeDump(ctx, session, dumpModeDatabase, nil, out)
 }
 
 // DumpSchemaStatement represents DUMP SCHEMA statement
 // It exports only DDL statements without any data
 type DumpSchemaStatement struct{}
 
-func (s *DumpSchemaStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	return executeDump(ctx, session, dumpModeSchema, nil)
+func (s *DumpSchemaStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
+	return executeDump(ctx, session, dumpModeSchema, nil, out)
 }
 
 // DumpTablesStatement represents DUMP TABLES statement
@@ -38,8 +38,8 @@ type DumpTablesStatement struct {
 	Tables []tableID
 }
 
-func (s *DumpTablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	return executeDump(ctx, session, dumpModeTables, s.Tables)
+func (s *DumpTablesStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
+	return executeDump(ctx, session, dumpModeTables, s.Tables, out)
 }
 
 // dumpMode represents the type of dump operation
@@ -74,7 +74,11 @@ type dumpDataPlan struct {
 	Empty  bool
 }
 
-func executeDump(ctx context.Context, session *Session, mode dumpMode, specificTables []tableID) (*Result, error) {
+func executeDump(ctx context.Context, session *Session, mode dumpMode, specificTables []tableID, out OperationOutput) (*Result, error) {
+	// Direct Execute tests often pass a zero OperationOutput after swapping
+	// StreamManager. Resolve here so a nil writer still uses StreamManager,
+	// without mutating Session. Caller-provided writers still win.
+	out = session.resolveOperationOutput(out)
 	if session.adminClient == nil {
 		return nil, fmt.Errorf("admin client is not initialized")
 	}
@@ -88,7 +92,7 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 		if err != nil {
 			return nil, err
 		}
-		return writeDumpPlan(ctx, session, mode, plan, nil, nil)
+		return writeDumpPlan(ctx, session, mode, plan, nil, nil, out)
 	}
 
 	dro := cloneDirectedRead(session.systemVariables.Query.DirectedRead)
@@ -98,7 +102,7 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 		if err != nil {
 			return err
 		}
-		result, err = writeDumpPlan(ctx, session, mode, plan, txn, dro)
+		result, err = writeDumpPlan(ctx, session, mode, plan, txn, dro, out)
 		return err
 	})
 	if err != nil {
@@ -107,12 +111,12 @@ func executeDump(ctx context.Context, session *Session, mode dumpMode, specificT
 	return result, nil
 }
 
-func writeDumpPlan(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, dro *sppb.DirectedReadOptions) (*Result, error) {
-	outStream := session.outputWriter()
+func writeDumpPlan(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, dro *sppb.DirectedReadOptions, out OperationOutput) (*Result, error) {
+	outStream := out.Writer()
 	if outStream != nil && outStream != io.Discard {
-		return executeDumpStreamingWithTxn(ctx, session, mode, plan, outStream, txn, dro)
+		return executeDumpStreamingWithTxn(ctx, session, mode, plan, out, txn, dro)
 	}
-	return executeDumpBufferedWithTxn(ctx, session, mode, plan, txn, dro)
+	return executeDumpBufferedWithTxn(ctx, session, mode, plan, txn, dro, out)
 }
 
 // buildSelectQueryWithColumns creates a SELECT query with explicit column list.
@@ -276,19 +280,19 @@ func prepareDumpWithTxn(ctx context.Context, session *Session, mode dumpMode, sp
 	return plan, nil
 }
 
-func executeDumpBufferedWithTxn(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, dro *sppb.DirectedReadOptions) (*Result, error) {
-	var out bytes.Buffer
-	affectedRows, err := writeDumpPlanTo(ctx, session, mode, plan, txn, &out, dro)
+func executeDumpBufferedWithTxn(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, dro *sppb.DirectedReadOptions, out OperationOutput) (*Result, error) {
+	var buf bytes.Buffer
+	affectedRows, err := writeDumpPlanTo(ctx, session, mode, plan, txn, out.withWriter(&buf), dro)
 	if err != nil {
 		return nil, err
 	}
-	return &Result{AffectedRows: affectedRows, Body: PreparedBody(out.Bytes())}, nil
+	return &Result{AffectedRows: affectedRows, Body: PreparedBody(buf.Bytes())}, nil
 }
 
 // executeDumpStreamingWithTxn writes dump output directly to out.
 // Callers that export data must pass the same read-only transaction used
 // for catalog preflight. SCHEMA has no data txn.
-func executeDumpStreamingWithTxn(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, out io.Writer, txn *spanner.ReadOnlyTransaction, dro *sppb.DirectedReadOptions) (*Result, error) {
+func executeDumpStreamingWithTxn(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, out OperationOutput, txn *spanner.ReadOnlyTransaction, dro *sppb.DirectedReadOptions) (*Result, error) {
 	affectedRows, err := writeDumpPlanTo(ctx, session, mode, plan, txn, out, dro)
 	if err != nil {
 		return nil, err
@@ -301,7 +305,8 @@ func executeDumpStreamingWithTxn(ctx context.Context, session *Session, mode dum
 // destination, which may have received completed units before a later error.
 // Data queries use the same writer and read transaction as the surrounding
 // traversal, so catalog, cyclic planning, and exported values share a snapshot.
-func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, out io.Writer, dro *sppb.DirectedReadOptions) (int, error) {
+func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan *dumpPlan, txn *spanner.ReadOnlyTransaction, out OperationOutput, dro *sppb.DirectedReadOptions) (int, error) {
+	dest := out.Writer()
 	probed := false
 	probeOutput := func() {
 		if session.dumpReadTxnProbe != nil && !probed {
@@ -311,7 +316,7 @@ func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan 
 	}
 	if len(plan.DDL) > 0 {
 		probeOutput()
-		if _, err := out.Write(plan.DDL); err != nil {
+		if _, err := dest.Write(plan.DDL); err != nil {
 			return 0, fmt.Errorf("write DDL: %w", err)
 		}
 	}
@@ -322,7 +327,7 @@ func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan 
 	for _, unit := range plan.Data {
 		probeOutput()
 		if unit.Cyclic != nil {
-			if err := unit.Cyclic.writeTo(out); err != nil {
+			if err := unit.Cyclic.writeTo(dest); err != nil {
 				return 0, fmt.Errorf("write cyclic data: %w", err)
 			}
 			totalAffectedRows += len(unit.Cyclic.Statements)
@@ -330,19 +335,19 @@ func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan 
 		}
 		table := unit.Table
 		if len(table.Columns) == 0 {
-			if _, err := fmt.Fprintf(out, "-- Skipping table %s (no writable columns)\n", table.ID.FQN()); err != nil {
+			if _, err := fmt.Fprintf(dest, "-- Skipping table %s (no writable columns)\n", table.ID.FQN()); err != nil {
 				return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
 			}
 			continue
 		}
 		if unit.Empty {
-			if _, err := fmt.Fprintf(out, "-- Data for table %s\n", table.ID.FQN()); err != nil {
+			if _, err := fmt.Fprintf(dest, "-- Data for table %s\n", table.ID.FQN()); err != nil {
 				return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
 			}
 			continue
 		}
 		selectQuery := buildSelectQueryWithColumns(session.systemVariables.Feature.DatabaseDialect, table.Columns, table.ID)
-		if _, err := fmt.Fprintf(out, "-- Data for table %s\n", table.ID.FQN()); err != nil {
+		if _, err := fmt.Fprintf(dest, "-- Data for table %s\n", table.ID.FQN()); err != nil {
 			return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
 		}
 		dataResult, err := executeSQLWithFormatAndTxn(ctx, session, txn, selectQuery,
@@ -352,7 +357,7 @@ func writeDumpPlanTo(ctx context.Context, session *Session, mode dumpMode, plan 
 		}
 		totalAffectedRows += dataResult.AffectedRows
 		if dataResult.AffectedRows > 0 {
-			if _, err := fmt.Fprintln(out); err != nil {
+			if _, err := fmt.Fprintln(dest); err != nil {
 				return 0, fmt.Errorf("write data for table %s: %w", table.ID.FQN(), err)
 			}
 		}

--- a/internal/mycli/statements_dump_test.go
+++ b/internal/mycli/statements_dump_test.go
@@ -63,7 +63,7 @@ func TestExecuteDumpStreamingWithTxnPropagatesWriteError(t *testing.T) {
 			t.Cleanup(session.Close)
 			want := errors.New("output failed")
 			// Header failures must stop before querying, so no data transaction is needed.
-			result, err := executeDumpStreamingWithTxn(t.Context(), session, tt.mode, &tt.plan, dumpFailWriter{err: want}, nil, nil)
+			result, err := executeDumpStreamingWithTxn(t.Context(), session, tt.mode, &tt.plan, OperationOutput{w: dumpFailWriter{err: want}}, nil, nil)
 			if result != nil {
 				t.Fatalf("result = %#v, want nil", result)
 			}

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -452,7 +452,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 	// regardless of CLI_QUERY_MODE.
 	iter, roTxn, err := session.txn.RunQueryWithStats(ctx, stmt, false, sppb.ExecuteSqlRequest_PROFILE)
 	if err != nil {
-		return nil, rollbackReadWriteIfAborted(ctx, session, err, OperationOutput{})
+		return nil, rollbackReadWriteIfAborted(ctx, session, err)
 	}
 
 	// Count the actual data rows while draining the iterator;
@@ -466,7 +466,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		err = session.txn.invokeQueryAfterCollectHook()
 	}
 	if err != nil {
-		return nil, rollbackReadWriteIfAborted(ctx, session, err, OperationOutput{})
+		return nil, rollbackReadWriteIfAborted(ctx, session, err)
 	}
 
 	// Cloud Spanner Emulator doesn't set query plan nodes to the result.

--- a/internal/mycli/statements_explain_describe.go
+++ b/internal/mycli/statements_explain_describe.go
@@ -60,7 +60,7 @@ func (s *ExplainStatement) String() string {
 }
 
 // Execute processes `EXPLAIN` statement for queries and DMLs.
-func (s *ExplainStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ExplainStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return executeExplain(ctx, session, s.Explain, s.IsDML, s.Format, s.Width, s.PrintSections)
 }
 
@@ -71,7 +71,7 @@ type ExplainAnalyzeStatement struct {
 	PrintSections *planref.PrintSections
 }
 
-func (s *ExplainAnalyzeStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ExplainAnalyzeStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	sql := s.Query
 
 	return executeExplainAnalyze(ctx, session, sql, s.Format, s.Width, s.PrintSections)
@@ -86,7 +86,7 @@ type ExplainAnalyzeDmlStatement struct {
 
 func (ExplainAnalyzeDmlStatement) isMutationStatement() {}
 
-func (s *ExplainAnalyzeDmlStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ExplainAnalyzeDmlStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return executeExplainAnalyzeDML(ctx, session, s.Dml, s.Format, s.Width, s.PrintSections)
 }
 
@@ -97,7 +97,7 @@ type ExplainLastQueryStatement struct {
 	PrintSections *planref.PrintSections
 }
 
-func (s *ExplainLastQueryStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ExplainLastQueryStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.systemVariables.LastResult.QueryCache == nil {
 		return nil, fmt.Errorf("last query cache missing because query not executed")
 	}
@@ -132,7 +132,7 @@ type ShowPlanNodeStatement struct {
 	NodeID int
 }
 
-func (s *ShowPlanNodeStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowPlanNodeStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.systemVariables.LastResult.QueryCache == nil || session.systemVariables.LastResult.QueryCache.QueryPlan == nil {
 		return nil, errors.New("no query plan cached. Run query or EXPLAIN ANALYZE first")
 	}
@@ -178,7 +178,7 @@ type ShowLastQueryPlanStatement struct {
 	IntoPath  string
 }
 
-func (s *ShowLastQueryPlanStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowLastQueryPlanStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	cache := session.systemVariables.LastResult.QueryCache
 	if cache == nil {
 		return nil, errors.New("no query plan cached. Run a query or EXPLAIN ANALYZE first")
@@ -366,7 +366,7 @@ func (s *DescribeStatement) String() string {
 }
 
 // Execute processes `DESCRIBE` statement for queries and DMLs.
-func (s *DescribeStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *DescribeStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	stmt, err := newStatement(s.Statement, session.systemVariables.Params, true)
 	if err != nil {
 		return nil, err
@@ -452,7 +452,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 	// regardless of CLI_QUERY_MODE.
 	iter, roTxn, err := session.txn.RunQueryWithStats(ctx, stmt, false, sppb.ExecuteSqlRequest_PROFILE)
 	if err != nil {
-		return nil, rollbackReadWriteIfAborted(ctx, session, err)
+		return nil, rollbackReadWriteIfAborted(ctx, session, err, OperationOutput{})
 	}
 
 	// Count the actual data rows while draining the iterator;
@@ -466,7 +466,7 @@ func executeExplainAnalyze(ctx context.Context, session *Session, sql string, fo
 		err = session.txn.invokeQueryAfterCollectHook()
 	}
 	if err != nil {
-		return nil, rollbackReadWriteIfAborted(ctx, session, err)
+		return nil, rollbackReadWriteIfAborted(ctx, session, err, OperationOutput{})
 	}
 
 	// Cloud Spanner Emulator doesn't set query plan nodes to the result.

--- a/internal/mycli/statements_explain_describe_rpc_test.go
+++ b/internal/mycli/statements_explain_describe_rpc_test.go
@@ -35,7 +35,7 @@ func TestExplainDescribeStatementsRPC(t *testing.T) {
 	t.Run("EXPLAIN SELECT", func(t *testing.T) {
 		t.Parallel()
 		session, _ := newQueryCacheRPCSession(t, testQueryPlan(t), stats, nil)
-		got, err := (&ExplainStatement{Explain: "SELECT 1"}).Execute(t.Context(), session)
+		got, err := (&ExplainStatement{Explain: "SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("EXPLAIN: %v", err)
 		}
@@ -51,7 +51,7 @@ func TestExplainDescribeStatementsRPC(t *testing.T) {
 	t.Run("EXPLAIN emulator without plan", func(t *testing.T) {
 		t.Parallel()
 		session, _ := newQueryCacheRPCSession(t, nil, stats, nil)
-		_, err := (&ExplainStatement{Explain: "SELECT 1"}).Execute(t.Context(), session)
+		_, err := (&ExplainStatement{Explain: "SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "EXPLAIN statement is not supported for Cloud Spanner Emulator") {
 			t.Fatalf("error = %v, want emulator EXPLAIN rejection", err)
 		}
@@ -60,7 +60,7 @@ func TestExplainDescribeStatementsRPC(t *testing.T) {
 	t.Run("EXPLAIN ANALYZE SELECT", func(t *testing.T) {
 		t.Parallel()
 		session, live := newQueryCacheRPCSession(t, testQueryPlan(t), stats, nil)
-		got, err := (&ExplainAnalyzeStatement{Query: "SELECT 1"}).Execute(t.Context(), session)
+		got, err := (&ExplainAnalyzeStatement{Query: "SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("EXPLAIN ANALYZE: %v", err)
 		}
@@ -78,7 +78,7 @@ func TestExplainDescribeStatementsRPC(t *testing.T) {
 	t.Run("EXPLAIN ANALYZE emulator without plan", func(t *testing.T) {
 		t.Parallel()
 		session, _ := newQueryCacheRPCSession(t, nil, stats, nil)
-		_, err := (&ExplainAnalyzeStatement{Query: "SELECT 1"}).Execute(t.Context(), session)
+		_, err := (&ExplainAnalyzeStatement{Query: "SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 		if !errors.Is(err, errExplainAnalyzeUnsupportedOnEmulator) {
 			t.Fatalf("error = %v, want %v", err, errExplainAnalyzeUnsupportedOnEmulator)
 		}
@@ -87,7 +87,7 @@ func TestExplainDescribeStatementsRPC(t *testing.T) {
 	t.Run("DESCRIBE SELECT", func(t *testing.T) {
 		t.Parallel()
 		session, _ := newQueryCacheRPCSession(t, testQueryPlan(t), stats, nil)
-		got, err := (&DescribeStatement{Statement: "SELECT 1"}).Execute(t.Context(), session)
+		got, err := (&DescribeStatement{Statement: "SELECT 1"}).Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("DESCRIBE: %v", err)
 		}

--- a/internal/mycli/statements_explain_describe_test.go
+++ b/internal/mycli/statements_explain_describe_test.go
@@ -886,7 +886,7 @@ func TestExplainLastQueryStatement_Execute(t *testing.T) {
 			got, err := tt.statement.Execute(context.Background(), &Session{systemVariables: &systemVariables{
 				Display:    DisplayVars{ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns},
 				LastResult: LastResult{QueryCache: tt.lastQueryCache},
-			}})
+			}}, OperationOutput{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1041,7 +1041,7 @@ func TestShowPlanNodeStatement_Execute(t *testing.T) {
 			got, err := tt.statement.Execute(context.Background(), &Session{systemVariables: &systemVariables{
 				Display:    DisplayVars{ParsedAnalyzeColumns: DefaultParsedAnalyzeColumns},
 				LastResult: LastResult{QueryCache: tt.lastQueryCache},
-			}})
+			}}, OperationOutput{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1093,7 +1093,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowLastQueryPlanStatement{}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{},
-		})
+		}, OperationOutput{})
 		if err == nil {
 			t.Fatal("Execute() error = nil, want error")
 		}
@@ -1103,7 +1103,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowLastQueryPlanStatement{}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{}}},
-		})
+		}, OperationOutput{})
 		if err == nil {
 			t.Fatal("Execute() error = nil, want error")
 		}
@@ -1113,7 +1113,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		got, err := (&ShowLastQueryPlanStatement{}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -1134,7 +1134,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowLastQueryPlanStatement{WithStats: true}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err == nil {
 			t.Fatal("Execute() error = nil, want missing-stats error")
 		}
@@ -1147,7 +1147,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 				QueryPlan:  plan,
 				QueryStats: statsMap,
 			}}},
-		})
+		}, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -1167,7 +1167,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		path := dir + "/plan.json"
 		got, err := (&ShowLastQueryPlanStatement{IntoPath: path}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -1190,7 +1190,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "query plan"+extension)
 			got, err := (&ShowLastQueryPlanStatement{IntoPath: path}).Execute(context.Background(), &Session{
 				systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-			})
+			}, OperationOutput{})
 			if err != nil {
 				t.Fatalf("Execute() error = %v", err)
 			}
@@ -1219,7 +1219,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 				QueryPlan:  plan,
 				QueryStats: statsMap,
 			}}},
-		})
+		}, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -1241,7 +1241,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		dir := t.TempDir()
 		_, err := (&ShowLastQueryPlanStatement{IntoPath: dir}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err == nil {
 			t.Fatal("Execute() error = nil, want directory rejection")
 		}
@@ -1251,7 +1251,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowLastQueryPlanStatement{IntoPath: "   "}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err == nil {
 			t.Fatal("Execute() error = nil, want empty-path rejection")
 		}
@@ -1261,7 +1261,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowLastQueryPlanStatement{IntoPath: "plan\x00.json"}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "NUL") {
 			t.Fatalf("Execute() error = %v, want NUL rejection", err)
 		}
@@ -1271,7 +1271,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowLastQueryPlanStatement{IntoPath: os.DevNull}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "not a regular file") {
 			t.Fatalf("Execute() error = %v, want non-regular rejection", err)
 		}
@@ -1282,7 +1282,7 @@ func TestShowLastQueryPlanStatement_Execute(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "missing", "plan.json")
 		_, err := (&ShowLastQueryPlanStatement{IntoPath: path}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{QueryPlan: plan}}},
-		})
+		}, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "invalid INTO path parent") {
 			t.Fatalf("Execute() error = %v, want missing-parent rejection", err)
 		}
@@ -1296,7 +1296,7 @@ func TestShowPlanNodeStatementMissingCache(t *testing.T) {
 		t.Parallel()
 		_, err := (&ShowPlanNodeStatement{NodeID: 0}).Execute(context.Background(), &Session{
 			systemVariables: &systemVariables{},
-		})
+		}, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "no query plan cached") {
 			t.Fatalf("error = %v, want missing-cache", err)
 		}
@@ -1308,7 +1308,7 @@ func TestShowPlanNodeStatementMissingCache(t *testing.T) {
 			systemVariables: &systemVariables{LastResult: LastResult{QueryCache: &LastQueryCache{
 				QueryPlan: selectProfileResultSet.GetStats().GetQueryPlan(),
 			}}},
-		})
+		}, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "node with ID 99 not found") {
 			t.Fatalf("error = %v, want out-of-range", err)
 		}

--- a/internal/mycli/statements_mutations.go
+++ b/internal/mycli/statements_mutations.go
@@ -31,7 +31,7 @@ type MutateStatement struct {
 
 func (MutateStatement) isMutationStatement() {}
 
-func (s *MutateStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *MutateStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	mutations, err := parseMutation(s.Table, s.Operation, s.Body)
 	if err != nil {
 		return nil, err

--- a/internal/mycli/statements_params.go
+++ b/internal/mycli/statements_params.go
@@ -34,7 +34,7 @@ func paramKind(v ast.Node) string {
 	}
 }
 
-func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	items := lo.MapToSlice(session.systemVariables.Params, func(k string, v ast.Node) paramRow {
 		return paramRow{
 			Name:  k,
@@ -44,7 +44,7 @@ func (s *ShowParamsStatement) Execute(ctx context.Context, session *Session) (*R
 	})
 	slices.SortFunc(items, func(lhs, rhs paramRow) int { return cmp.Compare(lhs.Name, rhs.Name) })
 
-	result, err := executeStructRows(showParamsRowEncoder, items, session)
+	result, err := executeStructRows(showParamsRowEncoder, items, session, out)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ type UnsetParamStatement struct {
 
 func (s *UnsetParamStatement) isDetachedCompatible() {}
 
-func (s *UnsetParamStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *UnsetParamStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if _, ok := session.systemVariables.Params[s.Name]; !ok {
 		return nil, fmt.Errorf("unknown parameter: %s", s.Name)
 	}
@@ -73,7 +73,7 @@ type SetParamTypeStatement struct {
 
 func (s *SetParamTypeStatement) isDetachedCompatible() {}
 
-func (s *SetParamTypeStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SetParamTypeStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if expr, err := parseMemefishType("", s.Type); err != nil {
 		return nil, err
 	} else {
@@ -89,7 +89,7 @@ type SetParamValueStatement struct {
 
 func (s *SetParamValueStatement) isDetachedCompatible() {}
 
-func (s *SetParamValueStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SetParamValueStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if expr, err := parseMemefishExpr("", s.Value); err != nil {
 		return nil, err
 	} else {

--- a/internal/mycli/statements_params_test.go
+++ b/internal/mycli/statements_params_test.go
@@ -34,7 +34,7 @@ func TestSetParamStatementMalformedInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			session := &Session{systemVariables: &systemVariables{Params: make(map[string]ast.Node)}}
-			if _, err := tt.stmt.Execute(context.Background(), session); err == nil {
+			if _, err := tt.stmt.Execute(context.Background(), session, OperationOutput{}); err == nil {
 				t.Fatal("Execute() error = nil, want malformed-input error")
 			}
 		})

--- a/internal/mycli/statements_partitioned_query.go
+++ b/internal/mycli/statements_partitioned_query.go
@@ -12,7 +12,7 @@ import (
 
 type PartitionStatement struct{ SQL string }
 
-func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *PartitionStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	stmt, err := newStatement(s.SQL, session.systemVariables.Params, false)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (s *PartitionStatement) Execute(ctx context.Context, session *Session) (*Re
 
 type TryPartitionedQueryStatement struct{ SQL string }
 
-func (s *TryPartitionedQueryStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *TryPartitionedQueryStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	stmt, err := newStatement(s.SQL, session.systemVariables.Params, false)
 	if err != nil {
 		return nil, err
@@ -82,12 +82,12 @@ func (s *TryPartitionedQueryStatement) Execute(ctx context.Context, session *Ses
 
 type RunPartitionedQueryStatement struct{ SQL string }
 
-func (s *RunPartitionedQueryStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
-	return runPartitionedQuery(ctx, session, s.SQL)
+func (s *RunPartitionedQueryStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
+	return runPartitionedQuery(ctx, session, s.SQL, out)
 }
 
 type RunPartitionStatement struct{ Token string }
 
-func (s *RunPartitionStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *RunPartitionStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	return nil, errors.New("unsupported statement")
 }

--- a/internal/mycli/statements_proto.go
+++ b/internal/mycli/statements_proto.go
@@ -41,7 +41,7 @@ type SyncProtoStatement struct {
 
 func (SyncProtoStatement) isMutationStatement() {}
 
-func (s *SyncProtoStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SyncProtoStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if name, ok := firstSharedFullName(s.UpsertPaths, s.DeletePaths); ok {
 		return nil, fmt.Errorf("SYNC PROTO BUNDLE conflict: %q appears in both UPSERT and DELETE", name)
 	}
@@ -115,10 +115,10 @@ func composeProtoBundleDDLs(fds *descriptorpb.FileDescriptorSet, upsertPaths, de
 
 type ShowLocalProtoStatement struct{}
 
-func (s *ShowLocalProtoStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowLocalProtoStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	fds := session.systemVariables.Internal.ProtoDescriptor
 
-	result, err := executeStructRows(localProtoRowEncoder, slices.Collect(fdsToInfoSeq(fds)), session)
+	result, err := executeStructRows(localProtoRowEncoder, slices.Collect(fdsToInfoSeq(fds)), session, out)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *ShowLocalProtoStatement) Execute(ctx context.Context, session *Session)
 
 type ShowRemoteProtoStatement struct{}
 
-func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	resp, err := session.GetDatabaseDdlCached(ctx)
 	if err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func (s *ShowRemoteProtoStatement) Execute(ctx context.Context, session *Session
 		return nil, err
 	}
 
-	result, err := executeStructRows(remoteProtoRowEncoder, slices.Collect(fdsToInfoSeq(&fds)), session)
+	result, err := executeStructRows(remoteProtoRowEncoder, slices.Collect(fdsToInfoSeq(&fds)), session, out)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mycli/statements_query_profile.go
+++ b/internal/mycli/statements_query_profile.go
@@ -60,7 +60,7 @@ optimizer_statistics_package: {{.OptimizerStatisticsPackage}}
 
 type ShowQueryProfilesStatement struct{}
 
-func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowQueryProfilesStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InReadWriteTransaction() {
 		// INFORMATION_SCHEMA can't be used in read-write transaction.
 		// https://cloud.google.com/spanner/docs/information-schema
@@ -142,7 +142,7 @@ type ShowQueryProfileStatement struct {
 	Fprint int64
 }
 
-func (s *ShowQueryProfileStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowQueryProfileStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InReadWriteTransaction() {
 		// INFORMATION_SCHEMA can't be used in read-write transaction.
 		// https://cloud.google.com/spanner/docs/information-schema

--- a/internal/mycli/statements_query_profile_test.go
+++ b/internal/mycli/statements_query_profile_test.go
@@ -304,7 +304,7 @@ func TestShowQueryProfileStatementsRejectReadWriteTransaction(t *testing.T) {
 			t.Parallel()
 			session := newSessionForLocalVarTest(t)
 			session.txn.tc = &transactionContext{attrs: transactionAttributes{mode: transactionModeReadWrite}}
-			_, err := stmt.Execute(t.Context(), session)
+			_, err := stmt.Execute(t.Context(), session, OperationOutput{})
 			if err == nil || err.Error() != want {
 				t.Fatalf("Execute() error = %v, want %q", err, want)
 			}
@@ -331,7 +331,7 @@ func TestShowQueryProfilesStatementExecute(t *testing.T) {
 	t.Run("empty result", func(t *testing.T) {
 		t.Parallel()
 		session, server := newQueryProfileRPCSession(t, nil)
-		got, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session)
+		got, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -352,7 +352,7 @@ func TestShowQueryProfilesStatementExecute(t *testing.T) {
 			latency:     0.01109,
 			profile:     profile,
 		}})
-		got, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session)
+		got, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -390,7 +390,7 @@ func TestShowQueryProfilesStatementExecute(t *testing.T) {
 			fingerprint: 1,
 			profile:     "{",
 		}})
-		_, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session)
+		_, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session, OperationOutput{})
 		if err == nil || (!strings.Contains(err.Error(), "cannot decode") && !strings.Contains(err.Error(), "unexpected EOF")) {
 			t.Fatalf("Execute() error = %v, want malformed JSON decode failure", err)
 		}
@@ -403,7 +403,7 @@ func TestShowQueryProfilesStatementExecute(t *testing.T) {
 			fingerprint: 1,
 			profile:     `[]`,
 		}})
-		_, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session)
+		_, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "cannot unmarshal") {
 			t.Fatalf("Execute() error = %v, want non-object profile JSON", err)
 		}
@@ -413,7 +413,7 @@ func TestShowQueryProfilesStatementExecute(t *testing.T) {
 		t.Parallel()
 		session, server := newQueryProfileRPCSession(t, nil)
 		server.execErr = status.Error(codes.NotFound, "QUERY_PROFILES_TOP_HOUR missing")
-		_, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session)
+		_, err := (&ShowQueryProfilesStatement{}).Execute(t.Context(), session, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "QUERY_PROFILES_TOP_HOUR missing") {
 			t.Fatalf("Execute() error = %v, want injected query error", err)
 		}
@@ -439,7 +439,7 @@ func TestShowQueryProfileStatementExecute(t *testing.T) {
 	t.Run("empty result", func(t *testing.T) {
 		t.Parallel()
 		session, server := newQueryProfileRPCSession(t, nil)
-		_, err := (&ShowQueryProfileStatement{Fprint: queryProfileFingerprint}).Execute(t.Context(), session)
+		_, err := (&ShowQueryProfileStatement{Fprint: queryProfileFingerprint}).Execute(t.Context(), session, OperationOutput{})
 		if err == nil || err.Error() != "empty result" {
 			t.Fatalf("Execute() error = %v, want empty result", err)
 		}
@@ -456,7 +456,7 @@ func TestShowQueryProfileStatementExecute(t *testing.T) {
 			latency:     0.00023,
 			profile:     profile,
 		}})
-		got, err := (&ShowQueryProfileStatement{Fprint: queryProfileFingerprint}).Execute(t.Context(), session)
+		got, err := (&ShowQueryProfileStatement{Fprint: queryProfileFingerprint}).Execute(t.Context(), session, OperationOutput{})
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
 		}
@@ -487,7 +487,7 @@ func TestShowQueryProfileStatementExecute(t *testing.T) {
 			fingerprint: queryProfileFingerprint,
 			profile:     `{"queryPlan":123,"queryStats":{}}`,
 		}})
-		_, err := (&ShowQueryProfileStatement{Fprint: queryProfileFingerprint}).Execute(t.Context(), session)
+		_, err := (&ShowQueryProfileStatement{Fprint: queryProfileFingerprint}).Execute(t.Context(), session, OperationOutput{})
 		if err == nil || !strings.Contains(err.Error(), "syntax error") {
 			t.Fatalf("Execute() error = %v, want malformed plan", err)
 		}

--- a/internal/mycli/statements_schema.go
+++ b/internal/mycli/statements_schema.go
@@ -20,7 +20,7 @@ type ShowCreateStatement struct {
 	Name       string
 }
 
-func (s *ShowCreateStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowCreateStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	ddlResponse, err := session.GetDatabaseDdlCached(ctx)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ type ShowTablesStatement struct {
 	Schema string
 }
 
-func (s *ShowTablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowTablesStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	alias := fmt.Sprintf("Tables_in_%s", session.systemVariables.Connection.Database)
 	stmt := spanner.Statement{
 		SQL:    fmt.Sprintf("SELECT t.TABLE_NAME AS %s FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_CATALOG = '' and t.TABLE_SCHEMA = @schema", spanvalue.QuoteIdentifier(session.systemVariables.Feature.DatabaseDialect, alias)),
@@ -67,7 +67,7 @@ type ShowColumnsStatement struct {
 	Table  string
 }
 
-func (s *ShowColumnsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowColumnsStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	stmt := spanner.Statement{
 		SQL: `SELECT
   C.COLUMN_NAME as Field,
@@ -101,7 +101,7 @@ type ShowIndexStatement struct {
 	Table  string
 }
 
-func (s *ShowIndexStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowIndexStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	stmt := spanner.Statement{
 		SQL: `SELECT
   TABLE_NAME as Table,
@@ -125,7 +125,7 @@ WHERE
 
 type ShowDdlsStatement struct{}
 
-func (s *ShowDdlsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowDdlsStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	resp, err := session.GetDatabaseDdlCached(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/mycli/statements_split_points.go
+++ b/internal/mycli/statements_split_points.go
@@ -27,7 +27,7 @@ type AddSplitPointsStatement struct {
 // statement_processing.go.
 func (AddSplitPointsStatement) isMutationStatement() {}
 
-func (s *AddSplitPointsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *AddSplitPointsStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	_, err := session.adminClient.AddSplitPoints(ctx, &databasepb.AddSplitPointsRequest{
 		Database:    session.DatabasePath(),
 		SplitPoints: s.SplitPoints,
@@ -42,7 +42,7 @@ func (s *AddSplitPointsStatement) Execute(ctx context.Context, session *Session)
 
 type ShowSplitPointsStatement struct{}
 
-func (s *ShowSplitPointsStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowSplitPointsStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	stmt := spanner.NewStatement("SELECT TABLE_NAME, INDEX_NAME, INITIATOR, SPLIT_KEY, EXPIRE_TIME FROM SPANNER_SYS.USER_SPLIT_POINTS")
 
 	return executeInformationSchemaBasedStatementImpl(ctx, session,

--- a/internal/mycli/statements_system_variable.go
+++ b/internal/mycli/statements_system_variable.go
@@ -19,7 +19,7 @@ type ShowVariableStatement struct {
 
 func (s *ShowVariableStatement) isDetachedCompatible() {}
 
-func (s *ShowVariableStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowVariableStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	value, err := session.systemVariables.Get(s.VarName)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ type ShowVariablesStatement struct{}
 
 func (s *ShowVariablesStatement) isDetachedCompatible() {}
 
-func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// Get all single-valued variables from the registry.
 	merged := session.systemVariables.ListVariables()
 
@@ -56,7 +56,7 @@ func (s *ShowVariablesStatement) Execute(ctx context.Context, session *Session) 
 		return cmp.Compare(lhs.Name, rhs.Name)
 	})
 
-	result, err := executeStructRows(nameValueRowEncoder, items, session)
+	result, err := executeStructRows(nameValueRowEncoder, items, session, out)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ type SetStatement struct {
 
 func (s *SetStatement) isDetachedCompatible() {}
 
-func (s *SetStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SetStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	sysVars := session.systemVariables
 	sysVars.ensureRegistry()
 	if strings.EqualFold(s.VarName, protoDescriptorsVarName) && session.batch.IsActive() {
@@ -101,7 +101,7 @@ type SetLocalStatement struct {
 	Value   string
 }
 
-func (s *SetLocalStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SetLocalStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn == nil || !session.txn.InTransaction() {
 		return nil, errors.New("SET LOCAL requires an active transaction; start one with BEGIN")
 	}
@@ -158,7 +158,7 @@ type SetAddStatement struct {
 
 func (s *SetAddStatement) isDetachedCompatible() {}
 
-func (s *SetAddStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SetAddStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	// The only ADD handler is PROTO_DESCRIPTORS_FILE_PATH, which is noLocal, so
 	// SET += cannot retire SET LOCAL undo. Do not hook ADD into that lifecycle.
 	if err := session.systemVariables.AddFromGoogleSQL(s.VarName, s.Value); err != nil {
@@ -219,7 +219,7 @@ func helpVariableRows(sysVars *systemVariables) []helpVariableRow {
 	return merged
 }
 
-func (s *HelpVariablesStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *HelpVariablesStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	var sysVars *systemVariables
 	if session != nil {
 		sysVars = session.systemVariables
@@ -234,7 +234,7 @@ func (s *HelpVariablesStatement) Execute(ctx context.Context, session *Session) 
 
 	// executeStructRows handles a nil session by rendering a buffered result
 	// with default formatting, preserving the pre-existing detached behavior.
-	result, err := executeStructRows(helpVariablesRowEncoder, merged, session)
+	result, err := executeStructRows(helpVariablesRowEncoder, merged, session, out)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mycli/statements_transaction.go
+++ b/internal/mycli/statements_transaction.go
@@ -32,7 +32,7 @@ type BeginRwStatement struct {
 
 func (BeginRwStatement) isMutationStatement() {}
 
-func (s *BeginRwStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *BeginRwStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InReadWriteTransaction() {
 		return nil, errors.New("you're in read-write transaction. Please finish the transaction by 'COMMIT;' or 'ROLLBACK;'")
 	}
@@ -53,7 +53,7 @@ type BeginStatement struct {
 	Priority       sppb.RequestOptions_Priority
 }
 
-func (s *BeginStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *BeginStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InTransaction() {
 		return nil, errors.New("you're in transaction. Please finish the transaction by 'COMMIT;' or 'ROLLBACK;'")
 	}
@@ -81,7 +81,7 @@ type SetTransactionStatement struct {
 	IsReadOnly bool
 }
 
-func (s *SetTransactionStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *SetTransactionStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	result := &Result{}
 
 	// Get transaction attributes atomically to avoid check-then-act race
@@ -138,7 +138,7 @@ func closeNonRWTransaction(session *Session, mode transactionMode, isActive bool
 
 type CommitStatement struct{}
 
-func (s *CommitStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *CommitStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	mode, isActive := session.txn.TransactionState()
 	if result, handled, err := closeNonRWTransaction(session, mode, isActive); handled || err != nil {
 		return result, err
@@ -169,7 +169,7 @@ func (s *CommitStatement) Execute(ctx context.Context, session *Session) (*Resul
 
 type RollbackStatement struct{}
 
-func (s *RollbackStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *RollbackStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	mode, isActive := session.txn.TransactionState()
 	if result, handled, err := closeNonRWTransaction(session, mode, isActive); handled || err != nil {
 		return result, err
@@ -182,14 +182,14 @@ func (s *RollbackStatement) Execute(ctx context.Context, session *Session) (*Res
 	return &Result{}, nil
 }
 
-func (s *BeginRoStatement) Execute(ctx context.Context, session *Session) (*Result, error) {
+func (s *BeginRoStatement) Execute(ctx context.Context, session *Session, out OperationOutput) (*Result, error) {
 	if session.txn.InReadWriteTransaction() {
 		return nil, errors.New("invalid state: You're in read-write transaction. Please finish the transaction by 'COMMIT;' or 'ROLLBACK;'")
 	}
 
 	if session.txn.InReadOnlyTransaction() {
 		// close current transaction implicitly
-		if _, err := (&RollbackStatement{}).Execute(ctx, session); err != nil {
+		if _, err := (&RollbackStatement{}).Execute(ctx, session, out); err != nil {
 			return nil, fmt.Errorf("error on close current transaction: %w", err)
 		}
 	}


### PR DESCRIPTION
Statement execution now carries a concrete `OperationOutput` through the existing `Execute` call chain. This removes `Session.output` and its save/restore wrappers while preserving caller-provided writers, lazy width resolution, direct-call defaults, DUMP buffering and MCP output isolation. Output-free abort rollback calls the transaction manager directly.

Regression tests exercise actual nested RUN BATCH success/error paths, the next statement's destination and buffered DUMP isolation. An intentional dropped forwarding argument is detected by the new test. Independent focused tests and `make check` passed at 71eaa172d7e863a8c732d0e6517b9f05be43aaea, along with current-head review and required CI (including `go test -short -race ./...`). The CI coverage floor remains 80%.

This completes the final child of the bounded simplification series in #911.

Fixes #918.
Fixes #911.
